### PR TITLE
⚡️ Make all entities immutable

### DIFF
--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -15,9 +15,9 @@ This version mainly covers all valid issues, API deprecations, and few new featu
 
 - The org name has been updated from `top.kikt` to `com.fluttercandies`.
 - The plugin name on native side has been updated from `ImageScanner` to `PhotoManager`.
+- `AssetPathEntity` and `AssetEntity` are now immutable.
 - `title` are required when using saving methods.
 - Arguments with `getAssetListPaged` are now required with name.
-- `AssetPathEntity` cannot be constructed with the default constructor.
 - `PhotoManager.notifyingOfChange` has no setter anymore.
 - `PhotoManager.refreshAssetProperties` and `PhotoManager.fetchPathProperties` have been moved to entities.
 - `containsLivePhotos` are `true` by default.
@@ -29,18 +29,21 @@ This version mainly covers all valid issues, API deprecations, and few new featu
 There are several APIs have been removed, since they can't provide precise meanings, or can be replaced by new APIs.
 If you've used these APIs, consider migrating them to the latest version.
 
-| Removed API                           | Migrate destination                                      |
-| :------------------------------------ | :------------------------------------------------------- |
-| `PhotoManager.getImageAsset`          | `PhotoManager.getAssetPathList(type: RequestType.image)` |
-| `PhotoManager.getVideoAsset`          | `PhotoManager.getAssetPathList(type: RequestType.video)` |
-| `PhotoManager.fetchPathProperties`    | `AssetPathEntity.fetchPathProperties`                    |
-| `PhotoManager.refreshAssetProperties` | `AssetEntity.refreshProperties`                          |
-| `PhotoManager.requestPermission`      | `PhotoManager.requestPermissionExtend`                   |
-| `AssetPathEntity.assetList`           | N/A, use pagination APIs instead                         |
-| `AssetEntity.fullData`                | `AssetEntity.originBytes`                                |
-| `FilterOptionGroup.dateTimeCond`      | `FilterOptionGroup.createTimeCond`                       |
+| Removed API/field                       | Migrate destination                                      |
+|:----------------------------------------|:---------------------------------------------------------|
+| `PhotoManager.getImageAsset`            | `PhotoManager.getAssetPathList(type: RequestType.image)` |
+| `PhotoManager.getVideoAsset`            | `PhotoManager.getAssetPathList(type: RequestType.video)` |
+| `PhotoManager.fetchPathProperties`      | `AssetPathEntity.fetchPathProperties`                    |
+| `PhotoManager.refreshAssetProperties`   | `AssetEntity.refreshProperties`                          |
+| `PhotoManager.requestPermission`        | `PhotoManager.requestPermissionExtend`                   |
+| `AssetPathEntity.assetList`             | N/A, use pagination APIs instead.                        |
+| `AssetPathEntity.refreshPathProperties` | `AssetPathEntity.obtainForNewProperties`                 |
+| `AssetEntity.createDtSecond`            | `AssetEntity.createDateSecond`                           |
+| `AssetEntity.fullData`                  | `AssetEntity.originBytes`                                |
+| `AssetEntity.refreshProperties`         | `AssetEntity.obtainForNewProperties`                     |
+| `FilterOptionGroup.dateTimeCond`        | `FilterOptionGroup.createTimeCond`                       |
 
-#### getAssetListPaged
+#### `getAssetListPaged`
 
 Before:
 ```dart
@@ -64,6 +67,25 @@ After:
 final List<AssetPathEntity> paths = PhotoManager.getAssetPathList(
   type: RequestType.video,
   filterOption: FilterOptionGroup(containsLivePhotos: false),
+);
+```
+
+#### iOS Editor favorite asset
+
+Before:
+```dart
+final bool isSucceed = await PhotoManager.editor.iOS.favoriteAsset(
+  entity: entity,
+  favorite: true,
+);
+```
+
+After:
+```dart
+/// If succeed, a new entity will be returned.
+final AssetEntity? newEntity = await PhotoManager.editor.iOS.favoriteAsset(
+  entity: entity,
+  favorite: true,
 );
 ```
 

