### PR TITLE
🐛 [Android] Correct permission checks with `requestPermissionExtend` on Android 33

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.4.0-dev.3
+
+### Fixes
+
+- Correct permission checks with `requestPermissionExtend` on Android 33. (#843)
+
 ## 2.4.0-dev.2
 
 ### Fixes

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -36,12 +36,11 @@ class Methods {
         const val getAssetListPaged = "getAssetListPaged"
         const val getAssetListRange = "getAssetListRange"
 
-        val android13PermissionMethods =
-            arrayOf(
-                fetchPathProperties,
-                getAssetPathList,
-                getAssetListPaged,
-                getAssetListRange,
-            )
+        val android13PermissionMethods = arrayOf(
+            fetchPathProperties,
+            getAssetPathList,
+            getAssetListPaged,
+            getAssetListRange,
+        )
     }
 }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -159,7 +159,7 @@ class PhotoManagerPlugin(
                 Manifest.permission.WRITE_EXTERNAL_STORAGE
             )
         val needReadPermission =
-            Build.VERSION.SDK_INT <= Build.VERSION_CODES.TIRAMISU
+            Build.VERSION.SDK_INT < Build.VERSION_CODES.TIRAMISU
                     && permissionsUtils.havePermissionInManifest(
                 applicationContext,
                 Manifest.permission.READ_EXTERNAL_STORAGE

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 2.4.0-dev.2
+version: 2.4.0-dev.3
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
- Do not require `READ_EXTERNAL_STORAGE` on Android 33.
- Explicitly handle `requestPermissionExtend` with Android 33 permissions.