### PR TITLE
⚡️ [iOS] Improve cache path for `PHAsset`

### DIFF
--- a/ios/Classes/core/PHAsset+PHAsset_getTitle.m
+++ b/ios/Classes/core/PHAsset+PHAsset_getTitle.m
@@ -72,8 +72,7 @@
 }
 
 - (PHAssetResource *)getAdjustResource {
-    NSArray<PHAssetResource *> *resources =
-    [PHAssetResource assetResourcesForAsset:self];
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:self];
     if (resources.count == 0) {
         return nil;
     }


### PR DESCRIPTION
Resolves #678, might be related to #636.

Files will be cached into the sandbox, but not matched with the modified date, which causes the same file returned without checking the modified date.