### PR TITLE
🔥 Request `WRITE_EXTERNAL_STORAGE` only when needed

### DIFF
--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android" package="com.fluttercandies.photo_manager">
-    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.fluttercandies.photo_manager">
+
     <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"/>
-    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 </manifest>

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -3,6 +3,7 @@
     package="com.fluttercandies.photo_manager_example">
 
     <uses-permission android:name="android.permission.INTERNET"/>
+    <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
 
     <application
         android:label="photo_manager example"


### PR DESCRIPTION
Resolves #665, #470.

`WRITE_EXTERNAL_STORAGE` and `ACCESS_MEDIA_LOCATION` are removed from the plugin's manifest and will request to for granted accordingly.