### PR TITLE
1. fix null point bug: （PMConvertUtils.convertPathToMap） entity id or…

### DIFF
--- a/ios/Classes/core/PMConvertUtils.m
+++ b/ios/Classes/core/PMConvertUtils.m
@@ -12,8 +12,8 @@
     
     for (PMAssetPathEntity *entity in array) {
         NSDictionary *item = @{
-            @"id": entity.id,
-            @"name": entity.name,
+            @"id": entity.id ?: @"",
+            @"name": entity.name ?: @"",
             @"length": @(entity.assetCount),
             @"isAll": @(entity.isAll),
             @"albumType": @(entity.type),


### PR DESCRIPTION
I meet the null point bug on special picture. It's rarly happen. I only receive one bug report on reallity online production environment.
But my QA colleague recurrence this case on one Apple Phone, so I must fix the bug.

Method stack:
Thread 12 Crashed:
0   CoreFoundation                  __exceptionPreprocess + 216
1   libobjc.A.dylib                 objc_exception_throw + 56
2   CoreFoundation                  -[__NSCFString characterAtIndex:].cold.1 + 0
3   CoreFoundation                  -[__NSPlaceholderDictionary initWithObjects:forKeys:count:].cold.5 + 0
4   CoreFoundation                  -[__NSPlaceholderDictionary initWithObjects:forKeys:count:] + 240
5   CoreFoundation                  +[NSDictionary dictionaryWithObjects:forKeys:count:] + 56
6   MyAppleProject                  +[PMConvertUtils convertPathToMap:] (PMConvertUtils.m:0)

Application Specific Information:
*** Terminating app due to uncaught exception 'NSInvalidArgumentException', reason: '*** -[__NSPlaceholderDictionary initWithObjects:forKeys:count:]: attempt to insert nil object from objects[1]
UserInfo:(null)'
