### PR TITLE
🚨 Ignore null-aware operator for `PaintingBinding`'s instance

### DIFF
--- a/lib/src/internal/image_provider.dart
+++ b/lib/src/internal/image_provider.dart
@@ -108,6 +108,7 @@ class AssetEntityImageProvider extends ImageProvider<AssetEntityImageProvider> {
       // have had a chance to track the key in the cache at all.
       // Schedule a microtask to give the cache a chance to add the key.
       Future<void>.microtask(() {
+        // ignore: invalid_null_aware_operator
         PaintingBinding.instance?.imageCache?.evict(key);
       });
       rethrow;


### PR DESCRIPTION
Solves the coming lint issues with Flutter 2.13, and keeps the compatibility of previous Flutter versions.