### PR TITLE
Support 'mimeType' for iOS and macOS

### DIFF
--- a/example/lib/util/common_util.dart
+++ b/example/lib/util/common_util.dart
@@ -44,6 +44,7 @@ class CommonUtil {
               _buildInfoItem('lat', lat.toString()),
               _buildInfoItem('lng', lng.toString()),
               _buildInfoItem('relative path', entity.relativePath ?? 'null'),
+              _buildInfoItemAsync('mimeType', entity.mimeTypeAsync),
             ],
           ),
         ),
@@ -70,10 +71,10 @@ class CommonUtil {
     );
   }
 
-  static Widget _buildInfoItemAsync(String title, Future<String> info) {
-    return FutureBuilder<String>(
+  static Widget _buildInfoItemAsync(String title, Future<String?> info) {
+    return FutureBuilder<String?>(
       future: info,
-      builder: (BuildContext context, AsyncSnapshot<String> snapshot) {
+      builder: (BuildContext context, AsyncSnapshot<String?> snapshot) {
         if (!snapshot.hasData) {
           return _buildInfoItem(title, '');
         }

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -387,6 +387,10 @@
             NSString *assetId = call.arguments[@"id"];
             NSString *title = [manager getTitleAsyncWithAssetId:assetId];
             [handler reply:title];
+        } else if ([call.method isEqualToString:@"getMimeTypeAsync"]) {
+            NSString *assetId = call.arguments[@"id"];
+            NSString *mimeType = [manager getMimeTypeAsyncWithAssetId:assetId];
+            [handler reply:mimeType];
         } else if ([@"getMediaUrl" isEqualToString:call.method]) {
             [manager getMediaUrl:call.arguments[@"id"] resultHandler:handler];
         } else if ([@"getPropertiesFromAssetEntity" isEqualToString:call.method]) {

--- a/ios/Classes/core/PHAsset+PM_COMMON.h
+++ b/ios/Classes/core/PHAsset+PM_COMMON.h
@@ -18,7 +18,13 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)unwrappedSubtype;
 
 - (NSString*)title;
-- (NSString*)mimeType;
+/**
+ Get the MIME type for this asset from UTI (`PHAssetResource.uniformTypeIdentifier`), such as `image/jpeg`, `image/heic`, `video/quicktime`, etc.
+ 
+ @note For Live Photos, this returns a type representing its image file.
+ @return The MIME type of this asset if available, otherwise `nil`.
+ */
+- (nullable NSString*)mimeType;
 - (BOOL)isAdjust;
 - (PHAssetResource *)getAdjustResource;
 - (void)requestAdjustedData:(void (^)(NSData *_Nullable result))block;

--- a/ios/Classes/core/PHAsset+PM_COMMON.h
+++ b/ios/Classes/core/PHAsset+PM_COMMON.h
@@ -18,6 +18,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (int)unwrappedSubtype;
 
 - (NSString*)title;
+- (NSString*)mimeType;
 - (BOOL)isAdjust;
 - (PHAssetResource *)getAdjustResource;
 - (void)requestAdjustedData:(void (^)(NSData *_Nullable result))block;

--- a/ios/Classes/core/PHAsset+PM_COMMON.m
+++ b/ios/Classes/core/PHAsset+PM_COMMON.m
@@ -4,6 +4,11 @@
 //
 
 #import "PHAsset+PM_COMMON.h"
+#if TARGET_OS_IOS || TARGET_OS_WATCH || TARGET_OS_TV
+#import <MobileCoreServices/MobileCoreServices.h>
+#else
+#import <CoreServices/CoreServices.h>
+#endif
 
 @implementation PHAsset (PM_COMMON)
 
@@ -88,6 +93,15 @@
         
         return @"";
     }
+}
+
+- (NSString *)mimeType {
+    PHAssetResource *resource = [[PHAssetResource assetResourcesForAsset:self] firstObject];
+    if (resource) {
+        NSString *uti = resource.uniformTypeIdentifier;
+        return (__bridge_transfer NSString *)UTTypeCopyPreferredTagWithClass((__bridge CFStringRef)uti, kUTTagClassMIMEType);
+    }
+    return nil;
 }
 
 - (BOOL)isAdjust {

--- a/ios/Classes/core/PHAsset+PM_COMMON.m
+++ b/ios/Classes/core/PHAsset+PM_COMMON.m
@@ -94,7 +94,7 @@
         return @"";
     }
 }
-// UTI:  https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html#//apple_ref/doc/uid/TP40001319
+// UTI: https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html#//apple_ref/doc/uid/TP40001319
 - (NSString *)mimeType {
     PHAssetResource *resource = [[PHAssetResource assetResourcesForAsset:self] firstObject];
     if (resource) {

--- a/ios/Classes/core/PHAsset+PM_COMMON.m
+++ b/ios/Classes/core/PHAsset+PM_COMMON.m
@@ -94,7 +94,7 @@
         return @"";
     }
 }
-
+// UTI:  https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_intro/understand_utis_intro.html#//apple_ref/doc/uid/TP40001319
 - (NSString *)mimeType {
     PHAssetResource *resource = [[PHAssetResource assetResourcesForAsset:self] firstObject];
     if (resource) {

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -62,6 +62,8 @@ typedef void (^AssetResult)(PMAssetEntity *);
 
 - (NSString*)getTitleAsyncWithAssetId: (NSString *) assetId;
 
+- (NSString*)getMimeTypeAsyncWithAssetId: (NSString *) assetId;
+
 - (void)getMediaUrl:(NSString *)assetId resultHandler:(NSObject <PMResultHandler> *)handler;
 
 - (NSArray<PMAssetPathEntity *> *)getSubPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(PMFilterOptionGroup *)option;

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -1077,6 +1077,15 @@
     return @"";
 }
 
+- (NSString *)getMimeTypeAsyncWithAssetId:(NSString *)assetId {
+    PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil];
+    PHAsset *asset = [self getFirstObjFromFetchResult:fetchResult];
+    if (asset) {
+        return [asset mimeType];
+    }
+    return nil;
+}
+
 - (void)getMediaUrl:(NSString *)assetId resultHandler:(NSObject <PMResultHandler> *)handler {
     BOOL isLocallyAvailable = [self entityIsLocallyAvailable:assetId];
     if (!isLocallyAvailable) {

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -28,6 +28,7 @@ class PMConstants {
   static const String mSystemVersion = 'systemVersion';
   static const String mGetLatLngAndroidQ = 'getLatLngAndroidQ';
   static const String mGetTitleAsync = 'getTitleAsync';
+  static const String mGetMimeTypeAsync = 'getMimeTypeAsync';
   static const String mGetMediaUrl = 'getMediaUrl';
   static const String mGetSubPath = 'getSubPath';
   static const String mCopyAsset = 'copyAsset';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -466,6 +466,20 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin {
       return _channel.invokeMethod(PMConstants.mPresentLimited);
     }
   }
+
+  Future<String?> getMimeTypeAsync(AssetEntity entity) async {
+    assert(Platform.isAndroid || Platform.isIOS || Platform.isMacOS);
+    if (Platform.isAndroid) {
+      return entity.mimeType;
+    }
+    if (Platform.isIOS || Platform.isMacOS) {
+      return _channel.invokeMethod<String>(
+        PMConstants.mGetMimeTypeAsync,
+        <String, dynamic>{'id': entity.id},
+      );
+    }
+    return null;
+  }
 }
 
 mixin IosPlugin on BasePlugin {

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -710,7 +710,10 @@ class AssetEntity {
   ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
   ///  * iOS/macOS: MIME type from `PHAssetResource.uniformTypeIdentifier`.
   /// 
+  /// For Live Photos on iOS/macOs, this returns a type representing its image file.
+  /// 
   /// See also:
+  ///  * [mimeType] the synchronized getter of the MIME type
   ///  * https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1
   Future<String?> get mimeTypeAsync => plugin.getMimeTypeAsync(this);
 

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -699,11 +699,19 @@ class AssetEntity {
 
   /// The mime type of the asset.
   ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
-  ///  * iOS/macOS: Always null.
+  ///  * iOS/macOS: Always null. Use the async getter [mimeTypeAsync] instead.
   ///
   /// See also:
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#MIME_TYPE
   final String? mimeType;
+
+  /// Get the mime type async.
+  ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
+  ///  * iOS/macOS: MIME type from `PHAssetResource.uniformTypeIdentifier`.
+  /// 
+  /// See also:
+  ///  * https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1
+  Future<String?> get mimeTypeAsync => plugin.getMimeTypeAsync(this);
 
   AssetEntity copyWith({
     String? id,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -713,7 +713,7 @@ class AssetEntity {
   /// For Live Photos on iOS/macOs, this returns a type representing its image file.
   /// 
   /// See also:
-  ///  * [mimeType] the synchronized getter of the MIME type
+  ///  * [mimeType] which is the synchronized getter of the MIME type.
   ///  * https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1
   Future<String?> get mimeTypeAsync => plugin.getMimeTypeAsync(this);
 

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -702,6 +702,7 @@ class AssetEntity {
   ///  * iOS/macOS: Always null. Use the async getter [mimeTypeAsync] instead.
   ///
   /// See also:
+  ///  * [mimeTypeAsync] which is the asynchronized getter of the MIME type.
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#MIME_TYPE
   final String? mimeType;
 


### PR DESCRIPTION
On iOS, we can detecting MIME type from UTI.
See https://developer.apple.com/documentation/photokit/phassetresource/1623989-uniformtypeidentifier?language=objc and https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1