### PR TITLE
🐛 [iOS] Avoid duplicate `copyItemAtURL`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.4.0-dev.2
+
+### Fixes
+
+- Avoid duplicate `copyItemAtURL` for videos on iOS. (#840)
+
 ## 2.4.0-dev.1
 
 ### Features

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -594,6 +594,17 @@
                 return;
             }
             NSError *error;
+            NSString *destinationPath = destination.path;
+            if ([manager fileExistsAtPath:destinationPath]) {
+                [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"Reading cache from %@", destinationPath]];
+                if (withScheme) {
+                    [handler reply:destination.absoluteString];
+                } else {
+                    [handler reply:destinationPath];
+                }
+                return;
+            }
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"Caching the video to %@", destination]];
             [[NSFileManager defaultManager] copyItemAtURL:videoURL
                                                     toURL:destination
                                                     error:&error];

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 2.4.0-dev.1
+version: 2.4.0-dev.2
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
Fix #818.