### PR TITLE
🐛 Fix invalid type cast with `AssetEntity.exists`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.1.3
+
+Fixes:
+
+- Fix invalid type cast with `AssetEntity.exists`. (#777)
+
 ## 2.1.2
 
 Improvements:

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager_example
 description: Demonstrates how to use the image_scanner plugin.
-version: 2.1.1+8
+version: 2.1.3+10
 publish_to: none
 
 environment:

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -304,11 +304,12 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin {
     );
   }
 
-  Future<bool> assetExistsWithId(String id) {
-    return _channel.invokeMethod<bool>(
+  Future<bool> assetExistsWithId(String id) async {
+    final bool? result = await _channel.invokeMethod(
       PMConstants.mAssetExists,
       <String, dynamic>{'id': id},
-    ) as Future<bool>;
+    );
+    return result ?? false;
   }
 
   Future<String> getSystemVersion() async {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
-version: 2.1.2
+version: 2.1.3
 homepage: https://github.com/fluttercandies/flutter_photo_manager
 
 environment:


### PR DESCRIPTION
Fix #776.