### PR TITLE
🎨 Unify codes

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -71,14 +71,14 @@ class PhotoManager(private val context: Context) {
     }
 
     fun getAssetList(
-        galleryId: String,
-        page: Int,
-        pageCount: Int,
+        id: String,
         typeInt: Int = 0,
+        page: Int,
+        size: Int,
         option: FilterOption
     ): List<AssetEntity> {
-        val gId = if (galleryId == ALL_ID) "" else galleryId
-        return dbUtils.getAssetFromGalleryId(context, gId, page, pageCount, typeInt, option)
+        val gId = if (id == ALL_ID) "" else id
+        return dbUtils.getAssetFromGalleryId(context, gId, page, size, typeInt, option)
     }
 
     fun getAssetListWithRange(

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -265,18 +265,18 @@ class PhotoManagerPlugin(
             }
             "getAssetWithGalleryId" -> {
                 runOnBackground {
-                    val id = call.argument<String>("id")!!
+                    val galleryId = call.argument<String>("id")!!
                     val type = call.argument<Int>("type")!!
                     val page = call.argument<Int>("page")!!
                     val size = call.argument<Int>("size")!!
                     val option = call.getOption()
-                    val list = photoManager.getAssetList(id, type, page, size, option)
+                    val list = photoManager.getAssetList(galleryId, type, page, size, option)
                     resultHandler.reply(ConvertUtils.convertToAssetResult(list))
                 }
             }
             "getAssetListWithRange" -> {
                 runOnBackground {
-                    val galleryId = call.getString("galleryId")
+                    val galleryId = call.getString("id")
                     val type = call.getInt("type")
                     val start = call.getInt("start")
                     val end = call.getInt("end")

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -266,11 +266,11 @@ class PhotoManagerPlugin(
             "getAssetWithGalleryId" -> {
                 runOnBackground {
                     val id = call.argument<String>("id")!!
-                    val page = call.argument<Int>("page")!!
-                    val pageCount = call.argument<Int>("pageCount")!!
                     val type = call.argument<Int>("type")!!
+                    val page = call.argument<Int>("page")!!
+                    val size = call.argument<Int>("size")!!
                     val option = call.getOption()
-                    val list = photoManager.getAssetList(id, page, pageCount, type, option)
+                    val list = photoManager.getAssetList(id, type, page, size, option)
                     resultHandler.reply(ConvertUtils.convertToAssetResult(list))
                 }
             }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
@@ -168,7 +168,7 @@ object Android30DbUtils : IDBUtils {
         context: Context,
         galleryId: String,
         page: Int,
-        pageSize: Int,
+        size: Int,
         requestType: Int,
         option: FilterOption,
         cacheContainer: CacheContainer?
@@ -222,20 +222,20 @@ object Android30DbUtils : IDBUtils {
 
     override fun getAssetFromGalleryIdRange(
         context: Context,
-        gId: String,
+        galleryId: String,
         start: Int,
         end: Int,
         requestType: Int,
         option: FilterOption
     ): List<AssetEntity> {
-        val isAll = gId.isEmpty()
+        val isAll = galleryId.isEmpty()
 
         val list = ArrayList<AssetEntity>()
         val uri = allUri
 
         val args = ArrayList<String>()
         if (!isAll) {
-            args.add(gId)
+            args.add(galleryId)
         }
         val typeSelection: String = getCondFromType(requestType, option, args)
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
@@ -197,7 +197,7 @@ object Android30DbUtils : IDBUtils {
             "${MediaStore.Images.ImageColumns.BUCKET_ID} = ? $typeSelection $dateSelection $sizeWhere"
         }
 
-        val sortOrder = getSortOrder(page * pageSize, pageSize, option)
+        val sortOrder = getSortOrder(page * size, size, option)
 
         val cursor =
             context.contentResolver.query(uri, keys, selection, args.toTypedArray(), sortOrder)

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/Android30DbUtils.kt
@@ -203,7 +203,7 @@ object Android30DbUtils : IDBUtils {
             context.contentResolver.query(uri, keys, selection, args.toTypedArray(), sortOrder)
                 ?: return emptyList()
 
-        cursorWithRange(cursor, page * pageSize, pageSize) {
+        cursorWithRange(cursor, page * size, size) {
             val asset = convertCursorToAssetEntity(cursor)
             list.add(asset)
         }
@@ -760,7 +760,7 @@ object Android30DbUtils : IDBUtils {
             val galleryID = cursor.getString(0)
             val path = cursor.getString(1)
 
-            return Pair(galleryID, File(path).parent)
+            return Pair(galleryID, File(path).parent!!)
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -149,9 +149,9 @@ object AndroidQDBUtils : IDBUtils {
     override fun getAssetFromGalleryId(
         context: Context,
         galleryId: String,
-        requestType: Int,
         page: Int,
         size: Int,
+        requestType: Int,
         option: FilterOption,
         cacheContainer: CacheContainer?
     ): List<AssetEntity> {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -757,7 +757,7 @@ object AndroidQDBUtils : IDBUtils {
             val galleryID = cursor.getString(0)
             val path = cursor.getString(1)
 
-            return Pair(galleryID, File(path).parent)
+            return Pair(galleryID, File(path).parent!!)
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -149,9 +149,9 @@ object AndroidQDBUtils : IDBUtils {
     override fun getAssetFromGalleryId(
         context: Context,
         galleryId: String,
-        page: Int,
-        pageSize: Int,
         requestType: Int,
+        page: Int,
+        size: Int,
         option: FilterOption,
         cacheContainer: CacheContainer?
     ): List<AssetEntity> {
@@ -179,7 +179,7 @@ object AndroidQDBUtils : IDBUtils {
             "${MediaStore.Images.ImageColumns.BUCKET_ID} = ? $typeSelection $dateSelection $sizeWhere"
         }
 
-        val sortOrder = getSortOrder(page * pageSize, pageSize, option)
+        val sortOrder = getSortOrder(page * size, size, option)
         val cursor =
             context.contentResolver.query(uri, keys, selection, args.toTypedArray(), sortOrder)
                 ?: return emptyList()
@@ -198,7 +198,7 @@ object AndroidQDBUtils : IDBUtils {
 
     override fun getAssetFromGalleryIdRange(
         context: Context,
-        gId: String,
+        galleryId: String,
         start: Int,
         end: Int,
         requestType: Int,
@@ -206,14 +206,14 @@ object AndroidQDBUtils : IDBUtils {
     ): List<AssetEntity> {
         val cache = cacheContainer
 
-        val isAll = gId.isEmpty()
+        val isAll = galleryId.isEmpty()
 
         val list = ArrayList<AssetEntity>()
         val uri = allUri
 
         val args = ArrayList<String>()
         if (!isAll) {
-            args.add(gId)
+            args.add(galleryId)
         }
         val typeSelection: String = getCondFromType(requestType, option, args)
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -165,9 +165,9 @@ object DBUtils : IDBUtils {
     override fun getAssetFromGalleryId(
         context: Context,
         galleryId: String,
-        requestType: Int,
         page: Int,
         size: Int,
+        requestType: Int,
         option: FilterOption,
         cacheContainer: CacheContainer?
     ): List<AssetEntity> {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -165,9 +165,9 @@ object DBUtils : IDBUtils {
     override fun getAssetFromGalleryId(
         context: Context,
         galleryId: String,
-        page: Int,
-        pageSize: Int,
         requestType: Int,
+        page: Int,
+        size: Int,
         option: FilterOption,
         cacheContainer: CacheContainer?
     ): List<AssetEntity> {
@@ -196,7 +196,7 @@ object DBUtils : IDBUtils {
             "${MediaStore.Images.ImageColumns.BUCKET_ID} = ? $typeSelection $dateSelection $sizeWhere"
         }
 
-        val sortOrder = getSortOrder(page * pageSize, pageSize, option)
+        val sortOrder = getSortOrder(page * size, size, option)
         val cursor =
             context.contentResolver.query(uri, keys, selection, args.toTypedArray(), sortOrder)
                 ?: return emptyList()
@@ -214,7 +214,7 @@ object DBUtils : IDBUtils {
 
     override fun getAssetFromGalleryIdRange(
         context: Context,
-        gId: String,
+        galleryId: String,
         start: Int,
         end: Int,
         requestType: Int,
@@ -222,14 +222,14 @@ object DBUtils : IDBUtils {
     ): List<AssetEntity> {
         val cache = cacheContainer
 
-        val isAll = gId.isEmpty()
+        val isAll = galleryId.isEmpty()
 
         val list = ArrayList<AssetEntity>()
         val uri = allUri
 
         val args = ArrayList<String>()
         if (!isAll) {
-            args.add(gId)
+            args.add(galleryId)
         }
         val typeSelection = getCondFromType(requestType, option, args)
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -731,7 +731,7 @@ object DBUtils : IDBUtils {
             val galleryID = cursor.getString(0)
             val path = cursor.getString(1)
 
-            return Pair(galleryID, File(path).parent)
+            return Pair(galleryID, File(path).parent!!)
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -165,7 +165,7 @@ interface IDBUtils {
 
     fun getAssetFromGalleryIdRange(
         context: Context,
-        gId: String,
+        galleryId: String,
         start: Int,
         end: Int,
         requestType: Int,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -99,7 +99,7 @@ interface IDBUtils {
         context: Context,
         galleryId: String,
         page: Int,
-        pageSize: Int,
+        size: Int,
         requestType: Int = 0,
         option: FilterOption,
         cacheContainer: CacheContainer? = null

--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -286,7 +286,10 @@ class AssetPathProvider extends ChangeNotifier {
 
     refreshing = true;
     await path.refreshPathProperties(maxDateTimeToNow: false);
-    final List<AssetEntity> list = await path.getAssetListPaged(0, loadCount);
+    final List<AssetEntity> list = await path.getAssetListPaged(
+      page: 0,
+      size: loadCount,
+    );
     page = 0;
     this.list.clear();
     this.list.addAll(list);
@@ -306,8 +309,8 @@ class AssetPathProvider extends ChangeNotifier {
       return;
     }
     final List<AssetEntity> list = await path.getAssetListPaged(
-      page + 1,
-      loadCount,
+      page: page + 1,
+      size: loadCount,
     );
     page = page + 1;
     this.list.addAll(list);

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -274,14 +274,14 @@
             [handler reply:dictionary];
             
         } else if ([call.method isEqualToString:@"getAssetListWithRange"]) {
-            NSString *galleryId = call.arguments[@"galleryId"];
+            NSString *id = call.arguments[@"id"];
             int type = [call.arguments[@"type"] intValue];
             NSUInteger start = [call.arguments[@"start"] unsignedIntegerValue];
             NSUInteger end = [call.arguments[@"end"] unsignedIntegerValue];
             PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
             NSArray<PMAssetEntity *> *array =
-            [manager getAssetEntityListWithRange:galleryId
+            [manager getAssetEntityListWithRange:id
                                             type:type
                                            start:start
                                              end:end

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -260,14 +260,14 @@
             NSString *id = call.arguments[@"id"];
             int type = [call.arguments[@"type"] intValue];
             NSUInteger page = [call.arguments[@"page"] unsignedIntValue];
-            NSUInteger pageCount = [call.arguments[@"pageCount"] unsignedIntValue];
+            NSUInteger size = [call.arguments[@"size"] unsignedIntValue];
             PMFilterOptionGroup *option =
             [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
             NSArray<PMAssetEntity *> *array =
             [manager getAssetEntityListWithGalleryId:id
                                                 type:type
                                                 page:page
-                                           pageCount:pageCount
+                                                size:size
                                         filterOption:option];
             NSDictionary *dictionary =
             [PMConvertUtils convertAssetToMap:array optionGroup:option];

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -34,7 +34,7 @@ typedef void (^AssetResult)(PMAssetEntity *);
 
 - (NSArray<PMAssetPathEntity *> *)getGalleryList:(int)type hasAll:(BOOL)hasAll onlyAll:(BOOL)onlyAll option:(PMFilterOptionGroup *)option;
 
-- (NSArray<PMAssetEntity *> *)getAssetEntityListWithGalleryId:(NSString *)id type:(int)type page:(NSUInteger)page pageCount:(NSUInteger)pageCount filterOption:(PMFilterOptionGroup *)filterOption;
+- (NSArray<PMAssetEntity *> *)getAssetEntityListWithGalleryId:(NSString *)id type:(int)type page:(NSUInteger)page size:(NSUInteger)size filterOption:(PMFilterOptionGroup *)filterOption;
 
 - (NSArray<PMAssetEntity *> *)getAssetEntityListWithRange:(NSString *)id type:(int)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption;
 

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -187,7 +187,7 @@
 
 #pragma clang diagnostic pop
 
-- (NSArray<PMAssetEntity *> *)getAssetEntityListWithGalleryId:(NSString *)id type:(int)type page:(NSUInteger)page pageCount:(NSUInteger)pageCount filterOption:(PMFilterOptionGroup *)filterOption {
+- (NSArray<PMAssetEntity *> *)getAssetEntityListWithGalleryId:(NSString *)id type:(int)type page:(NSUInteger)page size:(NSUInteger)size filterOption:(PMFilterOptionGroup *)filterOption {
     NSMutableArray<PMAssetEntity *> *result = [NSMutableArray new];
     
     PHFetchOptions *options = [PHFetchOptions new];
@@ -208,8 +208,8 @@
         return result;
     }
     
-    NSUInteger startIndex = page * pageCount;
-    NSUInteger endIndex = startIndex + pageCount - 1;
+    NSUInteger startIndex = page * size;
+    NSUInteger endIndex = startIndex + size - 1;
     
     NSUInteger count = assetArray.count;
     if (endIndex >= count) {

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -495,12 +495,7 @@ mixin IosPlugin on BasePlugin {
     if (result['errorMsg'] != null) {
       return null;
     }
-    return AssetPathEntity()
-      ..id = result['id'] as String
-      ..name = name
-      ..isAll = false
-      ..assetCount = 0
-      ..albumType = 1;
+    return AssetPathEntity.fromId(result['id'] as String);
   }
 
   Future<AssetPathEntity?> iosCreateFolder(
@@ -525,12 +520,7 @@ mixin IosPlugin on BasePlugin {
     if (result['errorMsg'] != null) {
       return null;
     }
-    return AssetPathEntity()
-      ..id = result['id'] as String
-      ..name = name
-      ..isAll = false
-      ..assetCount = 0
-      ..albumType = 2;
+    return AssetPathEntity.fromId(result['id'] as String, albumType: 2);
   }
 
   Future<bool> iosRemoveInAlbum(

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -66,7 +66,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
     String id, {
     required FilterOptionGroup optionGroup,
     int page = 0,
-    int pageCount = 15,
+    int size = 15,
     RequestType type = RequestType.all,
   }) async {
     final Map<dynamic, dynamic> result =
@@ -74,9 +74,9 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
       PMConstants.mGetAssetWithGalleryId,
       <String, dynamic>{
         'id': id,
-        'page': page,
-        'pageCount': pageCount,
         'type': type.value,
+        'page': page,
+        'size': size,
         'option': optionGroup.toMap(),
       },
     ) as Map<dynamic, dynamic>;
@@ -95,7 +95,7 @@ class Plugin with BasePlugin, IosPlugin, AndroidPlugin {
         await _channel.invokeMethod<Map<dynamic, dynamic>>(
       PMConstants.mGetAssetListWithRange,
       <String, dynamic>{
-        'galleryId': id,
+        'id': id,
         'type': type.value,
         'start': start,
         'end': end,

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -14,6 +14,12 @@ import 'notify_manager.dart';
 class PhotoManager {
   const PhotoManager._();
 
+  /// Editor instance for editing assets.
+  static final Editor editor = Editor();
+
+  /// Notify manager instance for managing photo changes.
+  static final NotifyManager _notifyManager = NotifyManager();
+
   /// ### Android (AndroidManifest.xml)
   ///  * WRITE_EXTERNAL_STORAGE
   ///  * READ_EXTERNAL_STORAGE
@@ -49,8 +55,6 @@ class PhotoManager {
   ///  * iOS 14: https://developer.apple.com/documentation/photokit/phphotolibrary/3616113-presentlimitedlibrarypickerfromv/
   ///  * iOS 15: https://developer.apple.com/documentation/photokit/phphotolibrary/3752108-presentlimitedlibrarypickerfromv/
   static Future<void> presentLimited() => plugin.presentLimited();
-
-  static Editor editor = Editor();
 
   /// Obtain albums/folders list with couple filter options.
   ///
@@ -126,9 +130,6 @@ class PhotoManager {
   /// Make sure callers of this method have `await`ed properly.
   static Future<void> releaseCache() => plugin.releaseCache();
 
-  /// Notification class for managing photo changes.
-  static final NotifyManager _notifyManager = NotifyManager();
-
   /// Add a callback for assets changing.
   static void addChangeCallback(ValueChanged<MethodCall> callback) =>
       _notifyManager.addCallback(callback);
@@ -138,7 +139,8 @@ class PhotoManager {
       _notifyManager.removeCallback(callback);
 
   /// Whether assets change event should be notified.
-  static bool notifyingOfChange = false;
+  static bool get notifyingOfChange => _notifyingOfChange;
+  static bool _notifyingOfChange = false;
 
   /// The notify enable flag in stream.
   static Stream<bool> get notifyStream => _notifyManager.notifyStream;
@@ -148,7 +150,7 @@ class PhotoManager {
   /// Make sure you've added a callback for changes.
   static void startChangeNotify() {
     _notifyManager.startHandleNotify();
-    notifyingOfChange = true;
+    _notifyingOfChange = true;
   }
 
   /// Disable notifications for assets changing.
@@ -156,7 +158,7 @@ class PhotoManager {
   /// Remember to remove callbacks for changes.
   static void stopChangeNotify() {
     _notifyManager.stopHandleNotify();
-    notifyingOfChange = false;
+    _notifyingOfChange = false;
   }
 
   static Future<void> forceOldApi() => plugin.forceOldApi();

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -7,7 +7,6 @@ import '../internal/enums.dart';
 import '../internal/plugin.dart';
 import '../types/entity.dart';
 import '../types/types.dart';
-import '../utils/convert_utils.dart';
 import 'notify_manager.dart';
 
 /// The core manager of this plugin.
@@ -158,41 +157,6 @@ class PhotoManager {
   static void stopChangeNotify() {
     _notifyManager.stopHandleNotify();
     notifyingOfChange = false;
-  }
-
-  /// Refresh the property of [AssetPathEntity] from the given ID.
-  static Future<AssetEntity?> refreshAssetProperties(String id) async {
-    final Map<dynamic, dynamic>? result =
-        await plugin.getPropertiesFromAssetEntity(id);
-    if (result == null) {
-      return null;
-    }
-    return ConvertUtils.convertMapToAsset(result.cast<String, dynamic>());
-  }
-
-  /// Obtain a new [AssetPathEntity] from the given one
-  /// with refreshed properties.
-  static Future<AssetPathEntity?> fetchPathProperties({
-    required AssetPathEntity entity,
-    required FilterOptionGroup filterOptionGroup,
-  }) async {
-    final Map<dynamic, dynamic>? result = await plugin.fetchPathProperties(
-      entity.id,
-      entity.type,
-      entity.filterOption,
-    );
-    if (result == null) {
-      return null;
-    }
-    final Object? list = result['data'];
-    if (list is List && list.isNotEmpty) {
-      return ConvertUtils.convertPath(
-        result.cast<String, dynamic>(),
-        type: entity.type,
-        optionGroup: entity.filterOption,
-      ).first;
-    }
-    return null;
   }
 
   static Future<void> forceOldApi() => plugin.forceOldApi();

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -11,7 +11,7 @@ import '../internal/editor.dart';
 import '../internal/enums.dart';
 import '../internal/plugin.dart';
 import '../internal/progress_handler.dart';
-import '../managers/photo_manager.dart';
+import '../utils/convert_utils.dart';
 import 'thumb_option.dart';
 import 'types.dart';
 
@@ -20,6 +20,31 @@ import 'types.dart';
 /// and the `PHAssetCollection` object on iOS/macOS.
 @immutable
 class AssetPathEntity {
+  AssetPathEntity._();
+
+  /// A factory constructor for convertion between channels.
+  factory AssetPathEntity.fromJson(
+    Map<String, dynamic> json, {
+    RequestType type = RequestType.all,
+    FilterOptionGroup? optionGroup,
+  }) {
+    final AssetPathEntity _entity = AssetPathEntity._()
+      ..id = json['id'] as String
+      ..name = json['name'] as String
+      ..type = type
+      ..isAll = json['isAll'] as bool
+      ..assetCount = json['length'] as int
+      ..albumType = json['albumType'] as int? ?? 1
+      ..filterOption = optionGroup ?? FilterOptionGroup();
+    final int? modifiedDate = json['modified'] as int?;
+    if (modifiedDate != null) {
+      _entity.lastModified = DateTime.fromMillisecondsSinceEpoch(
+        modifiedDate * 1000,
+      );
+    }
+    return _entity;
+  }
+
   /// Obtain an entity from ID.
   ///
   /// This method is not recommend in general, since the correspoding folder
@@ -31,7 +56,7 @@ class AssetPathEntity {
     int albumType = 1,
   }) async {
     assert(albumType == 1 || Platform.isIOS || Platform.isMacOS);
-    final AssetPathEntity entity = AssetPathEntity()
+    final AssetPathEntity entity = AssetPathEntity._()
       ..id = id
       ..albumType = albumType
       ..filterOption = filterOption ?? FilterOptionGroup()
@@ -92,17 +117,27 @@ class AssetPathEntity {
       );
     }
 
-    final AssetPathEntity? result = await PhotoManager.fetchPathProperties(
-      entity: this,
-      filterOptionGroup: filterOption,
+    final Map<dynamic, dynamic>? result = await plugin.fetchPathProperties(
+      id,
+      type,
+      filterOption,
     );
-    if (result != null) {
-      assetCount = result.assetCount;
-      name = result.name;
-      isAll = result.isAll;
-      type = result.type;
+    if (result == null) {
+      return;
+    }
+    final Object? list = result['data'];
+    if (list is List && list.isNotEmpty) {
+      final AssetPathEntity entity = ConvertUtils.convertPath(
+        result.cast<String, dynamic>(),
+        type: type,
+        optionGroup: filterOption,
+      ).first;
+      assetCount = entity.assetCount;
+      name = entity.name;
+      isAll = entity.isAll;
+      type = entity.type;
       filterOption = filterOption;
-      lastModified = result.lastModified;
+      lastModified = entity.lastModified;
     }
   }
 
@@ -169,6 +204,30 @@ class AssetPathEntity {
     return <AssetPathEntity>[];
   }
 
+  /// Obtain a new [AssetPathEntity] from the current one
+  /// with refreshed properties.
+  Future<AssetPathEntity?> fetchPathProperties({
+    FilterOptionGroup? filterOptionGroup,
+  }) async {
+    final Map<dynamic, dynamic>? result = await plugin.fetchPathProperties(
+      id,
+      type,
+      filterOptionGroup ?? filterOption,
+    );
+    if (result == null) {
+      return null;
+    }
+    final Object? list = result['data'];
+    if (list is List && list.isNotEmpty) {
+      return ConvertUtils.convertPath(
+        result.cast<String, dynamic>(),
+        type: type,
+        optionGroup: filterOptionGroup ?? filterOption,
+      ).first;
+    }
+    return null;
+  }
+
   @override
   bool operator ==(Object other) {
     if (other is! AssetPathEntity) {
@@ -223,16 +282,24 @@ class AssetEntity {
   /// could be deleted in anytime, which will cause properties invalid.
   static Future<AssetEntity?> fromId(String id) async {
     try {
-      return await PhotoManager.refreshAssetProperties(id);
+      return await _refreshAssetProperties(id);
     } catch (e) {
       return null;
     }
   }
 
-  /// Refresh properties for the current asset and return a new object.
-  Future<AssetEntity?> refreshProperties() {
-    return PhotoManager.refreshAssetProperties(id);
+  /// Refresh the property of [AssetPathEntity] from the given ID.
+  static Future<AssetEntity?> _refreshAssetProperties(String id) async {
+    final Map<dynamic, dynamic>? result =
+        await plugin.getPropertiesFromAssetEntity(id);
+    if (result == null) {
+      return null;
+    }
+    return ConvertUtils.convertMapToAsset(result.cast<String, dynamic>());
   }
+
+  /// Refresh properties for the current asset and return a new object.
+  Future<AssetEntity?> refreshProperties() => _refreshAssetProperties(id);
 
   /// The ID of the asset.
   ///  * Android: `_id` column in `MediaStore` database.

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -80,9 +80,7 @@ class AssetPathEntity {
   late bool isAll;
 
   /// Call this method to update the property
-  Future<void> refreshPathProperties({
-    bool maxDateTimeToNow = true,
-  }) async {
+  Future<void> refreshPathProperties({bool maxDateTimeToNow = true}) async {
     if (maxDateTimeToNow) {
       filterOption = filterOption.copyWith(
         createTimeCond: filterOption.createTimeCond.copyWith(
@@ -112,9 +110,12 @@ class AssetPathEntity {
   ///
   /// [page] should starts with and greater than 0.
   /// [pageSize] is item count of current [page].
-  Future<List<AssetEntity>> getAssetListPaged(int page, int pageSize) {
+  Future<List<AssetEntity>> getAssetListPaged({
+    required int page,
+    required int size,
+  }) {
     assert(albumType == 1, 'Only album can request for assets.');
-    assert(pageSize > 0, 'The pageSize must be greater than 0.');
+    assert(size > 0, 'Page size must be greater than 0.');
     assert(
       type == RequestType.image || !filterOption.onlyLivePhotos,
       'Filtering only Live Photos is only supported '
@@ -123,7 +124,7 @@ class AssetPathEntity {
     return plugin.getAssetWithGalleryIdPaged(
       id,
       page: page,
-      pageCount: pageSize,
+      size: size,
       type: type,
       optionGroup: filterOption,
     );

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -14,21 +14,13 @@ class ConvertUtils {
     final List<Map<dynamic, dynamic>> list =
         (data['data'] as List<dynamic>).cast<Map<dynamic, dynamic>>();
     for (final Map<dynamic, dynamic> item in list) {
-      final AssetPathEntity entity = AssetPathEntity()
-        ..id = item['id'] as String
-        ..name = item['name'] as String
-        ..type = type
-        ..isAll = item['isAll'] as bool
-        ..assetCount = item['length'] as int
-        ..albumType = item['albumType'] as int? ?? 1
-        ..filterOption = optionGroup ?? FilterOptionGroup();
-      final int? modifiedDate = item['modified'] as int?;
-      if (modifiedDate != null) {
-        entity.lastModified = DateTime.fromMillisecondsSinceEpoch(
-          modifiedDate * 1000,
-        );
-      }
-      result.add(entity);
+      result.add(
+        AssetPathEntity.fromJson(
+          item.cast<String, dynamic>(),
+          type: type,
+          optionGroup: optionGroup ?? FilterOptionGroup(),
+        ),
+      );
     }
     return result;
   }


### PR DESCRIPTION
### Breaking changes

- Arguments with `getAssetListPaged` are now required with name.
- `AssetPathEntity` cannot be constructed with the default constructor.
- `PhotoManager.notifyingOfChange` has no setter anymore.
- `PhotoManager.refreshAssetProperties` and `PhotoManager.fetchPathProperties` have been moved to entities.