### PR TITLE
✨ Support filtering Live Photos

### DIFF
--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -45,6 +45,24 @@ class PhotoProvider extends ChangeNotifier {
     notifyListeners();
   }
 
+  bool _containsLivePhotos = true;
+
+  bool get containsLivePhotos => _containsLivePhotos;
+
+  set containsLivePhotos(bool value) {
+    _containsLivePhotos = value;
+    notifyListeners();
+  }
+
+  bool _onlyLivePhotos = false;
+
+  bool get onlyLivePhotos => _onlyLivePhotos;
+
+  set onlyLivePhotos(bool value) {
+    _onlyLivePhotos = value;
+    notifyListeners();
+  }
+
   DateTime _startDt = DateTime(2005); // Default Before 8 years
 
   DateTime get startDt => _startDt;
@@ -215,7 +233,9 @@ class PhotoProvider extends ChangeNotifier {
       ..setOption(AssetType.audio, option)
       ..createTimeCond = createDtCond
       ..containsEmptyAlbum = _containsEmptyAlbum
-      ..containsPathModified = _containsPathModified;
+      ..containsPathModified = _containsPathModified
+      ..containsLivePhotos = _containsLivePhotos
+      ..onlyLivePhotos = onlyLivePhotos;
   }
 
   Future<void> refreshAllGalleryProperties() async {

--- a/example/lib/page/home_page.dart
+++ b/example/lib/page/home_page.dart
@@ -55,6 +55,8 @@ class _NewHomePageState extends State<NewHomePage> {
             _buildTypeChecks(watchProvider),
             _buildHasAllCheck(),
             _buildOnlyAllCheck(),
+            _buildContainsLivePhotos(),
+            _buildOnlyLivePhotos(),
             _buildContainsEmptyCheck(),
             _buildPathContainsModifiedDateCheck(),
             _buildPngCheck(),
@@ -150,6 +152,36 @@ class _NewHomePageState extends State<NewHomePage> {
         readProvider.changeOnlyAll(value);
       },
       title: const Text('onlyAll'),
+    );
+  }
+
+  Widget _buildContainsLivePhotos() {
+    if (Platform.isAndroid) {
+      return Container();
+    }
+    return CheckboxListTile(
+      value: watchProvider.containsLivePhotos,
+      onChanged: (bool? value) {
+        if (value != null) {
+          readProvider.containsLivePhotos = value;
+        }
+      },
+      title: const Text('Contains Live Photos'),
+    );
+  }
+
+  Widget _buildOnlyLivePhotos() {
+    if (Platform.isAndroid) {
+      return Container();
+    }
+    return CheckboxListTile(
+      value: watchProvider.onlyLivePhotos,
+      onChanged: (bool? value) {
+        if (value != null) {
+          readProvider.onlyLivePhotos = value;
+        }
+      },
+      title: const Text('Only Live Photos'),
     );
   }
 

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -241,8 +241,11 @@
             BOOL onlyAll = [call.arguments[@"onlyAll"] boolValue];
             PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
