### PR TITLE
🎨 Override `RequestType`'s equality

### DIFF
--- a/.github/workflows/build_test.yml
+++ b/.github/workflows/build_test.yml
@@ -47,6 +47,7 @@ jobs:
       - run: flutter pub get
       - run: flutter pub publish --dry-run
       - run: flutter analyze lib example/lib
+      - run: flutter test
       - run: /usr/bin/xcodebuild -version
       - run: cd example ; flutter build macos --debug
 
@@ -68,5 +69,6 @@ jobs:
       - run: flutter pub get
       - run: flutter pub publish --dry-run
       - run: flutter analyze lib example/lib
+      - run: flutter test
       - run: sudo echo "y" | sudo $ANDROID_HOME/tools/bin/sdkmanager "ndk;20.0.5594570"
       - run: cd example; flutter build apk --debug

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -1,7 +1,6 @@
 import 'dart:io';
 import 'dart:typed_data';
 
-import 'package:flutter/cupertino.dart';
 import 'package:flutter/material.dart';
 import 'package:photo_manager_example/develop/upload_to_dev_serve.dart';
 import 'package:photo_manager_example/model/photo_provider.dart';

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -51,6 +51,13 @@ class RequestType {
   }
 
   @override
+  bool operator ==(Object other) =>
+      other is RequestType && value == other.value;
+
+  @override
+  int get hashCode => value;
+
+  @override
   String toString() => '$runtimeType($value)';
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -11,6 +11,10 @@ dependencies:
   flutter:
     sdk: flutter
 
+dev_dependencies:
+  flutter_test:
+    sdk: flutter
+
 flutter:
   plugin:
     platforms:

--- a/test/photo_manager_test.dart
+++ b/test/photo_manager_test.dart
@@ -1,0 +1,12 @@
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+void main() {
+  test('RequestType equality test', () {
+    expect(RequestType.image == RequestType(1), equals(true));
+    expect(RequestType.video == RequestType(2), equals(true));
+    expect(RequestType.audio == RequestType(4), equals(true));
+    expect(RequestType.common == RequestType(3), equals(true));
+    expect(RequestType.all == RequestType(7), equals(true));
+  });
+}


### PR DESCRIPTION
Fix #647.