### PR TITLE
🎨 Improve platform default sort orders

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
@@ -148,6 +148,11 @@ object ConvertUtils {
     fun convertOrderByCondList(orders: List<*>): List<OrderByCond> {
         val list = ArrayList<OrderByCond>()
 
+        // Handle platform default sorting first.
+        if (orders.isEmpty()) {
+            // Use ID to sort by default.
+            return arrayListOf(OrderByCond(MediaStore.MediaColumns._ID, false))
+        }
         for (order in orders) {
             val map = order as Map<*, *>
             val keyIndex = map["type"] as Int

--- a/ios/Classes/core/PMFilterOption.m
+++ b/ios/Classes/core/PMFilterOption.m
@@ -8,7 +8,7 @@
 }
 
 - (NSArray<NSSortDescriptor *> *)sortCond {
-    if (self.sortArray.count == 0) {
+    if (self.sortArray == nil || self.sortArray.count == 0) {
         return nil;
     }
     return self.sortArray;
@@ -16,7 +16,14 @@
 
 - (void)injectSortArray:(NSArray *)array {
     NSMutableArray<NSSortDescriptor *> *result = [NSMutableArray new];
-
+    
+    // Handle platform default sorting first.
+    if (array.count == 0) {
+        // Set an empty sort array directly.
+        self.sortArray = nil;
+        return;
+    }
+    
     for (NSDictionary *dict in array) {
         int typeValue = [dict[@"type"] intValue];
         BOOL asc = [dict[@"asc"] boolValue];

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -200,11 +200,9 @@
     }
     
     PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
-    
     PHAssetCollection *collection = fetchResult.firstObject;
-    
-    PHFetchResult<PHAsset *> *assetArray =
-    [PHAsset fetchAssetsInAssetCollection:collection options:assetOptions];
+    PHFetchResult<PHAsset *> *assetArray = [PHAsset fetchAssetsInAssetCollection:collection
+                                                                         options:assetOptions];
     
     if (assetArray.count == 0) {
         return result;
@@ -222,7 +220,11 @@
     BOOL videoNeedTitle = filterOption.videoOption.needTitle;
     
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
-        PHAsset *asset = assetArray[i];
+        NSUInteger index = i;
+        if (assetOptions.sortDescriptors == nil) {
+            index = count - 1 - i;
+        }
+        PHAsset *asset = assetArray[index];
         BOOL needTitle = NO;
         if ([asset isVideo]) {
             needTitle = videoNeedTitle;
@@ -268,7 +270,11 @@
     }
     
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
-        PHAsset *asset = assetArray[i];
+        NSUInteger index = i;
+        if (assetOptions.sortDescriptors == nil) {
+            index = count - 1 - i;
+        }
+        PHAsset *asset = assetArray[index];
         BOOL needTitle;
         if ([asset isVideo]) {
             needTitle = filterOption.videoOption.needTitle;
@@ -707,11 +713,14 @@
     }
     PHAssetCollection *collection = result[0];
     PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
-    PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:collection options:assetOptions];
-    
+    NSUInteger count = collection.estimatedAssetCount;
+    if (count == NSNotFound) {
+        PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:collection options:assetOptions];
+        count = fetchResult.count;
+    }
     PMAssetPathEntity *entity = [PMAssetPathEntity entityWithId:id
                                                            name:collection.localizedTitle
-                                                     assetCount:(int) fetchResult.count];
+                                                     assetCount:count];
     entity.isAll = collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary;
     return entity;
 }

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -222,7 +222,7 @@
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
         NSUInteger index = i;
         if (assetOptions.sortDescriptors == nil) {
-            index = count - 1 - i;
+            index = count - i - 1;
         }
         PHAsset *asset = assetArray[index];
         BOOL needTitle = NO;
@@ -272,7 +272,7 @@
     for (NSUInteger i = startIndex; i <= endIndex; i++) {
         NSUInteger index = i;
         if (assetOptions.sortDescriptors == nil) {
-            index = count - 1 - i;
+            index = count - i - 1;
         }
         PHAsset *asset = assetArray[index];
         BOOL needTitle;

--- a/lib/src/filter/filter_option_group.dart
+++ b/lib/src/filter/filter_option_group.dart
@@ -14,7 +14,7 @@ class FilterOptionGroup {
     bool containsPathModified = false,
     DateTimeCond? createTimeCond,
     DateTimeCond? updateTimeCond,
-    List<OrderOption> orders = const [OrderOption()],
+    List<OrderOption> orders = const [],
   }) {
     _map[AssetType.image] = imageOption;
     _map[AssetType.video] = videoOption;

--- a/lib/src/filter/filter_options.dart
+++ b/lib/src/filter/filter_options.dart
@@ -1,5 +1,7 @@
 import 'dart:convert';
 
+import 'package:flutter/widgets.dart';
+
 import '../internal/enums.dart';
 
 /// A series of filter options for [AssetType] when querying assets.
@@ -10,7 +12,9 @@ class FilterOption {
     this.durationConstraint = const DurationConstraint(),
   });
 
-  /// This property affects performance on iOS. If not needed, please pass false, default is false.
+  /// This property affects performance on iOS.
+  ///
+  /// If not needed, please pass false, default is false.
   final bool needTitle;
 
   /// See [SizeConstraint]
@@ -166,18 +170,15 @@ class DateTimeCond {
 }
 
 class OrderOption {
-  final OrderOptionType type;
-  final bool asc;
-
   const OrderOption({
     this.type = OrderOptionType.createDate,
     this.asc = false,
   });
 
-  OrderOption copyWith({
-    OrderOptionType? type,
-    bool? asc,
-  }) {
+  final OrderOptionType type;
+  final bool asc;
+
+  OrderOption copyWith({OrderOptionType? type, bool? asc}) {
     return OrderOption(
       asc: asc ?? this.asc,
       type: type ?? this.type,
@@ -185,9 +186,14 @@ class OrderOption {
   }
 
   Map<String, dynamic> toMap() {
-    return {
-      'type': type.index,
-      'asc': asc,
-    };
+    return {'type': type.index, 'asc': asc};
   }
+
+  @override
+  bool operator ==(Object other) {
+    return other is OrderOption && type == other.type && asc == other.asc;
+  }
+
+  @override
+  int get hashCode => hashValues(type, asc);
 }


### PR DESCRIPTION
- Flutter: Remove the default `OrderOption` when constructing the group.
- Android: Use `MediaStore.MediaColumns._ID` with descending by default.
- iOS: Use `nil` sort descriptors and reverse the asset array.
  - Suggested by the [answer](https://stackoverflow.com/a/29949179).

### Issues

Related to #655, #603.

### Limitations

- Users won't able to trigger the default sort order manually, only if they pass an empty list of orders.
- Platform handlers are quite separate here, but I left comments, and let's hope it worked.