### PR TITLE
🚑️ [Android] Predicate more precise permissions requirements

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/AssetType.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/AssetType.kt
@@ -1,0 +1,3 @@
+package com.fluttercandies.photo_manager.constant
+
+enum class AssetType { Image, Video, Audio }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -1,0 +1,35 @@
+package com.fluttercandies.photo_manager.constant
+
+class Methods {
+    companion object {
+        const val log = "log"
+        const val openSetting = "openSetting"
+        const val forceOldAPI = "forceOldApi"
+        const val systemVersion = "systemVersion"
+        const val clearFileCache = "clearFileCache"
+        const val releaseMemoryCache = "releaseMemCache"
+
+        const val requestPermissionExtend = "requestPermissionExtend"
+        const val getAssetPathList = "getGalleryList"
+        const val getAssetWithGalleryId = "getAssetWithGalleryId"
+        const val getAssetListWithRange = "getAssetListWithRange"
+        const val getThumbnail = "getThumb"
+        const val requestCacheAssetsThumbnail = "requestCacheAssetsThumb"
+        const val cancelCacheRequests = "cancelCacheRequests"
+        const val assetExists = "assetExists"
+        const val getFullFile = "getFullFile"
+        const val getOriginBytes = "getOriginBytes"
+        const val getMediaUrl = "getMediaUrl"
+        const val getPropertiesFromAssetEntity = "getPropertiesFromAssetEntity"
+        const val fetchPathProperties = "fetchPathProperties"
+        const val getLatLng = "getLatLngAndroidQ"
+        const val notify = "notify"
+        const val deleteWithIds = "deleteWithIds"
+        const val saveImage = "saveImage"
+        const val saveImageWithPath = "saveImageWithPath"
+        const val saveVideo = "saveVideo"
+        const val copyAsset = "copyAsset"
+        const val moveAssetToPath = "moveAssetToPath"
+        const val removeNoExistsAssets = "removeNoExistsAssets"
+    }
+}

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/AssetType.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/AssetType.kt
@@ -1,3 +1,0 @@
-package com.fluttercandies.photo_manager.core
-
-enum class AssetType { Image, Video, Audio }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/FilterOption.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/FilterOption.kt
@@ -2,7 +2,7 @@ package com.fluttercandies.photo_manager.core.entity
 
 import android.annotation.SuppressLint
 import android.provider.MediaStore
-import com.fluttercandies.photo_manager.core.AssetType
+import com.fluttercandies.photo_manager.constant.AssetType
 import com.fluttercandies.photo_manager.core.utils.ConvertUtils
 
 class FilterOption(map: Map<*, *>) {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
@@ -1,7 +1,7 @@
 package com.fluttercandies.photo_manager.core.utils
 
 import android.provider.MediaStore
-import com.fluttercandies.photo_manager.core.AssetType
+import com.fluttercandies.photo_manager.constant.AssetType
 import com.fluttercandies.photo_manager.core.entity.*
 
 object ConvertUtils {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
@@ -8,7 +8,9 @@ import android.content.pm.PackageManager
 import android.net.Uri
 import android.os.Build
 import androidx.core.app.ActivityCompat
+import com.fluttercandies.photo_manager.constant.Methods
 import com.fluttercandies.photo_manager.util.LogUtils
+import io.flutter.plugin.common.MethodCall
 import java.lang.NullPointerException
 import java.util.ArrayList
 
@@ -75,7 +77,10 @@ class PermissionsUtils {
      * @return 返回 [PermissionsUtils] 自身，进行链式调用
      */
     @TargetApi(23)
-    private fun getPermissionsWithTips(requestCode: Int, vararg permissions: String): PermissionsUtils {
+    private fun getPermissionsWithTips(
+        requestCode: Int,
+        vararg permissions: String
+    ): PermissionsUtils {
         if (mActivity == null) {
             throw NullPointerException("Activity for the permission request is not exist.")
         }
@@ -177,5 +182,28 @@ class PermissionsUtils {
         localIntent.action = "android.settings.APPLICATION_DETAILS_SETTINGS"
         localIntent.data = Uri.fromParts("package", context!!.packageName, null)
         context.startActivity(localIntent)
+    }
+
+    fun needWriteExternalStorage(call: MethodCall): Boolean {
+        return when (call.method) {
+            Methods.saveImage,
+            Methods.saveImageWithPath,
+            Methods.saveVideo,
+            Methods.copyAsset,
+            Methods.moveAssetToPath,
+            Methods.deleteWithIds,
+            Methods.removeNoExistsAssets -> true
+            else -> false
+        }
+    }
+
+    fun needAccessLocation(call: MethodCall): Boolean {
+        return when (call.method) {
+            Methods.copyAsset,
+            Methods.getLatLng,
+            Methods.getOriginBytes -> true
+            Methods.getFullFile -> call.argument<Boolean>("isOrigin")!! && Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q
+            else -> false
+        }
     }
 }

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -4,6 +4,9 @@
 
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+    <uses-permission
+        android:name="android.permission.WRITE_EXTERNAL_STORAGE"
+        android:maxSdkVersion="29"/>
 
     <application
         android:label="photo_manager example"


### PR DESCRIPTION
Fix #722.

This fixes methods related to the `WRITE_EXTERNAL_STORAGE` permission on Android versions that are below 29. All methods are predefined, permissions requirements are checked based on each call's method.