### PR TITLE
[iOS] Predicate for live-photo filtering workaround

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ Improvements:
 
 - Correct `PermissionRequestOption` typo with a class type alias.
   Which also raised the Dart SDK constraint to `2.13.0`.
+- The original predicate for filtering live-photo cannot be executed correctly and unexpectedly rejects photos with media subtype `PHAssetMediaSubtypeNone`. Changing it from `( ( mediaSubtype & 8 ) != 8 )` to `NOT ( ( mediaSubtype & 8 ) == 8` works correctly.
 
 ## 2.1.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ Improvements:
 
 - Correct `PermissionRequestOption` typo with a class type alias.
   Which also raised the Dart SDK constraint to `2.13.0`.
-- The original predicate for filtering live-photo cannot be executed correctly and unexpectedly rejects photos with media subtype `PHAssetMediaSubtypeNone`. Changing it from `( ( mediaSubtype & 8 ) != 8 )` to `NOT ( ( mediaSubtype & 8 ) == 8` works correctly.
+- Improve Live-Photos filtering.
 
 ## 2.1.1
 

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -845,7 +845,7 @@
             } else if (!optionGroup.containsLivePhotos) {
                 [cond appendString:@" AND "];
                 [cond appendString:[NSString
-                                    stringWithFormat:@"( ( mediaSubtype & %lu ) != 8 )",
+                                    stringWithFormat:@"NOT ( ( mediaSubtype & %lu ) == 8 )",
                                     (unsigned long)PHAssetMediaSubtypePhotoLive]
                 ];
             }


### PR DESCRIPTION
Use `NOT` instead of `!=` in live-photo filtering expression.
With original predicate, a lot of non-live-photo cannot bet fetched unexpectedly.