### PR TITLE
🐛 [Android] Use `RELATIVE_PATH` only on Android Q+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.2.0-dev.5
+
+### Fixes
+
+- Fix invalid `RELATIVE_PATH` obtains with cursors on Android Q-. (#810)
+
 ## 2.2.0-dev.4
 
 ### Improvements

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -173,7 +173,7 @@ interface IDBUtils {
         val displayName = getString(MediaStore.MediaColumns.DISPLAY_NAME)
         val modifiedDate = getLong(MediaStore.MediaColumns.DATE_MODIFIED)
         val orientation: Int = getInt(MediaStore.MediaColumns.ORIENTATION)
-        val relativePath: String = getString(MediaStore.MediaColumns.RELATIVE_PATH)
+        val relativePath: String? = if (isAndroidQ) getString(MediaStore.MediaColumns.RELATIVE_PATH) else null
         if ((width == 0 || height == 0) && !mimeType.contains("svg")) {
             try {
                 val uri = getUri(id, getMediaType(type))

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
-version: 2.2.0-dev.4
-homepage: https://github.com/fluttercandies/flutter_photo_manager
+repository: https://github.com/fluttercandies/flutter_photo_manager
+version: 2.2.0-dev.5
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
Fix #809.