### PR TITLE
Include iCloud Shared Albums in the gallery list

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -108,7 +108,7 @@
         return;
     }
     for (PHCollection *phCollection in collections) {
-        if ([phCollection isMemberOfClass:[PHAssetCollection class]]) {
+        if ([phCollection isKindOfClass:[PHAssetCollection class]]) {
             PHAssetCollection *collection = (PHAssetCollection *) phCollection;
             PHFetchResult<PHAsset *> *result = [PHAsset fetchKeyAssetsInAssetCollection:collection options:option];
             NSLog(@"collection name = %@, count = %ld", collection.localizedTitle, result.count);
@@ -150,7 +150,7 @@
                           hasAll:(BOOL)hasAll
               containsEmptyAlbum:(BOOL)containsEmptyAlbum {
     for (id collection in result) {
-        if (![collection isMemberOfClass:[PHAssetCollection class]]) {
+        if (![collection isKindOfClass:[PHAssetCollection class]]) {
             continue;
         }
         


### PR DESCRIPTION
Currently, iCloud Shared Albums are filtered out of the results because Apple returns them as type 
`PHCloudSharedAlbum`, which is inherited from `PHAssetCollection`, but it only allows for exact match of `PHAssetCollection`. This change ensures those albums are returned correctly. 

This should fix #521 

