### PR TITLE
⚡️ [Android] Using `ContentResolver` as much as possible

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -93,9 +93,10 @@ class PhotoManager(private val context: Context) {
                 resultHandler.replyError("The asset not found!")
                 return
             }
-            ThumbnailUtil.getThumbnailByGlide(
+            val uri = asset.getUri()
+            ThumbnailUtil.getThumbnail(
                 context,
-                asset.path,
+                uri,
                 option.width,
                 option.height,
                 format,
@@ -104,7 +105,7 @@ class PhotoManager(private val context: Context) {
                 resultHandler.result
             )
         } catch (e: Exception) {
-            Log.e(LogUtils.TAG, "get $id thumb error, width : $width, height: $height", e)
+            Log.e(LogUtils.TAG, "get $id thumbnail error, width : $width, height: $height", e)
             dbUtils.logRowWithId(context, id)
             resultHandler.replyError("201", "get thumb error", e)
         }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -110,18 +110,18 @@ class PhotoManager(private val context: Context) {
         }
     }
 
-    fun getOriginBytes(id: String, resultHandler: ResultHandler) {
+    fun getOriginBytes(id: String, resultHandler: ResultHandler, haveLocationPermission: Boolean) {
         val asset = dbUtils.getAssetEntity(context, id)
         if (asset == null) {
             resultHandler.replyError("The asset not found")
             return
         }
         try {
-            val byteArray = File(asset.path).readBytes()
+            val byteArray = dbUtils.getOriginBytes(context, asset, haveLocationPermission)
             resultHandler.reply(byteArray)
         } catch (e: Exception) {
             dbUtils.logRowWithId(context, id)
-            resultHandler.replyError("202", "get origin Bytes error", e)
+            resultHandler.replyError("202", "get originBytes error", e)
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -296,7 +296,7 @@ class PhotoManagerPlugin(
             Methods.getOriginBytes -> {
                 runOnBackground {
                     val id = call.argument<String>("id")!!
-                    photoManager.getOriginBytes(id, resultHandler)
+                    photoManager.getOriginBytes(id, resultHandler, haveLocationPermission)
                 }
             }
             Methods.getMediaUrl -> {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -288,8 +288,7 @@ class PhotoManagerPlugin(
             Methods.getFullFile -> {
                 runOnBackground {
                     val id = call.argument<String>("id")!!
-                    val isOrigin =
-                        if (!haveLocationPermission) false else call.argument<Boolean>("isOrigin")!!
+                    val isOrigin = if (!haveLocationPermission) false else call.argument<Boolean>("isOrigin")!!
                     photoManager.getFile(id, isOrigin, resultHandler)
                 }
             }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -253,16 +253,13 @@ object AndroidQDBUtils : IDBUtils {
             && File(path).exists()
             && !mimeType.contains("svg")
         ) {
-//            try {
-                val uri = getUri(id, getMediaType(type))
-                context.contentResolver.openInputStream(uri)?.use {
-                    ExifInterface(it).apply {
-                        width = getAttribute(ExifInterface.TAG_IMAGE_WIDTH)?.toInt() ?: width
-                        height = getAttribute(ExifInterface.TAG_IMAGE_LENGTH)?.toInt() ?: height
-                    }
+            val uri = getUri(id, getMediaType(type))
+            context.contentResolver.openInputStream(uri)?.use {
+                ExifInterface(it).apply {
+                    width = getAttribute(ExifInterface.TAG_IMAGE_WIDTH)?.toInt() ?: width
+                    height = getAttribute(ExifInterface.TAG_IMAGE_LENGTH)?.toInt() ?: height
                 }
-//            } catch (_: Throwable) {
-//            }
+            }
         }
         return AssetEntity(
             id,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -176,7 +176,7 @@ object AndroidQDBUtils : IDBUtils {
         ) ?: return emptyList()
         cursor.use {
             cursorWithRange(it, page * size, size) {
-                val asset = convertCursorToAssetEntity(cursor)
+                val asset = convertCursorToAssetEntity(context, cursor)
                 list.add(asset)
             }
         }
@@ -219,7 +219,7 @@ object AndroidQDBUtils : IDBUtils {
         ) ?: return emptyList()
         cursor.use {
             cursorWithRange(it, start, pageSize) {
-                list.add(convertCursorToAssetEntity(cursor))
+                list.add(convertCursorToAssetEntity(context, cursor))
             }
         }
         return list
@@ -229,7 +229,7 @@ object AndroidQDBUtils : IDBUtils {
     private fun assetKeys() =
         IDBUtils.storeImageKeys + IDBUtils.storeVideoKeys + IDBUtils.typeKeys + arrayOf(MediaStore.MediaColumns.RELATIVE_PATH)
 
-    private fun convertCursorToAssetEntity(cursor: Cursor): AssetEntity {
+    private fun convertCursorToAssetEntity(context: Context, cursor: Cursor): AssetEntity {
         val id = cursor.getString(MediaStore.MediaColumns._ID)
         val path = cursor.getString(MediaStore.MediaColumns.DATA)
         var date = cursor.getLong(MediaStore.Images.Media.DATE_TAKEN)
@@ -248,11 +248,21 @@ object AndroidQDBUtils : IDBUtils {
         val modifiedDate = cursor.getLong(MediaStore.MediaColumns.DATE_MODIFIED)
         val orientation: Int = cursor.getInt(MediaStore.MediaColumns.ORIENTATION)
         val relativePath: String = cursor.getString(MediaStore.MediaColumns.RELATIVE_PATH)
-        if ((width == 0 || height == 0) && path.isNotBlank() && File(path).exists()) {
-            ExifInterface(path).apply {
-                width = getAttribute(ExifInterface.TAG_IMAGE_WIDTH)?.toInt() ?: width
-                height = getAttribute(ExifInterface.TAG_IMAGE_LENGTH)?.toInt() ?: height
-            }
+        if ((width == 0 || height == 0)
+            && path.isNotBlank()
+            && File(path).exists()
+            && !mimeType.contains("svg")
+        ) {
+//            try {
+                val uri = getUri(id, getMediaType(type), true)
+                context.contentResolver.openInputStream(uri)?.use {
+                    ExifInterface(it).apply {
+                        width = getAttribute(ExifInterface.TAG_IMAGE_WIDTH)?.toInt() ?: width
+                        height = getAttribute(ExifInterface.TAG_IMAGE_LENGTH)?.toInt() ?: height
+                    }
+                }
+//            } catch (_: Throwable) {
+//            }
         }
         return AssetEntity(
             id,
@@ -282,7 +292,8 @@ object AndroidQDBUtils : IDBUtils {
             null
         ) ?: return null
         cursor.use {
-            return if (it.moveToNext()) convertCursorToAssetEntity(it) else null
+            return if (it.moveToNext()) convertCursorToAssetEntity(context, it)
+            else null
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -254,7 +254,7 @@ object AndroidQDBUtils : IDBUtils {
             && !mimeType.contains("svg")
         ) {
 //            try {
-                val uri = getUri(id, getMediaType(type), true)
+                val uri = getUri(id, getMediaType(type))
                 context.contentResolver.openInputStream(uri)?.use {
                     ExifInterface(it).apply {
                         width = getAttribute(ExifInterface.TAG_IMAGE_WIDTH)?.toInt() ?: width

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -355,19 +355,6 @@ object AndroidQDBUtils : IDBUtils {
         return assetEntity.path
     }
 
-    override fun getThumbUri(
-        context: Context,
-        id: String,
-        width: Int,
-        height: Int,
-        type: Int?
-    ): Uri? {
-        if (type == null) {
-            return null
-        }
-        return getUri(id, type)
-    }
-
     private fun getUri(asset: AssetEntity, isOrigin: Boolean = false): Uri =
         getUri(asset.id, asset.type, isOrigin)
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -296,7 +296,7 @@ object DBUtils : IDBUtils {
         asset: AssetEntity,
         haveLocationPermission: Boolean
     ): ByteArray {
-        TODO("not implemented")
+        return File(asset.path).readBytes()
     }
 
     override fun getExif(context: Context, id: String): ExifInterface? {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -147,16 +147,6 @@ object DBUtils : IDBUtils {
         }
     }
 
-    override fun getThumbUri(
-        context: Context,
-        id: String,
-        width: Int,
-        height: Int,
-        type: Int?
-    ): Uri? {
-        TODO("not implemented")
-    }
-
     override fun getAssetFromGalleryId(
         context: Context,
         galleryId: String,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -151,8 +151,6 @@ interface IDBUtils {
 
     fun getFilePath(context: Context, id: String, origin: Boolean): String?
 
-    fun getThumbUri(context: Context, id: String, width: Int, height: Int, type: Int?): Uri?
-
     fun getAssetFromGalleryIdRange(
         context: Context,
         galleryId: String,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -309,7 +309,7 @@ interface IDBUtils {
     }
 
     fun getMediaUri(context: Context, id: String, type: Int): String {
-        val uri = AndroidQDBUtils.getUri(id, type, false)
+        val uri = getUri(id, type, false)
         return uri.toString()
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/thumb/ThumbnailUtil.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/thumb/ThumbnailUtil.kt
@@ -14,7 +14,7 @@ import java.io.ByteArrayOutputStream
 import java.io.File
 
 object ThumbnailUtil {
-    fun getThumbnailByGlide(
+    fun getThumbnail(
         ctx: Context,
         path: String,
         width: Int,
@@ -40,7 +40,7 @@ object ThumbnailUtil {
         }
     }
 
-    fun getThumbOfUri(
+    fun getThumbnail(
         context: Context,
         uri: Uri,
         width: Int,
@@ -48,8 +48,10 @@ object ThumbnailUtil {
         format: Bitmap.CompressFormat,
         quality: Int,
         frame: Long,
-        callback: (ByteArray?) -> Unit
+        result: MethodChannel.Result?
     ) {
+        val resultHandler = ResultHandler(result)
+
         try {
             val resource = Glide.with(context)
                 .asBitmap()
@@ -58,9 +60,9 @@ object ThumbnailUtil {
                 .submit(width, height).get()
             val bos = ByteArrayOutputStream()
             resource.compress(format, quality, bos)
-            callback(bos.toByteArray())
+            resultHandler.reply(bos.toByteArray())
         } catch (e: Exception) {
-            callback(null)
+            resultHandler.reply(null)
         }
     }
 


### PR DESCRIPTION
Further improvements for #727, #707.

Now the plugin will obtain thumbnails and `originBytes` using the Content URI as much as possible, to avoid some storage mechanisms with various vendors.