### PR TITLE
fix: 🐛 startChangeNotify don't work on iOS Device

### DIFF
--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -322,6 +322,7 @@
             } else {
                 [notificationManager stopNotify];
             }
+            [handler reply:NULL];
         } else if ([call.method isEqualToString:@"isNotifying"]) {
             BOOL isNotifying = [notificationManager isNotifying];
             [handler reply:@(isNotifying)];


### PR DESCRIPTION
![image](https://user-images.githubusercontent.com/13459925/178669356-0ca234bc-f4ac-45dc-988e-d55246eb50e8.png)
There is no way to keep going , because on Objc code "notify" method never return result.