--- a/example/lib/widget/gallery_item_widget.dart
+++ b/example/lib/widget/gallery_item_widget.dart
@@ -50,13 +50,6 @@ class GalleryItemWidget extends StatelessWidget {
           return ListDialog(
             children: <Widget>[
               ElevatedButton(
-                child: const Text('refresh properties'),
-                onPressed: () async {
-                  await item.refreshPathProperties();
-                  setState(() {});
-                },
-              ),
-              ElevatedButton(
                 child: Text('Delete self (${item.name})'),
                 onPressed: () async {
                   if (!(Platform.isIOS || Platform.isMacOS)) {

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -187,15 +187,15 @@ class IosEditor {
     return plugin.iosDeleteCollection(path);
   }
 
-  Future<bool> favoriteAsset({
+  Future<AssetEntity?> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
     final bool result = await plugin.favoriteAsset(entity.id, favorite);
     if (result) {
-      entity.isFavorite = favorite;
+      return entity.copyWith(isFavorite: favorite);
     }
-    return result;
+    return null;
   }
 }
 

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -55,7 +55,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin {
     if (result == null) {
       return <AssetPathEntity>[];
     }
-    return ConvertUtils.convertPath(
+    return ConvertUtils.convertToPathList(
       result.cast<String, dynamic>(),
       type: type,
       optionGroup: filterOption,
@@ -367,7 +367,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin {
       },
     ) as Map<dynamic, dynamic>;
     final Map<dynamic, dynamic> items = result['list'] as Map<dynamic, dynamic>;
-    return ConvertUtils.convertPath(
+    return ConvertUtils.convertToPathList(
       items.cast<String, dynamic>(),
       type: pathEntity.type,
       optionGroup: pathEntity.filterOption,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -233,6 +233,28 @@ class AssetPathEntity {
     return null;
   }
 
+  AssetPathEntity copyWith({
+    String? id,
+    String? name,
+    int? assetCount,
+    int? albumType = 1,
+    DateTime? lastModified,
+    RequestType? type,
+    bool? isAll,
+    FilterOptionGroup? filterOption,
+  }) {
+    return AssetPathEntity(
+      id: id ?? this.id,
+      name: name ?? this.name,
+      assetCount: assetCount ?? this.assetCount,
+      albumType: albumType ?? this.albumType,
+      lastModified: lastModified ?? this.lastModified,
+      type: type ?? this.type,
+      isAll: isAll ?? this.isAll,
+      filterOption: filterOption ?? this.filterOption,
+    );
+  }
+
   @override
   bool operator ==(Object other) {
     if (other is! AssetPathEntity) {

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -1,4 +1,3 @@
-// ignore_for_file: must_be_immutable
 import 'dart:io';
 import 'dart:typed_data';
 
@@ -20,30 +19,16 @@ import 'types.dart';
 /// and the `PHAssetCollection` object on iOS/macOS.
 @immutable
 class AssetPathEntity {
-  AssetPathEntity._();
-
-  /// A factory constructor for convertion between channels.
-  factory AssetPathEntity.fromJson(
-    Map<String, dynamic> json, {
-    RequestType type = RequestType.all,
-    FilterOptionGroup? optionGroup,
-  }) {
-    final AssetPathEntity _entity = AssetPathEntity._()
-      ..id = json['id'] as String
-      ..name = json['name'] as String
-      ..type = type
-      ..isAll = json['isAll'] as bool
-      ..assetCount = json['length'] as int
-      ..albumType = json['albumType'] as int? ?? 1
-      ..filterOption = optionGroup ?? FilterOptionGroup();
-    final int? modifiedDate = json['modified'] as int?;
-    if (modifiedDate != null) {
-      _entity.lastModified = DateTime.fromMillisecondsSinceEpoch(
-        modifiedDate * 1000,
-      );
-    }
-    return _entity;
-  }
+  AssetPathEntity({
+    required this.id,
+    required this.name,
+    this.assetCount = 0,
+    this.albumType = 1,
+    this.lastModified,
+    this.type = RequestType.common,
+    this.isAll = false,
+    FilterOptionGroup? filterOption,
+  }) : filterOption = filterOption ??= FilterOptionGroup();
 
   /// Obtain an entity from ID.
   ///
@@ -56,89 +41,109 @@ class AssetPathEntity {
     int albumType = 1,
   }) async {
     assert(albumType == 1 || Platform.isIOS || Platform.isMacOS);
-    final AssetPathEntity entity = AssetPathEntity._()
-      ..id = id
-      ..albumType = albumType
-      ..filterOption = filterOption ?? FilterOptionGroup()
-      ..type = type;
-    await entity.refreshPathProperties();
+    final AssetPathEntity entity = await obtainPathFromProperties(
+      id: id,
+      albumType: albumType,
+      type: type,
+      optionGroup: filterOption ?? FilterOptionGroup(),
+    );
     return entity;
   }
 
   /// The ID of the album (asset collection).
   ///  * Android: `MediaStore.Images.Media.BUCKET_ID`.
   ///  * iOS/macOS: localIndentifier.
-  late final String id;
+  final String id;
 
   /// The name of the album.
   ///  * Android: Path name.
   ///  * iOS/macOS: Album/Folder name.
-  late String name;
+  final String name;
 
   /// Total assets count of the album.
-  late int assetCount;
+  final int assetCount;
 
   /// The type of the album.
   ///  * Android: Always be 1.
   ///  * iOS: 1 - Album, 2 - Folder.
-  late int albumType;
-
-  /// The collection of filter options of the album.
-  late FilterOptionGroup filterOption;
+  final int albumType;
 
   /// The latest modification date of the album.
   ///
   /// This field will only be included when
   /// [FilterOptionGroup.containsPathModified] is true.
-  DateTime? lastModified;
+  final DateTime? lastModified;
 
   /// The value used internally by the user.
   /// Used to indicate the value that should be available inside the path.
   /// The [RequestType] of the album.
   ///
   /// this value is determined as final when user construct the album.
-  late RequestType type;
+  final RequestType type;
 
   /// Whether the album contains all assets.
   ///
   /// An album includes all assets is the default album in general.
-  late bool isAll;
+  final bool isAll;
 
-  /// Call this method to update the property
-  Future<void> refreshPathProperties({bool maxDateTimeToNow = true}) async {
+  /// The collection of filter options of the album.
+  final FilterOptionGroup filterOption;
+
+  /// Call this method to obtain new path entity.
+  static Future<AssetPathEntity> obtainPathFromProperties({
+    required String id,
+    int albumType = 1,
+    RequestType type = RequestType.common,
+    FilterOptionGroup? optionGroup,
+    bool maxDateTimeToNow = true,
+  }) async {
+    optionGroup ??= FilterOptionGroup();
+    final StateError _error = StateError(
+      'Unable to fetch properties for path $id.',
+    );
+    final FilterOptionGroup? _optionGroup;
     if (maxDateTimeToNow) {
-      filterOption = filterOption.copyWith(
-        createTimeCond: filterOption.createTimeCond.copyWith(
+      _optionGroup = optionGroup.copyWith(
+        createTimeCond: optionGroup.createTimeCond.copyWith(
           max: DateTime.now(),
         ),
-        updateTimeCond: filterOption.updateTimeCond.copyWith(
+        updateTimeCond: optionGroup.updateTimeCond.copyWith(
           max: DateTime.now(),
         ),
       );
+    } else {
+      _optionGroup = optionGroup;
     }
 
     final Map<dynamic, dynamic>? result = await plugin.fetchPathProperties(
       id,
       type,
-      filterOption,
+      _optionGroup,
     );
     if (result == null) {
-      return;
+      throw _error;
     }
     final Object? list = result['data'];
     if (list is List && list.isNotEmpty) {
-      final AssetPathEntity entity = ConvertUtils.convertPath(
+      return ConvertUtils.convertToPathList(
         result.cast<String, dynamic>(),
         type: type,
-        optionGroup: filterOption,
+        optionGroup: _optionGroup,
       ).first;
-      assetCount = entity.assetCount;
-      name = entity.name;
-      isAll = entity.isAll;
-      type = entity.type;
-      filterOption = filterOption;
-      lastModified = entity.lastModified;
     }
+    throw _error;
+  }
+
+  /// Call this method to obtain new path entity.
+  Future<AssetPathEntity> obtainForNewProperties({
+    bool maxDateTimeToNow = true,
+  }) {
+    return AssetPathEntity.obtainPathFromProperties(
+      id: id,
+      albumType: albumType,
+      type: type,
+      optionGroup: filterOption,
+    );
   }
 
   /// Entity list with pagination support.
@@ -219,7 +224,7 @@ class AssetPathEntity {
     }
     final Object? list = result['data'];
     if (list is List && list.isNotEmpty) {
-      return ConvertUtils.convertPath(
+      return ConvertUtils.convertToPathList(
         result.cast<String, dynamic>(),
         type: type,
         optionGroup: filterOptionGroup ?? filterOption,
@@ -253,11 +258,11 @@ class AssetPathEntity {
 }
 
 /// The abstraction of assets (images/videos/audios).
-/// It represent a series of fields with `MediaStore` on Android,
+/// It represents a series of fields `MediaStore` on Android
 /// and the `PHAsset` object on iOS/macOS.
 @immutable
 class AssetEntity {
-  AssetEntity({
+  const AssetEntity({
     required this.id,
     required this.typeInt,
     required this.width,
@@ -266,7 +271,7 @@ class AssetEntity {
     this.orientation = 0,
     this.isFavorite = false,
     this.title,
-    this.createDtSecond,
+    this.createDateSecond,
     this.modifiedDateSecond,
     this.relativePath,
     double? latitude,
@@ -282,14 +287,14 @@ class AssetEntity {
   /// could be deleted in anytime, which will cause properties invalid.
   static Future<AssetEntity?> fromId(String id) async {
     try {
-      return await _refreshAssetProperties(id);
+      return await _obtainAssetFromId(id);
     } catch (e) {
       return null;
     }
   }
 
   /// Refresh the property of [AssetPathEntity] from the given ID.
-  static Future<AssetEntity?> _refreshAssetProperties(String id) async {
+  static Future<AssetEntity?> _obtainAssetFromId(String id) async {
     final Map<dynamic, dynamic>? result =
         await plugin.getPropertiesFromAssetEntity(id);
     if (result == null) {
@@ -299,7 +304,7 @@ class AssetEntity {
   }
 
   /// Refresh properties for the current asset and return a new object.
-  Future<AssetEntity?> refreshProperties() => _refreshAssetProperties(id);
+  Future<AssetEntity?> obtainForNewProperties() => _obtainAssetFromId(id);
 
   /// The ID of the asset.
   ///  * Android: `_id` column in `MediaStore` database.
@@ -570,16 +575,16 @@ class AssetEntity {
   Size get size => Size(width.toDouble(), height.toDouble());
 
   /// The create time in unix timestamp of the asset.
-  int? createDtSecond;
+  final int? createDateSecond;
 
   /// The create time of the asset in [DateTime].
   DateTime get createDateTime {
-    final int value = createDtSecond ?? 0;
+    final int value = createDateSecond ?? 0;
     return DateTime.fromMillisecondsSinceEpoch(value * 1000);
   }
 
   /// The modified time in unix timestamp of the asset.
-  int? modifiedDateSecond;
+  final int? modifiedDateSecond;
 
   /// The modified time of the asset in [DateTime].
   DateTime get modifiedDateTime {
@@ -658,7 +663,7 @@ class AssetEntity {
   ///
   /// See also:
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#ORIENTATION
-  int orientation;
+  final int orientation;
 
   /// Whether the asset is favorited on the device.
   ///  * Android: Always false.
@@ -666,13 +671,13 @@ class AssetEntity {
   ///
   /// See also:
   ///  * [IosEditor.favoriteAsset] to update the favorite status.
-  bool isFavorite;
+  final bool isFavorite;
 
   /// The relative path abstraction of the asset.
   ///  * Android 10 and above: `MediaStore.MediaColumns.RELATIVE_PATH`.
   ///  * Android 9 and below: The parent path of `MediaStore.MediaColumns.DATA`.
   ///  * iOS/macOS: Always null.
-  String? relativePath;
+  final String? relativePath;
 
   /// The mime type of the asset.
   ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
@@ -680,7 +685,43 @@ class AssetEntity {
   ///
   /// See also:
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#MIME_TYPE
-  String? mimeType;
+  final String? mimeType;
+
+  AssetEntity copyWith({
+    String? id,
+    int? typeInt,
+    int? width,
+    int? height,
+    int? duration,
+    int? orientation,
+    bool? isFavorite,
+    String? title,
+    int? createDateSecond,
+    int? modifiedDateSecond,
+    String? relativePath,
+    double? latitude,
+    double? longitude,
+    String? mimeType,
+    int? subtype,
+  }) {
+    return AssetEntity(
+      id: id ?? this.id,
+      typeInt: typeInt ?? this.typeInt,
+      width: width ?? this.width,
+      height: height ?? this.height,
+      duration: duration ?? this.duration,
+      orientation: orientation ?? this.orientation,
+      isFavorite: isFavorite ?? this.isFavorite,
+      title: title ?? this.title,
+      createDateSecond: createDateSecond ?? this.createDateSecond,
+      modifiedDateSecond: modifiedDateSecond ?? this.modifiedDateSecond,
+      relativePath: relativePath ?? this.relativePath,
+      latitude: latitude ?? this.latitude,
+      longitude: longitude ?? this.longitude,
+      mimeType: mimeType ?? this.mimeType,
+      subtype: subtype ?? this.subtype,
+    );
+  }
 
   @override
   int get hashCode => hashValues(id, isFavorite);

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -5,7 +5,7 @@ import '../types/types.dart';
 class ConvertUtils {
   const ConvertUtils._();
 
-  static List<AssetPathEntity> convertPath(
+  static List<AssetPathEntity> convertToPathList(
     Map<String, dynamic> data, {
     RequestType type = RequestType.all,
     FilterOptionGroup? optionGroup,
@@ -15,7 +15,7 @@ class ConvertUtils {
         (data['data'] as List<dynamic>).cast<Map<dynamic, dynamic>>();
     for (final Map<dynamic, dynamic> item in list) {
       result.add(
-        AssetPathEntity.fromJson(
+        convertMapToPath(
           item.cast<String, dynamic>(),
           type: type,
           optionGroup: optionGroup ?? FilterOptionGroup(),
@@ -35,6 +35,28 @@ class ConvertUtils {
     return result;
   }
 
+  static AssetPathEntity convertMapToPath(
+    Map<String, dynamic> data, {
+    RequestType type = RequestType.common,
+    FilterOptionGroup? optionGroup,
+  }) {
+    final int? modified = data['modified'] as int?;
+    final DateTime? lastModified = modified != null
+        ? DateTime.fromMillisecondsSinceEpoch(modified * 1000)
+        : null;
+    final AssetPathEntity result = AssetPathEntity(
+      id: data['id'] as String,
+      name: data['name'] as String,
+      assetCount: data['length'] as int,
+      albumType: data['albumType'] as int? ?? 1,
+      filterOption: optionGroup ?? FilterOptionGroup(),
+      lastModified: lastModified,
+      type: type,
+      isAll: data['isAll'] as bool,
+    );
+    return result;
+  }
+
   static AssetEntity convertMapToAsset(
     Map<String, dynamic> data, {
     String? title,
@@ -49,7 +71,7 @@ class ConvertUtils {
       isFavorite: data['favorite'] as bool? ?? false,
       title: data['title'] as String? ?? title,
       subtype: data['subtype'] as int? ?? 0,
-      createDtSecond: data['createDt'] as int?,
+      createDateSecond: data['createDt'] as int?,
       modifiedDateSecond: data['modifiedDt'] as int?,
       relativePath: data['relativePath'] as String?,
       latitude: data['lat'] as double?,


### PR DESCRIPTION
Breaking changes:
- `AssetPathEntity` and `AssetEntity` become immutable.
- `IosEditor.favoriteAsset` now returns `AssetEntity?` instead of boolean value.
- `AssetPathEntity.refreshPathProperties` has been removed, use `obtainForNewProperties` with different signature.
- `createDtSecond` has been renamed to `createDateSecond` in `AssetEntity`.
- `refreshProperties` has been renamed to `obtainForNewProperties` in `AssetEntity`.