-            NSArray<PMAssetPathEntity *> *array = [manager getGalleryList:type hasAll:hasAll onlyAll:onlyAll option:option];
-            
+            NSArray<PMAssetPathEntity *> *array = [manager
+                                                   getGalleryList:type
+                                                   hasAll:hasAll
+                                                   onlyAll:onlyAll
+                                                   option:option];
             if (option.containsModified) {
                 for (PMAssetPathEntity *path in array) {
                     [manager injectModifyToDate:path];
@@ -261,20 +264,28 @@
             PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
             NSArray<PMAssetEntity *> *array =
-            [manager getAssetEntityListWithGalleryId:id type:type page:page pageCount:pageCount filterOption:option];
+            [manager getAssetEntityListWithGalleryId:id
+                                                type:type
+                                                page:page
+                                           pageCount:pageCount
+                                        filterOption:option];
             NSDictionary *dictionary =
             [PMConvertUtils convertAssetToMap:array optionGroup:option];
             [handler reply:dictionary];
             
         } else if ([call.method isEqualToString:@"getAssetListWithRange"]) {
             NSString *galleryId = call.arguments[@"galleryId"];
-            NSUInteger type = [call.arguments[@"type"] unsignedIntegerValue];
+            int type = [call.arguments[@"type"] intValue];
             NSUInteger start = [call.arguments[@"start"] unsignedIntegerValue];
             NSUInteger end = [call.arguments[@"end"] unsignedIntegerValue];
             PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
             NSArray<PMAssetEntity *> *array =
-            [manager getAssetEntityListWithRange:galleryId type:type start:start end:end filterOption:option];
+            [manager getAssetEntityListWithRange:galleryId
+                                            type:type
+                                           start:start
+                                             end:end
+                                    filterOption:option];
             NSDictionary *dictionary =
             [PMConvertUtils convertAssetToMap:array optionGroup:option];
             [handler reply:dictionary];

--- a/ios/Classes/core/PMAssetPathEntity.h
+++ b/ios/Classes/core/PMAssetPathEntity.h
@@ -36,7 +36,7 @@
 @property(nonatomic, assign) double lat;
 @property(nonatomic, assign) double lng;
 @property(nonatomic, copy) NSString *title;
-@property(nonatomic, assign) NSUInteger subType;
+@property(nonatomic, assign) NSUInteger subtype;
 @property(nonatomic, assign) BOOL favorite;
 @property(nonatomic, assign) BOOL isLocallyAvailable;
 

--- a/ios/Classes/core/PMConvertUtils.m
+++ b/ios/Classes/core/PMConvertUtils.m
@@ -87,7 +87,7 @@
         @"lng": @(asset.location.coordinate.longitude),
         @"lat": @(asset.location.coordinate.latitude),
         @"title": needTitle ? [asset title] : @"",
-        @"subType": @(asset.mediaSubtypes),
+        @"subtype": @(asset.mediaSubtypes),
     };
 }
 
@@ -105,7 +105,7 @@
         @"lng": @(asset.lng),
         @"lat": @(asset.lat),
         @"title": needTitle ? asset.title : @"",
-        @"subType": @(asset.subType),
+        @"subtype": @(asset.subtype),
     };
 }
 
@@ -122,6 +122,8 @@
     container.updateOption = [self convertMapToPMDateOption:map[@"updateDate"]];
     container.containsEmptyAlbum = [map[@"containsEmptyAlbum"] boolValue];
     container.containsModified = [map[@"containsPathModified"] boolValue];
+    container.containsLivePhotos = [map[@"containsLivePhotos"] boolValue];
+    container.onlyLivePhotos = [map[@"onlyLivePhotos"] boolValue];
     
     NSArray *sortArray = map[@"orders"];
     [container injectSortArray: sortArray];

--- a/ios/Classes/core/PMFilterOption.h
+++ b/ios/Classes/core/PMFilterOption.h
@@ -56,6 +56,8 @@ typedef struct PMDurationConstraint {
 @property(nonatomic, strong) PMFilterOption *audioOption;
 @property(nonatomic, strong) PMDateOption *dateOption;
 @property(nonatomic, strong) PMDateOption *updateOption;
+@property(nonatomic, assign) BOOL containsLivePhotos;
+@property(nonatomic, assign) BOOL onlyLivePhotos;
 @property(nonatomic, assign) BOOL containsEmptyAlbum;
 @property(nonatomic, assign) BOOL containsModified;
 @property(nonatomic, strong) NSArray<NSSortDescriptor*> *sortArray;

--- a/ios/Classes/core/PMFilterOption.m
+++ b/ios/Classes/core/PMFilterOption.m
@@ -79,13 +79,13 @@
 - (NSString *)dateCond:(NSString *)key {
     NSMutableString *str = [NSMutableString new];
     
-    [str appendString:@"AND "];
+    [str appendString:@" AND "];
     [str appendString:@"( "];
     
     // min
     
     [str appendString:key];
-    [str appendString:@" >= %@ "];
+    [str appendString:@" >= %@"];
     
     
     // and

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -36,6 +36,8 @@ typedef void (^AssetResult)(PMAssetEntity *);
 
 - (NSArray<PMAssetEntity *> *)getAssetEntityListWithGalleryId:(NSString *)id type:(int)type page:(NSUInteger)page pageCount:(NSUInteger)pageCount filterOption:(PMFilterOptionGroup *)filterOption;
 
+- (NSArray<PMAssetEntity *> *)getAssetEntityListWithRange:(NSString *)id type:(int)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption;
+
 - (PMAssetEntity *)getAssetEntity:(NSString *)assetId;
 
 - (void)clearCache;
@@ -47,8 +49,6 @@ typedef void (^AssetResult)(PMAssetEntity *);
 - (PMAssetPathEntity *)fetchPathProperties:(NSString *)id type:(int)type filterOption:(PMFilterOptionGroup *)filterOption;
 
 - (void)deleteWithIds:(NSArray<NSString *> *)ids changedBlock:(ChangeIds)block;
-
-- (NSArray<PMAssetEntity *> *)getAssetEntityListWithRange:(NSString *)id type:(NSUInteger)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption;
 
 - (void)saveImage:(NSData *)data
             title:(NSString *)title

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -111,7 +111,7 @@
         if ([phCollection isKindOfClass:[PHAssetCollection class]]) {
             PHAssetCollection *collection = (PHAssetCollection *) phCollection;
             PHFetchResult<PHAsset *> *result = [PHAsset fetchKeyAssetsInAssetCollection:collection options:option];
-            NSLog(@"collection name = %@, count = %ld", collection.localizedTitle, result.count);
+            NSLog(@"collection name = %@, count = %lu", collection.localizedTitle, (unsigned long)result.count);
         } else {
             NSLog(@"collection name = %@", phCollection.localizedTitle);
         }
@@ -199,8 +199,8 @@
         return result;
     }
     
-    PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
     PHAssetCollection *collection = fetchResult.firstObject;
+    PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
     PHFetchResult<PHAsset *> *assetArray = [PHAsset fetchAssetsInAssetCollection:collection
                                                                          options:assetOptions];
     
@@ -239,7 +239,7 @@
     return result;
 }
 
