### PR TITLE
⚡️ [Android] Always declare `READ_EXTERNAL_STORAGE` on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ that can be found in the LICENSE file. -->
 
 ### Improvements
 
+- Always declare `READ_EXTERNAL_STORAGE` permission on Android. (#874)
 - Use `ContentUris` for retrieving Media URIs on Android. (#870)
 
 ## 2.5.1

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,7 +1,6 @@
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
     package="com.fluttercandies.photo_manager">
 
-    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32" />
+    <uses-permission android:name="android.permission.READ_EXTERNAL_STORAGE" />
 
 </manifest>

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
@@ -1,5 +1,3 @@
-@file:Suppress("DEPRECATION")
-
 package com.fluttercandies.photo_manager.permission
 
 import android.Manifest
@@ -120,14 +118,12 @@ class PermissionsUtils {
     private fun checkPermissions(vararg permissions: String): Boolean {
         if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.M) {
             resetStatus()
-            for (i in permissions.indices) {
-                // 检查权限
-                if (mActivity!!.checkSelfPermission(permissions[i]) == PackageManager.PERMISSION_DENIED) {
-                    needToRequestPermissionsList.add(permissions[i])
+            for (p in permissions) {
+                if (mActivity!!.checkSelfPermission(p) == PackageManager.PERMISSION_DENIED) {
+                    return false
                 }
             }
-            // 全部权限获取成功返回 true，否则返回 false
-            return needToRequestPermissionsList.isEmpty()
+            return true
         }
         return true
     }
@@ -272,10 +268,18 @@ class PermissionsUtils {
 
     fun havePermissionInManifest(context: Context, permission: String): Boolean {
         val applicationInfo = context.applicationInfo
-        val packageInfo = context.packageManager.getPackageInfo(
-            applicationInfo.packageName,
-            PackageManager.GET_PERMISSIONS
-        )
+        val packageInfo = if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.TIRAMISU) {
+            context.packageManager.getPackageInfo(
+                applicationInfo.packageName,
+                PackageManager.PackageInfoFlags.of(PackageManager.GET_PERMISSIONS.toLong())
+            )
+        } else {
+            @Suppress("DEPRECATION")
+            context.packageManager.getPackageInfo(
+                applicationInfo.packageName,
+                PackageManager.GET_PERMISSIONS
+            )
+        }
         return packageInfo.requestedPermissions.contains(permission)
     }
 }


### PR DESCRIPTION
Although the document says *starting in API level 33, this permission has no effect*, we still heard from many users that devices are unable to fetch assets. From the comment https://github.com/fluttercandies/flutter_photo_manager/issues/852#issuecomment-1296844804 the permission might affect the result. So until the permission is deprecated, we might continue to declare the permission as well.

Related issues:
- https://github.com/fluttercandies/flutter_photo_manager/issues/852
- https://github.com/fluttercandies/flutter_wechat_assets_picker/issues/388