### PR TITLE
✨ `AssetPathEntity.assetCountAsync`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,30 +4,39 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.2.0
+
+### Breaking changes
+
+- Introduce `AssetPathEntity.assetCountAsync` getter,
+  which improves the speed when loading paths mainly on iOS, also:
+  - Deprecate `AssetPathEntity.assetCount`.
+  - Remove `FilterOptionGroup.containsEmptyAlbum`.
+
 ## 2.1.4
 
-Improvements:
+### Improvements
 
 - [iOS] Check `canPerformEditOperation` before performing change requests. (#782)
 
-Fixes:
+### Fixes
 
 - [Android] Fix `orientation` missing during conversions. (#783)
 
 ## 2.1.3
 
-Improvements:
+### Improvements
 
 - Expose `PhotoManager.plugin`. (#778)
 
-Fixes:
+### Fixes
 
 - Fix `forceOldApi` not well-called. (#778)
 - Fix invalid type cast with `AssetEntity.exists`. (#777)
 
 ## 2.1.2
 
-Improvements:
+### Improvements
 
 - Correct `PermissionRequestOption` typo with a class type alias.
   Which also raised the Dart SDK constraint to `2.13.0`.
@@ -36,24 +45,24 @@ Improvements:
 
 ## 2.1.1
 
-Improvements:
+### Improvements
 
 - Protect cursors convert on Android. (#761)
 - Present exceptions in the image provider when debugging. (#766)
 
-Fixes:
+### Fixes
 
 - Fix `ACCESS_MEDIA_LOCATION` checks on Android. (#765)
 
 ## 2.1.0+2
 
-Improvements:
+### Improvements
 
 - Support Flutter 3.
 
 ## 2.0.9
 
-Improvements:
+### Improvements
 
 - (Not working) Ignore the null-aware operator for
   `PaintingBinding`'s instance in order to solve
@@ -63,37 +72,37 @@ Improvements:
 
 ## 2.0.8
 
-Improvements:
+### Improvements
 
 - Using `ContentResolver` as much as possible on Android. (#755)
 
 ## 2.0.7
 
-Fixes:
+### Fixes
 
 - Fix assets pagination issues on Android 29+. (#748)
 
 ## 2.0.6
 
-Fixes:
+### Fixes
 
 - Fix file caches clearing on iOS. (#743)
 
 ## 2.0.5
 
-Improvements:
+### Improvements
 
 - Improve `AssetEntity.titleAsync`'s implementation on iOS. (#740)
 
 ## 2.0.4
 
-Fixes:
+### Fixes
 
 - Fix invalid `InputStream` when saving images on Android. (#736)
 
 ## 2.0.3
 
-Improvements:
+### Improvements
 
 - Improve `getMediaUrl` on iOS.
 - Read orientation when saving images on Android. (#730)
@@ -101,17 +110,17 @@ Improvements:
 
 ## 2.0.2
 
-Fixes:
+### Fixes
 
 - Ensure file exists before reading EXIF on Android. (#728)
 
 ## 2.0.1
 
-Improvements:
+### Improvements
 
 - Update legacy external storage exception on Android.
 
-Fixes:
+### Fixes
 
 - Predicate more precise permissions requirements on Android <29. (#723)
 
@@ -121,7 +130,7 @@ A major version release for performance improvements, new features, issues fixed
 Also, the LICENSE has been updated with the new author [FlutterCandies](https://github.com/fluttercandies).
 To know more about breaking changes, see the [Migration Guide][].
 
-Features:
+### Features
 
 - Add `mimeTypeAsync`. (#717)
 - Add `ThumbnailSize`. (#709)
@@ -131,7 +140,7 @@ Features:
 - Support to obtain the first frame for the video thumbnail on Android. (#658)
 - Allow plugin to be mocked/overridden with tests. (#703)
 
-Improvements:
+### Improvements
 
 - Improve path modified injection and asset count fetching. (#712)
 - Make all entities immutable. (#708)
@@ -152,7 +161,7 @@ Improvements:
 - Rename org to `com.fluttercandies`. (#624)
 - `ImageScanner` -> `PhotoManager`. (#611)
 
-Fixes:
+### Fixes
 
 - Fix `Activity` leaks when detached on Android. (#716)
 - Fix potential NPE when moving assets on Android.
@@ -163,117 +172,117 @@ Fixes:
 
 ## 1.3.10
 
-Improvements:
+### Improvements
 
 - Allow all kinds of `PHAssetCollection` which should expand the support for shared albums. (#641)
 
 ## 1.3.9+1
 
-Fixes:
+### Fixes
 
 - Fix compile error on Xcode 12 for iOS 14. (#630)
 
 ## 1.3.9
 
-Fixes:
+### Fixes
 
 - Fix `presentLimited` issues on iOS 14 real devices. (#627)
 
 ## 1.3.8
 
-Improvements:
+### Improvements
 
 - Improve sort orders on all platforms. (#623)
 
 ## 1.3.7
 
-Improvements:
+### Improvements
 
 - Improve sort orders on iOS. (#620)
 
 ## 1.3.6
 
-Improvements:
+### Improvements
 
 - Prettify file name on iOS. (#615)
 
 ## 1.3.5
 
-Improvements:
+### Improvements
 
 - Support `presentLimited` with the new API on iOS 15. (#609)
 
 ## 1.3.4
 
-Improvements:
+### Improvements
 
 - Obtain more albums on iOS/macOS. (#601)
 
 ## 1.3.3
 
-Improvements:
+### Improvements
 
 - Loosen comparison between `AssetEntity`s.
 
 ## 1.3.2
 
-Improvements:
+### Improvements
 
 - Apply more fields to compare between entities.
 
 ## 1.3.1
 
-Fixes:
+### Fixes
 
 - `fetchPathProperties` returned wrong `isAll` on iOS. (#580)
 - `updateTimeCond` not constructed correctly with `FilterOptionGroup`.
 
 ## 1.3.0
 
-Improvements:
+### Improvements
 
 - Repo cleanup.
 
-Fixes:
+### Fixes
 
 - Removed recursive calls with progress handler. (#577)
 
 We're bumping the minor version because we've achieved recent goals
-and applied multiple Fixes: which make this plugin as the most solid ever.
+and applied multiple ### Fixes which make this plugin as the most solid ever.
 
 ## 1.2.9
 
-Features:
+### Features
 
 - Add orientated getters. (#575)
 
 ## 1.2.8
 
-Fixes:
+### Fixes
 
 - Saving methods return null. (#573)
 
 ## 1.2.7
 
-Improvements:
+### Improvements
 
 - Improve `AssetEntity.getMediaUrl()` behaviors.
 
-Fixes:
+### Fixes
 
 - Merge all fields for `FilterOptionGroup`.
 - Make `AssetEntity.isLocallyAvailable` as a `Future` getter.
 
 ## 1.2.6+1
 
-Fixes:
+### Fixes
 
 - Apply further fix to #559 .
 - Repo cleanup.
 
 ## 1.2.6
 
-Fixes:
+### Fixes
 
 - #558
 - #559
@@ -281,50 +290,50 @@ Fixes:
 
 ## 1.2.5
 
-Fixes:
+### Fixes
 
 - Fix `open` setting for macOS.
 - Fix `setLog` for iOS and macOS.
 
 ## 1.2.4
 
-Fixes:
+### Fixes
 
 - `saveImage` method missing file extension for the fallback title.
 - `openSettings` method.
 
 ## 1.2.3
 
-Fixes:
-
-- Change notify issue on remove callback.
-- Reply result for `presentLimited` method.
-
-Feature:
+### Features
 
 - Add assets count change when notify on iOS.
 - Add some properties and methods for change notify.
 
+### Fixes
+
+- Change notify issue on remove callback.
+- Reply result for `presentLimited` method.
+
 ## 1.2.2
 
-Fixes:
+### Fixes
 
 - Add request permissions result listener when activity re-attached. (#515)
 
 ## 1.2.1
 
-Fixes:
+### Fixes
 
 - An error of iOS. See #509 and #510 .
 
 ## 1.2.0
 
-Feature:
+### Features
 
-- Add requestPermissionExtend code to support iOS 14 permission.
+- Add `requestPermissionExtend` code to support iOS 14 permission.
 - Add update limited photos method for iOS 14.
 
-Fixes:
+### Fixes
 
 - Permissions dialog of launch on old iOS versions. (#503)
 
@@ -351,18 +360,18 @@ Fixes:
 
 ## 1.1.1
 
-Fixes:
+### Fixes
 
 - `thumbWithSize` of `AssetEntity`.
 
 ## 1.1.0
 
-Feature:
+### Features
 
 - `modified` of `AssetPathEntity`.
 - Update constructor of `FilterOptionGroup`.
 
-Fixes:
+### Fixes
 
 - Order option of the `FilterOptionGroup`.
 
@@ -389,14 +398,18 @@ Fixes:
 
 ## 1.0.0
 
-Breaking changes:
+### Breaking changes
 
 - Migrate to null safety.
 - Correct type in `PMRequestState` .
 
 ## 0.6.0
 
-Feature
+### Breaking changes
+
+- Support multiple sorting conditions, and the `asc` of `DateTimeCond` is removed.
+
+### Features
 
 - Support android API 30.
 - Support show empty album in iOS (#365).
@@ -408,26 +421,22 @@ Feature
 - Add `OrderOption` as sort condition. The option default value is order by create date desc;
 - Support icloud asset progress.
 
-Fixes:
+### Fixes
 
 - #362
 - Delete assets in androidQ.
 - Edited image data in iOS.
 - Fix delete error in androidR.
 
-Breaking change:
-
-- Support multiple sorting conditions, and the `asc` of `DateTimeCond` is removed.
-
 ## 0.5.8
 
-Fixes:
+### Fixes
 
 - Delete assets in androidQ.
 
 ## 0.5.7
 
-Fixes:
+### Fixes
 
 - Audio asset error for androidQ. See #340 and #341 .
 
@@ -453,7 +462,7 @@ Fixes:
 
 ## 0.5.3
 
-Fixes:
+### Fixes
 
 - Cannot get audio problem in androidQ.
 
@@ -464,7 +473,7 @@ Fixes:
 
 ## 0.5.1
 
-Feature:
+### Features
 
 - Save image asset with file path.
 - Copy asset to another album.
@@ -480,15 +489,7 @@ Feature:
     - Remove all non-existing rows.
     - add `relativePath` for android.
 
-Fixes:
-
-- Problem of AssetPathEntity.refreshPathProperties.
-- Open setting in iOS.
-- Edited asset in iOS.
-- Audio properties of FilterOption.
-- Android onlyAll assetCount bug.
-
-Change:
+### Improvements
 
 - Modified `AssetEntity.file`'s behavior on iOS,
   it will return a picture in jpg format instead of heic/gif/png currently.
@@ -497,29 +498,39 @@ Change:
 - Update android change media url from file scheme to content scheme.
 - Clean up some unused code.
 
+### Fixes
+
+- Problem of AssetPathEntity.refreshPathProperties.
+- Open setting in iOS.
+- Edited asset in iOS.
+- Audio properties of FilterOption.
+- Android onlyAll assetCount bug.
+
 ## 0.5.0
 
-Feature:
+### Breaking changes
+- Add date condition to filter datetime
+- Add class `DateTimeCond`
+- Add `dateTimeCond` to `FilterOptionGroup`
+- Remove `fetchDateTime` from `getAssetPathList`
+- Remove param `dt` from `AssetPathEntity.refreshPathProperties`,
+  and add `refreshPathProperties` params to the method.
+- Split video filter and image filter.
+
+### Features
 
 - Add `getSubPathEntities` for `AssetPathEntity`.
 - Add `quality` for `AssetEntity.thumbDataWithSize`.
 - Add `orientation` for `AssetEntity`.
 - Add `onlyAll` for `getAssetPathList`.
 - Support audio type(Only android, iOS Photos have no audio)
-- **Breaking change**, Add date condition to filter datetime
-    - Add class `DateTimeCond`
-    - Add `dateTimeCond` to `FilterOptionGroup`
-    - Remove `fetchDateTime` from `getAssetPathList`
-    - Remove param `dt` from `AssetPathEntity.refreshPathProperties`, and add `refreshPathProperties` params to the
-      method.
 
-Update:
+### Improvements
 
-- **Breaking change**, Split video filter and image filter
 - iOS code is running background thread.
 - getThumb is running in background thread.
 
-Fixes:
+### Fixes
 
 - exists error on android.
 - use edited origin file on iOS.
@@ -528,24 +539,24 @@ Fixes:
 
 ## 0.4.8
 
-Fixes:
+### Fixes
 
 - #169
 - #170
 
 ## 0.4.7
 
-New feature:
+### Features
 
 - Add `FilterOption` for method `getAssetPathList`.
 
 ## 0.4.6
 
-Fixes:
+### Fixes
 
 - originFile of `AssetEntity`
 
-Add:
+### Features
 
 - location(`latitude`,`longitude`) of `AssetEntity`
 - `title` of `AssetEntity`
@@ -554,20 +565,20 @@ Add:
 
 ## 0.4.5
 
-Fixes:
+### Fixes
 
 - Can't get thumb/file of video on androidQ.
 
 ## 0.4.4
 
-Fixes:
+### Fixes
 
 - Compatibility code, when the width and height of the video is empty, it can still be scanned.
 - Add a default value to `type` of `getAssetPathList`.
 
 ## 0.4.3
 
-Add:
+### Features
 
 - Delete asset.
 - Add Image.
@@ -575,7 +586,7 @@ Add:
 - Add modifyDate property.
 - Fix videoDuration error.
 
-Fixes:
+### Fixes
 
 - CreateDate error.
 
@@ -589,13 +600,13 @@ Fixes:
 
 ## 0.4.0
 
-Breaking change.
+### Breaking changes
 
 - Some properties in the entity were modified from asynchronous to synchronous.
 - Remove `isCache` params. Now, `getAssetPathList` will reload info everytime.
   If user want to cache `List<AssetPathEntity>`, then user must do it manually.
 
-Added:
+### Features
 
 - Added a method `getAssetListPaged` for paging loading resources to path.
   The paging implementation is lazy loading, that is, the resource corresponding information is loaded when requested.
@@ -625,15 +636,23 @@ Added:
 
 ## 0.3.0
 
+### Breaking changes
+
 - Support Android X.
-- **Breaking change**: Migrate from the deprecated original Android Support Library to AndroidX.
   This shouldn't result in any functional changes,
-  but it requires any Android apps using this plugin to also migrate if they're using the original support library.
-- Fix NPE for image crash on android.
+  but it requires any Android apps using this plugin to also migrate
+  if they're using the original support library.
+
+### Features
+
 - Add a method to create `AssetEntity` with id.
 - Add `isCache` for method `getImageAsset`,`getVideoAsset` or `getAssetPathList`.
 - Add observer for photo change.
 - Add field `createTime` for `AssetEntity`.
+
+### Fixes
+
+- Fix NPE for image crash on android.
 
 ## 0.2.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
-## 2.2.0
+## 2.2.0-dev.1
 
 ### Breaking changes
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -86,7 +86,7 @@ class _SimpleExamplePageState extends State<_SimpleExamplePage> {
     setState(() {
       _path = paths.first;
     });
-    _totalEntitiesCount = _path!.assetCount;
+    _totalEntitiesCount = await _path!.assetCountAsync;
     final List<AssetEntity> entities = await _path!.getAssetListPaged(
       page: 0,
       size: _sizePerPage,

--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -1,5 +1,4 @@
 import 'package:flutter/foundation.dart';
-import 'package:oktoast/oktoast.dart';
 import 'package:photo_manager/photo_manager.dart';
 
 import '../main.dart';
@@ -201,11 +200,6 @@ class PhotoProvider extends ChangeNotifier {
       ),
       prefix: 'Obtain path list duration',
     );
-
-    galleryList.sort((AssetPathEntity s1, AssetPathEntity s2) {
-      return s2.assetCount.compareTo(s1.assetCount);
-    });
-
     list.clear();
     list.addAll(galleryList);
   }
@@ -282,9 +276,12 @@ class AssetPathProvider extends ChangeNotifier {
   List<AssetEntity> list = <AssetEntity>[];
   int page = 0;
 
+  int get assetCount => _assetCount!;
+  int? _assetCount;
+
   int get showItemCount {
-    if (list.length == path.assetCount) {
-      return path.assetCount;
+    if (_assetCount != null && list.length == _assetCount) {
+      return assetCount;
     }
     return list.length + 1;
   }
@@ -295,9 +292,9 @@ class AssetPathProvider extends ChangeNotifier {
     if (refreshing) {
       return;
     }
-
     refreshing = true;
     path = await path.obtainForNewProperties(maxDateTimeToNow: false);
+    _assetCount = await path.assetCountAsync;
     final List<AssetEntity> list = await elapsedFuture(
       path.getAssetListPaged(page: 0, size: loadCount),
       prefix: 'Refresh assets list from path ${path.id}',
@@ -316,7 +313,7 @@ class AssetPathProvider extends ChangeNotifier {
     if (refreshing) {
       return;
     }
-    if (showItemCount > path.assetCount) {
+    if (showItemCount > assetCount) {
       Log.d('already max');
       return;
     }
@@ -351,7 +348,6 @@ class AssetPathProvider extends ChangeNotifier {
     final List<String> ids = entity.map((AssetEntity e) => e.id).toList();
     await PhotoManager.editor.deleteWithIds(ids);
     path = await path.obtainForNewProperties();
-    showToast('The path ${path.name} asset count have :${path.assetCount}');
     notifyListeners();
   }
 

--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -28,15 +28,6 @@ class PhotoProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  bool _containsEmptyAlbum = false;
-
-  bool get containsEmptyAlbum => _containsEmptyAlbum;
-
-  set containsEmptyAlbum(bool containsEmptyAlbum) {
-    _containsEmptyAlbum = containsEmptyAlbum;
-    notifyListeners();
-  }
-
   bool _containsPathModified = false;
 
   bool get containsPathModified => _containsPathModified;
@@ -168,14 +159,6 @@ class PhotoProvider extends ChangeNotifier {
     notifyListeners();
   }
 
-  void changeContainsEmptyAlbum(bool? value) {
-    if (value == null) {
-      return;
-    }
-    containsEmptyAlbum = value;
-    notifyListeners();
-  }
-
   void changeContainsPathModified(bool? value) {
     if (value == null) {
       return;
@@ -230,7 +213,6 @@ class PhotoProvider extends ChangeNotifier {
       ..setOption(AssetType.image, option)
       ..setOption(AssetType.audio, option)
       ..createTimeCond = createDtCond
-      ..containsEmptyAlbum = _containsEmptyAlbum
       ..containsPathModified = _containsPathModified
       ..containsLivePhotos = _containsLivePhotos
       ..onlyLivePhotos = onlyLivePhotos;

--- a/example/lib/page/developer/dev_title_page.dart
+++ b/example/lib/page/developer/dev_title_page.dart
@@ -29,7 +29,7 @@ class _DevelopingExampleState extends State<DevelopingExample> {
             );
             for (final AssetPathEntity path in list) {
               imageList.addAll(
-                await path.getAssetListRange(start: 0, end: path.assetCount),
+                await path.getAssetListRange(start: 0, end: 1),
               );
             }
             if (imageList.isNotEmpty) {

--- a/example/lib/page/developer/issues_page/issue_734.dart
+++ b/example/lib/page/developer/issues_page/issue_734.dart
@@ -49,10 +49,10 @@ class _Issue734PageState extends State<Issue734Page>
     }
 
     final AssetPathEntity recent = pathList[0];
+    final int assetCount = await recent.assetCountAsync;
+    Log.d('recent.assetCount: $assetCount');
 
-    Log.d('recent.assetCount: ${recent.assetCount}');
-
-    for (int i = 0; i < recent.assetCount; i++) {
+    for (int i = 0; i < assetCount; i++) {
       final List<AssetEntity> pageAssetList = await recent.getAssetListPaged(
         page: i,
         size: 1,

--- a/example/lib/page/home_page.dart
+++ b/example/lib/page/home_page.dart
@@ -57,7 +57,6 @@ class _NewHomePageState extends State<NewHomePage> {
             _buildOnlyAllCheck(),
             _buildContainsLivePhotos(),
             _buildOnlyLivePhotos(),
-            _buildContainsEmptyCheck(),
             _buildPathContainsModifiedDateCheck(),
             _buildPngCheck(),
             _buildNotifyCheck(),
@@ -182,19 +181,6 @@ class _NewHomePageState extends State<NewHomePage> {
         }
       },
       title: const Text('Only Live Photos'),
-    );
-  }
-
-  Widget _buildContainsEmptyCheck() {
-    if (!Platform.isIOS) {
-      return Container();
-    }
-    return CheckboxListTile(
-      value: watchProvider.containsEmptyAlbum,
-      onChanged: (bool? value) {
-        readProvider.changeContainsEmptyAlbum(value);
-      },
-      title: const Text('contains empty album(only iOS)'),
     );
   }
 

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -44,7 +44,7 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
   void initState() {
     super.initState();
     path
-        .getAssetListRange(start: 0, end: path.assetCount)
+        .getAssetListRange(start: 0, end: 1)
         .then((List<AssetEntity> value) {
       if (value.isEmpty) {
         return;
@@ -76,12 +76,12 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
       create: (_) => AssetPathProvider(widget.path),
       builder: (BuildContext context, _) => Scaffold(
         appBar: AppBar(title: Text(path.name)),
-        body: buildRefreshIndicator(context, path.assetCount),
+        body: buildRefreshIndicator(context),
       ),
     );
   }
 
-  Widget buildRefreshIndicator(BuildContext context, int length) {
+  Widget buildRefreshIndicator(BuildContext context) {
     return RefreshIndicator(
       onRefresh: () => _onRefresh(context),
       child: Scrollbar(

--- a/example/lib/widget/gallery_item_widget.dart
+++ b/example/lib/widget/gallery_item_widget.dart
@@ -23,19 +23,26 @@ class GalleryItemWidget extends StatelessWidget {
     return GestureDetector(
       child: ListTile(
         title: Text(item.name),
-        subtitle: Text('count : ${item.assetCount}'),
+        subtitle: FutureBuilder<int>(
+          future: item.assetCountAsync,
+          builder: (_, AsyncSnapshot<int> data) {
+            if (data.hasData) {
+              return Text('count : ${data.data}');
+            }
+            return const SizedBox.shrink();
+          },
+        ),
         trailing: _buildSubButton(item),
       ),
-      onTap: () {
-        if (item.assetCount == 0) {
-          showToast('The asset count is 0.');
-          return;
-        }
+      onTap: () async {
         if (item.albumType == 2) {
           showToast("The folder can't get asset");
           return;
         }
-
+        if (await item.assetCountAsync == 0) {
+          showToast('The asset count is 0.');
+          return;
+        }
         Navigator.of(context).push<void>(
           MaterialPageRoute<void>(
             builder: (_) => GalleryContentListPage(

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager_example
 description: Demonstrates how to use the photo_manager plugin.
-version: 2.1.4+11
+version: 2.2.0+12
 publish_to: none
 
 environment:

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -243,6 +243,15 @@
                                                    option:option];
             NSDictionary *dictionary = [PMConvertUtils convertPathToMap:array];
             [handler reply:dictionary];
+        } else if ([call.method isEqualToString:@"getAssetCountFromPath"]) {
+            NSString *id = call.arguments[@"id"];
+            int requestType = [call.arguments[@"type"] intValue];
+            PMFilterOptionGroup *option =
+            [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
+            NSUInteger result = [manager getAssetCountFromPath:id
+                                                          type:requestType
+                                                  filterOption:option];
+            [handler reply:@(result)];
         } else if ([call.method isEqualToString:@"getAssetListPaged"]) {
             NSString *id = call.arguments[@"id"];
             int type = [call.arguments[@"type"] intValue];

--- a/ios/Classes/core/PHAsset+PM_COMMON.m
+++ b/ios/Classes/core/PHAsset+PM_COMMON.m
@@ -101,11 +101,6 @@
             return [self getLivePhotosResource].originalFilename;
         }
     }
-    if (@available(macOS 10.11, *)) {
-        if ([self isLivePhoto] && subtype == PHAssetMediaSubtypePhotoLive) {
-            return [self getLivePhotosResource].originalFilename;
-        }
-    }
     PHAssetResource *resource = [self getAdjustResource];
     if (resource) {
         return resource.originalFilename;

--- a/ios/Classes/core/PHAssetCollection+PM_COMMON.m
+++ b/ios/Classes/core/PHAssetCollection+PM_COMMON.m
@@ -10,8 +10,7 @@
 @implementation PHAssetCollection (PM_COMMON)
 
 - (NSUInteger)obtainAssetCount:(PHFetchOptions *)options {
-    PHFetchResult<PHAsset *> *fetchResult =
-    [PHAsset fetchAssetsInAssetCollection:self options:options];
+    PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:self options:options];
     NSUInteger count = fetchResult.count;
     return count;
 }

--- a/ios/Classes/core/PMAssetPathEntity.h
+++ b/ios/Classes/core/PMAssetPathEntity.h
@@ -8,14 +8,13 @@
 
 @property(nonatomic, copy) NSString *id;
 @property(nonatomic, copy) NSString *name;
-@property(nonatomic, assign) NSUInteger assetCount;
 @property(nonatomic, assign) BOOL isAll;
 @property(nonatomic, assign) int type;
 @property(nonatomic, assign) long modifiedDate;
 
-- (instancetype)initWithId:(NSString *)id name:(NSString *)name assetCount:(NSUInteger)assetCount;
+- (instancetype)initWithId:(NSString *)id name:(NSString *)name;
 
-+ (instancetype)entityWithId:(NSString *)id name:(NSString *)name assetCount:(NSUInteger)assetCount;
++ (instancetype)entityWithId:(NSString *)id name:(NSString *)name;
 
 @end
 

--- a/ios/Classes/core/PMAssetPathEntity.m
+++ b/ios/Classes/core/PMAssetPathEntity.m
@@ -1,14 +1,11 @@
 #import <Photos/Photos.h>
 #import "PMAssetPathEntity.h"
 
-@implementation PMAssetPathEntity {
-    
-}
+@implementation PMAssetPathEntity {}
 
 - (instancetype)init {
     self = [super init];
     if (self) {
-        self.assetCount = 0;
         self.type = PM_TYPE_ALBUM;
     }
     
@@ -16,28 +13,26 @@
 }
 
 
-- (instancetype)initWithId:(NSString *)id name:(NSString *)name assetCount:(NSUInteger)assetCount {
+- (instancetype)initWithId:(NSString *)id name:(NSString *)name {
     self = [super init];
     if (self) {
         self.id = id;
         self.name = name;
-        self.assetCount = assetCount;
         self.type = PM_TYPE_ALBUM;
     }
     
     return self;
 }
 
-+ (instancetype)entityWithId:(NSString *)id name:(NSString *)name assetCount:(NSUInteger)assetCount {
-    return [[self alloc] initWithId:id name:name assetCount:assetCount];
++ (instancetype)entityWithId:(NSString *)id name:(NSString *)name {
+    return [[self alloc] initWithId:id name:name];
 }
 
 @end
 
 
-@implementation PMAssetEntity {
-    
-}
+@implementation PMAssetEntity {}
+
 - (instancetype)initWithId:(NSString *)id createDt:(long)createDt width:(NSUInteger)width height:(NSUInteger)height
 duration:(long)duration type:(int)type {
     self = [super init];

--- a/ios/Classes/core/PMConvertUtils.m
+++ b/ios/Classes/core/PMConvertUtils.m
@@ -13,7 +13,6 @@
         NSDictionary *item = @{
             @"id": entity.id,
             @"name": entity.name,
-            @"length": @(entity.assetCount),
             @"isAll": @(entity.isAll),
             @"albumType": @(entity.type),
         };
@@ -115,7 +114,6 @@
     container.audioOption = [self convertMapToPMFilterOption:audio];
     container.dateOption = [self convertMapToPMDateOption:map[@"createDate"]];
     container.updateOption = [self convertMapToPMDateOption:map[@"updateDate"]];
-    container.containsEmptyAlbum = [map[@"containsEmptyAlbum"] boolValue];
     container.containsModified = [map[@"containsPathModified"] boolValue];
     container.containsLivePhotos = [map[@"containsLivePhotos"] boolValue];
     container.onlyLivePhotos = [map[@"onlyLivePhotos"] boolValue];

--- a/ios/Classes/core/PMFilterOption.h
+++ b/ios/Classes/core/PMFilterOption.h
@@ -55,7 +55,6 @@ typedef struct PMDurationConstraint {
 @property(nonatomic, strong) PMDateOption *updateOption;
 @property(nonatomic, assign) BOOL containsLivePhotos;
 @property(nonatomic, assign) BOOL onlyLivePhotos;
-@property(nonatomic, assign) BOOL containsEmptyAlbum;
 @property(nonatomic, assign) BOOL containsModified;
 @property(nonatomic, strong) NSArray<NSSortDescriptor*> *sortArray;
 

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -35,6 +35,8 @@ typedef void (^AssetResult)(PMAssetEntity *);
 
 - (NSArray<PMAssetPathEntity *> *)getAssetPathList:(int)type hasAll:(BOOL)hasAll onlyAll:(BOOL)onlyAll option:(PMFilterOptionGroup *)option;
 
+- (NSUInteger)getAssetCountFromPath:(NSString *)id type:(int)type filterOption:(PMFilterOptionGroup *)filterOption;
+
 - (NSArray<PMAssetEntity *> *)getAssetListPaged:(NSString *)id type:(int)type page:(NSUInteger)page size:(NSUInteger)size filterOption:(PMFilterOptionGroup *)filterOption;
 
 - (NSArray<PMAssetEntity *> *)getAssetListRange:(NSString *)id type:(int)type start:(NSUInteger)start end:(NSUInteger)end filterOption:(PMFilterOptionGroup *)filterOption;

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -60,11 +60,9 @@
         if (smartAlbumResult && smartAlbumResult.count) {
             for (PHAssetCollection *collection in smartAlbumResult) {
                 if (collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary) {
-                    NSUInteger count = [collection obtainAssetCount:assetOptions];
                     PMAssetPathEntity *pathEntity = [PMAssetPathEntity
                                                      entityWithId:collection.localIdentifier
-                                                     name:collection.localizedTitle
-                                                     assetCount:count];
+                                                     name:collection.localizedTitle];
                     pathEntity.isAll = YES;
                     [array addObject:pathEntity];
                     break;
@@ -78,8 +76,7 @@
                             result:smartAlbumResult
                            options:assetOptions
                             hasAll:hasAll
-                  containsModified:option.containsModified
-                containsEmptyAlbum:option.containsEmptyAlbum];
+                  containsModified:option.containsModified];
     
     PHFetchResult<PHAssetCollection *> *albumResult = [PHAssetCollection
                                                        fetchAssetCollectionsWithType:PHAssetCollectionTypeAlbum
@@ -90,8 +87,7 @@
                             result:albumResult
                            options:assetOptions
                             hasAll:hasAll
-                  containsModified:option.containsModified
-                containsEmptyAlbum:option.containsEmptyAlbum];
+                  containsModified:option.containsModified];
     
     return array;
 }
@@ -160,8 +156,7 @@
                           result:(PHFetchResult *)result
                          options:(PHFetchOptions *)options
                           hasAll:(BOOL)hasAll
-                containsModified:(BOOL)containsModified
-              containsEmptyAlbum:(BOOL)containsEmptyAlbum {
+                containsModified:(BOOL)containsModified {
     for (id collection in result) {
         if (![collection isKindOfClass:[PHAssetCollection class]]) {
             continue;
@@ -182,27 +177,21 @@
             continue;
         }
         
-        PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:options];
-        NSUInteger assetCount = fetchResult.count;
-        
-        PMAssetPathEntity *entity = [PMAssetPathEntity entityWithId:localIdentifier name:localizedTitle assetCount:assetCount];
-        
+        PMAssetPathEntity *entity = [PMAssetPathEntity entityWithId:localIdentifier name:localizedTitle];
         entity.isAll = assetCollection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary;
         
-        if (containsModified && fetchResult.count > 0) {
-            PHAsset *asset = fetchResult.firstObject;
-            entity.modifiedDate = (long) asset.modificationDate.timeIntervalSince1970;
+        if (containsModified) {
+            PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:assetCollection options:options];
+            if (fetchResult.count > 0) {
+                PHAsset *asset = fetchResult.firstObject;
+                entity.modifiedDate = (long) asset.modificationDate.timeIntervalSince1970;
+            }
         }
         
         if (!hasAll && entity.isAll) {
             continue;
         }
-        
-        if (entity.assetCount && entity.assetCount > 0) {
-            [array addObject:entity];
-        } else if (containsEmptyAlbum && assetCollection.assetCollectionType == PHAssetCollectionTypeAlbum) {
-            [array addObject:entity];
-        }
+        [array addObject:entity];
     }
 }
 
@@ -813,12 +802,8 @@
     if (!localIdentifier || localIdentifier.isEmpty || !localizedTitle || localizedTitle.isEmpty) {
         return nil;
     }
-    
-    PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
-    NSUInteger count = [collection obtainAssetCount:assetOptions];
     PMAssetPathEntity *entity = [PMAssetPathEntity entityWithId:localIdentifier
-                                                           name:localizedTitle
-                                                     assetCount:count];
+                                                           name:localizedTitle];
     entity.isAll = collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary;
     return entity;
 }
@@ -1178,12 +1163,8 @@
     pathEntity.isAll = NO;
     pathEntity.name = phCollection.localizedTitle;
     if ([phCollection isMemberOfClass:PHAssetCollection.class]) {
-        PHAssetCollection *collection = (PHAssetCollection *) phCollection;
-        PHFetchResult<PHAsset *> *fetchResult = [PHAsset fetchAssetsInAssetCollection:collection options:option];
-        pathEntity.assetCount = fetchResult.count;
         pathEntity.type = PM_TYPE_ALBUM;
     } else {
-        pathEntity.assetCount = 0;
         pathEntity.type = PM_TYPE_FOLDER;
     }
     
@@ -1470,25 +1451,25 @@
     NSString *imagePath = [self getCachePath:PM_IMAGE_CACHE_PATH];
     NSString *videoPath = [self getCachePath:PM_VIDEO_CACHE_PATH];
     NSString *fullFilePath = [self getCachePath:PM_FULL_IMAGE_CACHE_PATH];
-
+    
     NSError *err;
     [PMFileHelper deleteFile:imagePath isDirectory:YES error:err];
     if (err) {
         [PMLogUtils.sharedInstance
-            info:[NSString stringWithFormat:@"Remove .image cache %@, error: %@", imagePath, err]];
+         info:[NSString stringWithFormat:@"Remove .image cache %@, error: %@", imagePath, err]];
     }
     [PMFileHelper deleteFile:videoPath isDirectory:YES error:err];
     if (err) {
         [PMLogUtils.sharedInstance
-            info:[NSString stringWithFormat:@"Remove .video cache %@, error: %@", videoPath, err]];
+         info:[NSString stringWithFormat:@"Remove .video cache %@, error: %@", videoPath, err]];
     }
-
+    
     [PMFileHelper deleteFile:fullFilePath isDirectory:YES error:err];
     if (err) {
         [PMLogUtils.sharedInstance
-            info:[NSString stringWithFormat:@"Remove .full file cache %@, error: %@", fullFilePath, err]];
+         info:[NSString stringWithFormat:@"Remove .full file cache %@, error: %@", fullFilePath, err]];
     }
-
+    
 }
 
 #pragma mark cache thumb

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -96,6 +96,21 @@
     return array;
 }
 
+- (NSUInteger)getAssetCountFromPath:(NSString *)id type:(int)type filterOption:(PMFilterOptionGroup *)filterOption {
+    PHFetchOptions *assetOptions = [self getAssetOptions:type filterOption:filterOption];
+    PHFetchOptions *fetchCollectionOptions = [PHFetchOptions new];
+    PHFetchResult<PHAssetCollection *> *result = [PHAssetCollection
+                                                  fetchAssetCollectionsWithLocalIdentifiers:@[id]
+                                                  options:fetchCollectionOptions];
+    
+    if (result == nil || result.count == 0) {
+        return 0;
+    }
+    PHAssetCollection *collection = result[0];
+    NSUInteger count = [collection obtainAssetCount:assetOptions];
+    return count;
+}
+
 - (void)logCollections:(PHFetchResult *)collections option:(PHFetchOptions *)option {
     if(!PMLogUtils.sharedInstance.isLog){
         return;

--- a/lib/src/filter/filter_option_group.dart
+++ b/lib/src/filter/filter_option_group.dart
@@ -14,7 +14,6 @@ class FilterOptionGroup {
     FilterOption imageOption = const FilterOption(),
     FilterOption videoOption = const FilterOption(),
     FilterOption audioOption = const FilterOption(),
-    this.containsEmptyAlbum = false,
     this.containsPathModified = false,
     this.containsLivePhotos = true,
     this.onlyLivePhotos = false,
@@ -42,9 +41,6 @@ class FilterOptionGroup {
   void setOption(AssetType type, FilterOption option) {
     _map[type] = option;
   }
-
-  /// Whether to obtain empty albums.
-  bool containsEmptyAlbum = false;
 
   /// Whether the [AssetPathEntity]s will return with modified time.
   ///
@@ -77,7 +73,6 @@ class FilterOptionGroup {
     for (final AssetType type in _map.keys) {
       _map[type] = _map[type]!.merge(other.getOption(type));
     }
-    containsEmptyAlbum = other.containsEmptyAlbum;
     containsPathModified = other.containsPathModified;
     containsLivePhotos = other.containsLivePhotos;
     onlyLivePhotos = other.onlyLivePhotos;
@@ -96,7 +91,6 @@ class FilterOptionGroup {
         'video': getOption(AssetType.video).toMap(),
       if (_map.containsKey(AssetType.audio))
         'audio': getOption(AssetType.audio).toMap(),
-      'containsEmptyAlbum': containsEmptyAlbum,
       'containsPathModified': containsPathModified,
       'containsLivePhotos': containsLivePhotos,
       'onlyLivePhotos': onlyLivePhotos,
@@ -110,7 +104,6 @@ class FilterOptionGroup {
     FilterOption? imageOption,
     FilterOption? videoOption,
     FilterOption? audioOption,
-    bool? containsEmptyAlbum,
     bool? containsPathModified,
     bool? containsLivePhotos,
     bool? onlyLivePhotos,
@@ -121,7 +114,6 @@ class FilterOptionGroup {
     imageOption ??= _map[AssetType.image];
     videoOption ??= _map[AssetType.video];
     audioOption ??= _map[AssetType.audio];
-    containsEmptyAlbum ??= this.containsEmptyAlbum;
     containsPathModified ??= this.containsPathModified;
     containsLivePhotos ??= this.containsLivePhotos;
     onlyLivePhotos ??= this.onlyLivePhotos;
@@ -133,7 +125,6 @@ class FilterOptionGroup {
       ..setOption(AssetType.image, imageOption!)
       ..setOption(AssetType.video, videoOption!)
       ..setOption(AssetType.audio, audioOption!)
-      ..containsEmptyAlbum = containsEmptyAlbum
       ..containsPathModified = containsPathModified
       ..containsLivePhotos = containsLivePhotos
       ..onlyLivePhotos = onlyLivePhotos

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -16,6 +16,7 @@ class PMConstants {
   static const String mFetchEntityProperties = 'fetchEntityProperties';
   static const String mFetchPathProperties = 'fetchPathProperties';
   static const String mGetAssetPathList = 'getAssetPathList';
+  static const String mGetAssetCountFromPath = 'getAssetCountFromPath';
   static const String mGetAssetListPaged = 'getAssetListPaged';
   static const String mGetAssetListRange = 'getAssetListRange';
   static const String mGetThumb = 'getThumb';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -76,6 +76,24 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin {
     return PermissionState.values[result];
   }
 
+  Future<int> getAssetCountFromPath(AssetPathEntity path) async {
+    // Use `assetCount` for Android until we break the API
+    // and migrate to `InternalAssetPathEntity`.
+    if (Platform.isAndroid) {
+      // ignore: deprecated_member_use_from_same_package
+      return path.assetCount;
+    }
+    final int result = await _channel.invokeMethod<int>(
+      PMConstants.mGetAssetCountFromPath,
+      <String, dynamic>{
+        'id': path.id,
+        'type': path.type.value,
+        'option': path.filterOption.toMap(),
+      },
+    ) as int;
+    return result;
+  }
+
   /// Use pagination to get album content.
   Future<List<AssetEntity>> getAssetListPaged(
     String id, {

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -72,6 +72,9 @@ class AssetPathEntity {
   @Deprecated('Use assetCountAsync instead. This will be removed in 3.0.0.')
   final int assetCount;
 
+  /// Total assets count of the path with the asynchronized getter.
+  Future<int> get assetCountAsync => plugin.getAssetCountFromPath(this);
+
   /// The type of the album.
   ///  * Android: Always be 1.
   ///  * iOS: 1 - Album, 2 - Folder.
@@ -195,8 +198,9 @@ class AssetPathEntity {
       'Filtering only Live Photos is only supported '
       'when the request type contains image.',
     );
-    if (end > assetCount) {
-      end = assetCount;
+    final int count = await assetCountAsync;
+    if (end > count) {
+      end = count;
     }
     return plugin.getAssetListRange(
       id,
@@ -244,7 +248,6 @@ class AssetPathEntity {
   AssetPathEntity copyWith({
     String? id,
     String? name,
-    int? assetCount,
     int? albumType = 1,
     DateTime? lastModified,
     RequestType? type,
@@ -254,7 +257,6 @@ class AssetPathEntity {
     return AssetPathEntity(
       id: id ?? this.id,
       name: name ?? this.name,
-      assetCount: assetCount ?? this.assetCount,
       albumType: albumType ?? this.albumType,
       lastModified: lastModified ?? this.lastModified,
       type: type ?? this.type,
@@ -270,7 +272,6 @@ class AssetPathEntity {
     }
     return id == other.id &&
         name == other.name &&
-        assetCount == other.assetCount &&
         albumType == other.albumType &&
         type == other.type &&
         lastModified == other.lastModified &&
@@ -279,11 +280,11 @@ class AssetPathEntity {
 
   @override
   int get hashCode =>
-      hashValues(id, name, assetCount, albumType, type, lastModified, isAll);
+      hashValues(id, name, albumType, type, lastModified, isAll);
 
   @override
   String toString() {
-    return 'AssetPathEntity(id: $id, name: $name, assetCount: $assetCount)';
+    return 'AssetPathEntity(id: $id, name: $name)';
   }
 }
 

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -69,7 +69,10 @@ class AssetPathEntity {
   ///
   /// The synchronized count will cause performance regression on iOS,
   /// here the asynchronized getter [assetCountAsync] is perferred.
-  @Deprecated('Use assetCountAsync instead. This will be removed in 3.0.0.')
+  @Deprecated(
+    'Always 0. Use assetCountAsync instead. '
+    'This will be removed in 3.0.0.',
+  )
   final int assetCount;
 
   /// Total assets count of the path with the asynchronized getter.

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -26,6 +26,7 @@ class AssetPathEntity {
   AssetPathEntity({
     required this.id,
     required this.name,
+    @Deprecated('Use assetCountAsync instead. This will be removed in 3.0.0.')
     this.assetCount = 0,
     this.albumType = 1,
     this.lastModified,
@@ -65,6 +66,10 @@ class AssetPathEntity {
   final String name;
 
   /// Total assets count of the album.
+  ///
+  /// The synchronized count will cause performance regression on iOS,
+  /// here the asynchronized getter [assetCountAsync] is perferred.
+  @Deprecated('Use assetCountAsync instead. This will be removed in 3.0.0.')
   final int assetCount;
 
   /// The type of the album.

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -51,7 +51,8 @@ class ConvertUtils {
     final AssetPathEntity result = AssetPathEntity(
       id: data['id'] as String,
       name: data['name'] as String,
-      assetCount: data['length'] as int,
+      // ignore: deprecated_member_use_from_same_package
+      assetCount: data['length'] as int? ?? 0,
       albumType: data['albumType'] as int? ?? 1,
       filterOption: optionGroup ?? FilterOptionGroup(),
       lastModified: lastModified,

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
-version: 2.1.4
+version: 2.2.0
 homepage: https://github.com/fluttercandies/flutter_photo_manager
 
 environment:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
-version: 2.2.0
+version: 2.2.0-dev.1
 homepage: https://github.com/fluttercandies/flutter_photo_manager
 
 environment:


### PR DESCRIPTION
- Deprecate `AssetPathEntity.assetCount`.
- Add `AssetPathEntity.assetCountAsync`.
- Remove `containsEmptyAlbum` from `FilterOptionGroup`.

### Local test result:
Before:
<img width="681" alt="image" src="https://user-images.githubusercontent.com/15884415/175761422-5e1342a7-0b7e-47a8-9e1a-32bd4f4169b6.png">
After:
<img width="685" alt="image" src="https://user-images.githubusercontent.com/15884415/175761459-f0071602-9478-4f96-81af-f0b9282fe191.png">