-- (NSArray<PMAssetEntity *> *)getAssetEntityListWithRange:(NSString *)id type:(NSUInteger)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption {
+- (NSArray<PMAssetEntity *> *)getAssetEntityListWithRange:(NSString *)id type:(int)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption {
     NSMutableArray<PMAssetEntity *> *result = [NSMutableArray new];
     
     PHFetchOptions *options = [PHFetchOptions new];
@@ -251,11 +251,10 @@
         return result;
     }
     
-    PHFetchOptions *assetOptions = [self getAssetOptions:(int) type filterOption:filterOption];
-    
     PHAssetCollection *collection = fetchResult.firstObject;
-    PHFetchResult<PHAsset *> *assetArray =
-    [PHAsset fetchAssetsInAssetCollection:collection options:assetOptions];
+    PHFetchOptions *assetOptions = [self getAssetOptions:(int) type filterOption:filterOption];
+    PHFetchResult<PHAsset *> *assetArray = [PHAsset fetchAssetsInAssetCollection:collection
+                                                                         options:assetOptions];
     
     if (assetArray.count == 0) {
         return result;
@@ -322,7 +321,7 @@
     entity.lng = asset.location.coordinate.longitude;
     entity.title = needTitle ? [asset title] : @"";
     entity.favorite = asset.isFavorite;
-    entity.subType = asset.mediaSubtypes;
+    entity.subtype = asset.mediaSubtypes;
     
     return entity;
 }
@@ -736,7 +735,7 @@
     BOOL containsAudio = [PMRequestTypeUtils containsAudio:type];
     
     if (containsImage) {
-        [cond appendString:@"("];
+        [cond appendString:@" ( "];
         
         PMFilterOption *imageOption = optionGroup.imageOption;
         
@@ -752,12 +751,12 @@
             [args addObjectsFromArray:sizeArgs];
         }
         
-        [cond appendString:@")"];
+        [cond appendString:@" )"];
     }
     
     if (containsVideo) {
         if (![cond isEmpty]) {
-            [cond appendString:@" OR "];
+            [cond appendString:@" OR"];
         }
         
         [cond appendString:@" ( "];
@@ -878,7 +877,7 @@
             block:(AssetResult)block {
     __block NSString *assetId = nil;
     
-    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with data, length: %ld, title:%@, desc: %@", data.length, title, desc]];
+    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with data, length: %lu, title:%@, desc: %@", (unsigned long)data.length, title, desc]];
     
     [[PHPhotoLibrary sharedPhotoLibrary]
      performChanges:^{

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -750,6 +750,21 @@
             [cond appendString:sizeCond];
             [args addObjectsFromArray:sizeArgs];
         }
+        if (@available(iOS 9.1, *)) {
+            if (optionGroup.onlyLivePhotos) {
+                [cond appendString:@" AND "];
+                [cond appendString:[NSString
+                                    stringWithFormat:@"mediaSubtype == %lu",
+                                    (unsigned long)PHAssetMediaSubtypePhotoLive]
+                ];
+            } else if (!optionGroup.containsLivePhotos) {
+                [cond appendString:@" AND "];
+                [cond appendString:[NSString
+                                    stringWithFormat:@"mediaSubtype != %lu",
+                                    (unsigned long)PHAssetMediaSubtypePhotoLive]
+                ];
+            }
+        }
         
         [cond appendString:@" )"];
     }
@@ -771,6 +786,21 @@
         [cond appendString:@" AND "];
         [cond appendString:durationCond];
         [args addObjectsFromArray:durationArgs];
+        
+        if (@available(iOS 9.1, *)) {
+            if (!containsImage && optionGroup.containsLivePhotos) {
+                [cond appendString:@" )"];
+                [cond appendString:@" OR "];
+                [cond appendString:@"( "];
+                [cond appendString:@"mediaType == %d"];
+                [args addObject:@(PHAssetMediaTypeImage)];
+                [cond appendString:@" AND "];
+                [cond appendString:[NSString
+                                    stringWithFormat:@"mediaSubtype == %lu",
+                                    (unsigned long)PHAssetMediaSubtypePhotoLive]
+                ];
+            }
+        }
         
         [cond appendString:@" ) "];
     }

--- a/lib/src/filter/filter_option_group.dart
+++ b/lib/src/filter/filter_option_group.dart
@@ -50,7 +50,14 @@ class FilterOptionGroup {
   ///  * [AssetPathEntity.lastModified].
   bool containsPathModified = false;
 
+  /// Whether to obtain live photos.
+  ///
+  /// This option only takes effects on iOS.
   bool containsLivePhotos = true;
+
+  /// Whether to obtain only live photos.
+  ///
+  /// This option only takes effects on iOS and when the request type is image.
   bool onlyLivePhotos = false;
 
   DateTimeCond createTimeCond = DateTimeCond.def();

--- a/lib/src/filter/filter_option_group.dart
+++ b/lib/src/filter/filter_option_group.dart
@@ -12,6 +12,8 @@ class FilterOptionGroup {
     FilterOption audioOption = const FilterOption(),
     this.containsEmptyAlbum = false,
     this.containsPathModified = false,
+    this.containsLivePhotos = true,
+    this.onlyLivePhotos = false,
     DateTimeCond? createTimeCond,
     DateTimeCond? updateTimeCond,
     List<OrderOption> orders = const <OrderOption>[],
@@ -48,6 +50,9 @@ class FilterOptionGroup {
   ///  * [AssetPathEntity.lastModified].
   bool containsPathModified = false;
 
+  bool containsLivePhotos = true;
+  bool onlyLivePhotos = false;
+
   DateTimeCond createTimeCond = DateTimeCond.def();
   DateTimeCond updateTimeCond = DateTimeCond.def().copyWith(ignore: true);
 
@@ -63,6 +68,8 @@ class FilterOptionGroup {
     }
     containsEmptyAlbum = other.containsEmptyAlbum;
     containsPathModified = other.containsPathModified;
+    containsLivePhotos = other.containsLivePhotos;
+    onlyLivePhotos = other.onlyLivePhotos;
     createTimeCond = other.createTimeCond;
     updateTimeCond = other.updateTimeCond;
     orders
@@ -80,6 +87,8 @@ class FilterOptionGroup {
         'audio': getOption(AssetType.audio).toMap(),
       'containsEmptyAlbum': containsEmptyAlbum,
       'containsPathModified': containsPathModified,
+      'containsLivePhotos': containsLivePhotos,
+      'onlyLivePhotos': onlyLivePhotos,
       'createDate': createTimeCond.toMap(),
       'updateDate': updateTimeCond.toMap(),
       'orders': orders.map((OrderOption e) => e.toMap()).toList(),
@@ -90,10 +99,12 @@ class FilterOptionGroup {
     FilterOption? imageOption,
     FilterOption? videoOption,
     FilterOption? audioOption,
-    DateTimeCond? createTimeCond,
-    DateTimeCond? updateTimeCond,
     bool? containsEmptyAlbum,
     bool? containsPathModified,
+    bool? containsLivePhotos,
+    bool? onlyLivePhotos,
+    DateTimeCond? createTimeCond,
+    DateTimeCond? updateTimeCond,
     List<OrderOption>? orders,
   }) {
     imageOption ??= _map[AssetType.image];
@@ -101,6 +112,8 @@ class FilterOptionGroup {
     audioOption ??= _map[AssetType.audio];
     containsEmptyAlbum ??= this.containsEmptyAlbum;
     containsPathModified ??= this.containsPathModified;
+    containsLivePhotos ??= this.containsLivePhotos;
+    onlyLivePhotos ??= this.onlyLivePhotos;
     createTimeCond ??= this.createTimeCond;
     updateTimeCond ??= this.updateTimeCond;
     orders ??= this.orders;
@@ -109,10 +122,12 @@ class FilterOptionGroup {
       ..setOption(AssetType.image, imageOption!)
       ..setOption(AssetType.video, videoOption!)
       ..setOption(AssetType.audio, audioOption!)
-      ..createTimeCond = createTimeCond
-      ..updateTimeCond = updateTimeCond
       ..containsEmptyAlbum = containsEmptyAlbum
       ..containsPathModified = containsPathModified
+      ..containsLivePhotos = containsLivePhotos
+      ..onlyLivePhotos = onlyLivePhotos
+      ..createTimeCond = createTimeCond
+      ..updateTimeCond = updateTimeCond
       ..orders.addAll(orders);
 
     return result;

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -78,6 +78,10 @@ class PhotoManager {
       'The request type must have video, image or audio.',
     );
     assert(
+      type != RequestType.audio || !filterOption.containsLivePhotos,
+      'Filtering Live Photos is not supported when the request type is audio.',
+    );
+    assert(
       type == RequestType.image || !filterOption.onlyLivePhotos,
       'Filtering only Live Photos is only supported '
       'when the request type contains image.',

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -77,6 +77,11 @@ class PhotoManager {
       type != RequestType.all,
       'The request type must have video, image or audio.',
     );
+    assert(
+      type == RequestType.image || !filterOption.onlyLivePhotos,
+      'Filtering only Live Photos is only supported '
+      'when the request type contains image.',
+    );
     if (type == RequestType.all) {
       return <AssetPathEntity>[];
     }

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -115,6 +115,11 @@ class AssetPathEntity {
   Future<List<AssetEntity>> getAssetListPaged(int page, int pageSize) {
     assert(albumType == 1, 'Only album can request for assets.');
     assert(pageSize > 0, 'The pageSize must be greater than 0.');
+    assert(
+      type == RequestType.image || !filterOption.onlyLivePhotos,
+      'Filtering only Live Photos is only supported '
+      'when the request type contains image.',
+    );
     return plugin.getAssetWithGalleryIdPaged(
       id,
       page: page,
@@ -136,6 +141,11 @@ class AssetPathEntity {
     assert(albumType == 1, 'Only album can request for assets.');
     assert(start >= 0, 'The start must be greater than 0.');
     assert(end > start, 'The end must be greater than start.');
+    assert(
+      type == RequestType.image || !filterOption.onlyLivePhotos,
+      'Filtering only Live Photos is only supported '
+      'when the request type contains image.',
+    );
     if (end > assetCount) {
       end = assetCount;
     }

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -202,7 +202,7 @@ class AssetEntity {
     double? latitude,
     double? longitude,
     this.mimeType,
-    this.subType = 0,
+    this.subtype = 0,
   })  : _latitude = latitude,
         _longitude = longitude;
 
@@ -248,10 +248,10 @@ class AssetEntity {
   ///
   /// * Android: Always 0.
   /// * iOS/macOS: https://developer.apple.com/documentation/photokit/phassetmediasubtype
-  final int subType;
+  final int subtype;
 
   /// Whether the asset is a live photo. Only valid on iOS/macOS.
-  bool get isLivePhoto => subType == 8;
+  bool get isLivePhoto => subtype == 8;
 
   /// The type value of the [type].
   final int typeInt;

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -56,7 +56,7 @@ class ConvertUtils {
       orientation: data['orientation'] as int? ?? 0,
       isFavorite: data['favorite'] as bool? ?? false,
       title: data['title'] as String? ?? title,
-      subType: data['subType'] as int? ?? 0,
+      subtype: data['subtype'] as int? ?? 0,
       createDtSecond: data['createDt'] as int?,
       modifiedDateSecond: data['modifiedDt'] as int?,
       relativePath: data['relativePath'] as String?,


### PR DESCRIPTION
Resolves #386.

This PR also introduced a behavior breaking change:

`containsLivePhotos` are `true` by default. If you previously used `RequestType.video` to filter assets, they'll include live photos now. To keep to old behavior, you should explicitly set `containsLivePhotos` to `false` in this case.