### PR TITLE
✨[darwin] add track segment meta

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.7.0
+
+Feature:
+
+- Updated `AssetEntity` API to include `getAvAssetTrackMetaList()` method. (#912)
+
 ## 2.6.0
 
 Features:

--- a/README.md
+++ b/README.md
@@ -607,6 +607,29 @@ In generally, a `PHAsset` will have three status:
   In this case, the best practise is to use the `PMProgressHandler`
   to provide a responsive user interface.
 
+
+
+### AssetEntity
+
+
+
+#### Get track metadata
+
+| Class                 | Description                                                  |
+| --------------------- | ------------------------------------------------------------ |
+| `AVAssetTrackMeta`    | Represents metadata for a single track in an `AVAsset`.      |
+| `CMTimeRange`         | Represents a range of time defined by a start time and a duration. |
+| `AVAssetTrackSegment` | Represents a segment of an `AVAssetTrack`, defined by a source and target `CMTimeRange`. |
+
+Example:
+
+```dart
+void showTrackMeta(AssetEntity entity) async {
+  final metaList = await entity.getAvAssetTrackMetaList();
+  print('metaList: ${metaList.map((e) => e.prettyJson())}');
+}
+```
+
 ### Entities change notify
 
 Plugin will post entities change events from native,

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -179,7 +179,16 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
               child: const Text('Copy to another path'),
               onPressed: () => copyToAnotherPath(entity),
             ),
-            _buildMoveAnotherPath(entity),
+            if (Platform.isAndroid)
+              ElevatedButton(
+                onPressed: () => Navigator.push<void>(
+                  context,
+                  MaterialPageRoute<void>(
+                    builder: (_) => MoveToAnotherExample(entity: entity),
+                  ),
+                ),
+                child: const Text('Move to another gallery.'),
+              ),
             _buildRemoveInAlbumWidget(entity),
             ElevatedButton(
               child: const Text('Test progress'),
@@ -215,7 +224,25 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
                   }
                 },
               ),
-          ],
+            if (Platform.isIOS || Platform.isMacOS)
+              ElevatedButton(
+                child: const Text('Show asset track info in console'),
+                onPressed: () async {
+                  final metaList = await entity.getAvAssetTrackMetaList();
+                  print('metaList: ${metaList.map((e) => e.prettyJson())}');
+                },
+              ),
+          ]
+              .map(
+                (e) => Padding(
+                  padding: const EdgeInsets.symmetric(
+                    horizontal: 30,
+                    vertical: 10,
+                  ),
+                  child: e,
+                ),
+              )
+              .toList(),
         ),
       ),
     );
@@ -335,21 +362,6 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
 
   void deleteAssetInAlbum(AssetEntity entity) {
     readPathProvider(context).removeInAlbum(entity);
-  }
-
-  Widget _buildMoveAnotherPath(AssetEntity entity) {
-    if (!Platform.isAndroid) {
-      return Container();
-    }
-    return ElevatedButton(
-      onPressed: () => Navigator.push<void>(
-        context,
-        MaterialPageRoute<void>(
-          builder: (_) => MoveToAnotherExample(entity: entity),
-        ),
-      ),
-      child: const Text('Move to another gallery.'),
-    );
   }
 
   Future<void> showThumb(AssetEntity entity, int size) async {

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -531,6 +531,12 @@
     } else if ([@"cancelCacheRequests" isEqualToString:call.method]) {
         [manager cancelCacheRequests];
         [handler reply:@YES];
+    } else if ([@"getAvAssetTrackMeta" isEqualToString:call.method]) {
+        NSString *assetId = call.arguments[@"assetId"];
+        [manager getAVAssetWithId:assetId completionHandler:^(AVAsset * _Nullable asset) {
+            NSArray *array = [PMConvertUtils convertAvAssetToSegmentsArray:asset];
+            [handler reply:array];
+        }];
     } else {
         [handler notImplemented];
     }

--- a/ios/Classes/core/PMConvertUtils.h
+++ b/ios/Classes/core/PMConvertUtils.h
@@ -23,4 +23,7 @@
 + (PMFilterOption *)convertMapToPMFilterOption:(NSDictionary *)map;
 
 + (NSObject<PMBaseFilter> *)convertMapToOptionContainer:(NSDictionary *)map;
+
++ (NSArray *) convertAvAssetToSegmentsArray:(AVAsset *) asset;
+
 @end

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -103,6 +103,8 @@ typedef void (^AssetResult)(PMAssetEntity *);
 
 - (void)cancelCacheRequests;
 
+- (void)getAVAssetWithId:(NSString *)phAssetId completionHandler:(void (^)(AVAsset * _Nullable asset))completionHandler;
+
 - (void)injectModifyToDate:(PMAssetPathEntity *)path;
 
 - (NSUInteger) getAssetCountWithType:(int)type option:(NSObject<PMBaseFilter> *) filter;

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -1475,4 +1475,31 @@
     }
 }
 
+#pragma mark get slow video info
+
+- (void)getAVAssetWithId:(NSString *)phAssetId completionHandler:(void (^)(AVAsset * _Nullable asset))completionHandler {
+    PHFetchResult *result = [PHAsset fetchAssetsWithLocalIdentifiers:@[phAssetId] options:nil];
+
+    if (result.count > 0) {
+        PHAsset *asset = result.firstObject;
+
+        PHVideoRequestOptions *options = [[PHVideoRequestOptions alloc] init];
+        options.networkAccessAllowed = YES;
+
+        [[PHImageManager defaultManager] requestAVAssetForVideo:asset options:options resultHandler:^(AVAsset * _Nullable avAsset, AVAudioMix * _Nullable audioMix, NSDictionary * _Nullable info) {
+            dispatch_async(dispatch_get_main_queue(), ^{
+                if (completionHandler) {
+                    completionHandler(avAsset);
+                }
+            });
+        }];
+    } else {
+        NSLog(@"Could not find PHAsset with ID %@", phAssetId);
+
+        if (completionHandler) {
+            completionHandler(nil);
+        }
+    }
+}
+
 @end

--- a/lib/photo_manager.dart
+++ b/lib/photo_manager.dart
@@ -28,6 +28,7 @@ export 'src/managers/photo_manager.dart';
 
 export 'src/types/entity.dart';
 export 'src/types/thumbnail.dart';
-export 'src/types/types.dart';
+export 'src/types/types.dart' hide IMappable;
+export 'src/types/av_asset_meta.dart';
 
 export 'src/utils/column_utils.dart';

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -61,6 +61,8 @@ class PMConstants {
   static const String mGetAssetCount = 'getAssetCount';
   static const String mGetAssetsByRange = 'getAssetsByRange';
 
+  static const String mGetAvAssetTrackMeta = 'getAvAssetTrackMeta';
+
   /// Constant value.
   static const int vDefaultThumbnailSize = 150;
   static const int vDefaultThumbnailQuality = 95;

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'dart:typed_data' as typed_data;
 
 import 'package:flutter/services.dart';
+import 'package:photo_manager/src/types/av_asset_meta.dart';
 
 import '../filter/base_filter.dart';
 import '../filter/classical/filter_option_group.dart';
@@ -658,6 +659,15 @@ mixin IosPlugin on BasePlugin {
       },
     );
     return result?['msg'] == null;
+  }
+
+  Future<List<AVAssetTrackMeta>> getAvAssetTrackMeta(AssetEntity assetEntity) {
+    return _channel.invokeMethod<List>(PMConstants.mGetAvAssetTrackMeta, {
+      'assetId': assetEntity.id,
+    }).then((value) {
+      if (value is! List) return [];
+      return ConvertUtils.convertToAVAssetTrackList(value);
+    });
   }
 }
 

--- a/lib/src/types/av_asset_meta.dart
+++ b/lib/src/types/av_asset_meta.dart
@@ -1,0 +1,110 @@
+import 'dart:convert';
+
+import '../../photo_manager.dart';
+
+// {
+//   "timeRange": {
+//     "startTime": 0.0,
+//     "duration": 40.18666666666667
+//   },
+//   "mediaType": "vide",
+//   "nominalFrameRate": 47.81670379638672,
+//   "segments": [
+//     {
+//       "target": {
+//         "start": 0.0,
+//         "duration": 40.18666666666667
+//       },
+//       "source": {
+//         "start": 2.033333333333333,
+//         "duration": 40.18666666666667
+//       }
+//     }
+//   ]
+// }
+
+class CMTimeRange with IMappable {
+  final double startTime;
+  final double duration;
+
+  CMTimeRange({
+    required this.startTime,
+    required this.duration,
+  });
+
+  factory CMTimeRange.fromJson(Map json) {
+    return CMTimeRange(
+      startTime: json['startTime'] as double,
+      duration: json['duration'] as double,
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'startTime': startTime,
+      'duration': duration,
+    };
+  }
+}
+
+class AVAssetTrackSegment with IMappable {
+  final CMTimeRange source;
+  final CMTimeRange target;
+
+  AVAssetTrackSegment({
+    required this.source,
+    required this.target,
+  });
+
+  factory AVAssetTrackSegment.fromJson(Map json) {
+    return AVAssetTrackSegment(
+      source: CMTimeRange.fromJson(json['source']),
+      target: CMTimeRange.fromJson(json['target']),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'source': source.toMap(),
+      'target': target.toMap(),
+    };
+  }
+}
+
+class AVAssetTrackMeta with IMappable {
+  final String mediaType;
+  final CMTimeRange timeRange;
+  final double nominalFrameRate;
+  final List<AVAssetTrackSegment> segments;
+
+  AVAssetTrackMeta({
+    required this.mediaType,
+    required this.timeRange,
+    required this.nominalFrameRate,
+    required this.segments,
+  });
+
+  factory AVAssetTrackMeta.fromJson(Map json) {
+    print(JsonEncoder.withIndent('  ').convert(json));
+    return AVAssetTrackMeta(
+      mediaType: json['mediaType'] as String,
+      timeRange: CMTimeRange.fromJson(json['timeRange']),
+      nominalFrameRate: json['nominalFrameRate'] as double,
+      segments: (json['segments'] as List)
+          .map((e) => AVAssetTrackSegment.fromJson(e))
+          .toList(),
+    );
+  }
+
+  @override
+  Map<String, dynamic> toMap() {
+    return {
+      'mediaType': mediaType,
+      'timeRange': timeRange.toMap(),
+      'nominalFrameRate': nominalFrameRate,
+      'segments': segments.map((e) => e.toMap()).toList(),
+    };
+  }
+}

--- a/lib/src/types/av_asset_meta.dart
+++ b/lib/src/types/av_asset_meta.dart
@@ -87,7 +87,6 @@ class AVAssetTrackMeta with IMappable {
   });
 
   factory AVAssetTrackMeta.fromJson(Map json) {
-    print(JsonEncoder.withIndent('  ').convert(json));
     return AVAssetTrackMeta(
       mediaType: json['mediaType'] as String,
       timeRange: CMTimeRange.fromJson(json['timeRange']),

--- a/lib/src/types/av_asset_meta.dart
+++ b/lib/src/types/av_asset_meta.dart
@@ -112,6 +112,7 @@ class AVAssetTrackSegment with IMappable {
     };
   }
 }
+
 /// {@template av_asset_track_meta}
 /// A metadata object that represents a single track in an `AVAsset`.
 ///

--- a/lib/src/types/av_asset_meta.dart
+++ b/lib/src/types/av_asset_meta.dart
@@ -1,6 +1,4 @@
-import 'dart:convert';
-
-import '../../photo_manager.dart';
+import 'types.dart';
 
 // {
 //   "timeRange": {
@@ -23,15 +21,35 @@ import '../../photo_manager.dart';
 //   ]
 // }
 
+/// {@template cm_time_range}
+/// A range of time defined by a start time and a duration.
+///
+/// This class is used to represent a time range, which consists of a start time
+/// (measured in seconds) and a duration (also measured in seconds).
+/// {@endtemplate}
 class CMTimeRange with IMappable {
+  /// The start time of the time range, specified in seconds.
   final double startTime;
+
+  /// The duration of the time range, specified in seconds.
   final double duration;
 
+  /// {@macro cm_time_range}
+  ///
+  /// Creates a new `CMTimeRange` instance with the given `startTime` and `duration`.
+  ///
+  /// Both parameters are required and must be non-null.
   CMTimeRange({
     required this.startTime,
     required this.duration,
   });
 
+  /// {@macro cm_time_range}
+  ///
+  /// Creates a new `CMTimeRange` instance from a JSON map.
+  ///
+  /// The map should contain the keys `startTime` and `duration`, which correspond
+  /// to the `startTime` and `duration` properties of the `CMTimeRange` class.
   factory CMTimeRange.fromJson(Map json) {
     return CMTimeRange(
       startTime: json['startTime'] as double,
@@ -48,15 +66,37 @@ class CMTimeRange with IMappable {
   }
 }
 
+/// {@template av_asset_track_segment}
+/// A segment of an `AVAssetTrack`, defined by a source and target `CMTimeRange`.
+///
+/// This class is used to represent a segment of an `AVAssetTrack`, which consists
+/// of a source `CMTimeRange` and a target `CMTimeRange`. The source `CMTimeRange`
+/// represents the time range in the original asset from which the segment was extracted,
+/// while the target `CMTimeRange` represents the corresponding time range in the new asset.
+/// {@endtemplate}
 class AVAssetTrackSegment with IMappable {
+  /// The source `CMTimeRange` of the segment.
   final CMTimeRange source;
+
+  /// The target `CMTimeRange` of the segment.
   final CMTimeRange target;
 
+  /// {@macro av_asset_track_segment}
+  ///
+  /// Creates a new `AVAssetTrackSegment` instance with the given `source` and `target`.
+  ///
+  /// Both parameters are required and must be non-null.
   AVAssetTrackSegment({
     required this.source,
     required this.target,
   });
 
+  /// {@macro av_asset_track_segment}
+  ///
+  /// Creates a new `AVAssetTrackSegment` instance from a JSON map.
+  ///
+  /// The map should contain the keys `source` and `target`, which correspond
+  /// to the `source` and `target` properties of the `AVAssetTrackSegment` class.
   factory AVAssetTrackSegment.fromJson(Map json) {
     return AVAssetTrackSegment(
       source: CMTimeRange.fromJson(json['source']),
@@ -72,13 +112,34 @@ class AVAssetTrackSegment with IMappable {
     };
   }
 }
-
+/// {@template av_asset_track_meta}
+/// A metadata object that represents a single track in an `AVAsset`.
+///
+/// This class is used to represent metadata for a single track in an `AVAsset`, which
+/// includes its media type, time range, nominal frame rate, and segments. The `mediaType`
+/// property indicates the type of media contained in the track (e.g., audio or video), while
+/// the `timeRange` property represents the duration of the track. The `nominalFrameRate`
+/// property indicates the expected frame rate of the track, and the `segments` property
+/// is a list of `AVAssetTrackSegment` objects that define individual portions of the track.
+/// {@endtemplate}
 class AVAssetTrackMeta with IMappable {
+  /// The media type of the asset track.
   final String mediaType;
+
+  /// The time range of the asset track.
   final CMTimeRange timeRange;
+
+  /// The nominal frame rate of the asset track.
   final double nominalFrameRate;
+
+  /// The segments of the asset track.
   final List<AVAssetTrackSegment> segments;
 
+  /// {@macro av_asset_track_meta}
+  ///
+  /// Creates a new `AVAssetTrackMeta` instance with the given properties.
+  ///
+  /// All parameters are required and must be non-null.
   AVAssetTrackMeta({
     required this.mediaType,
     required this.timeRange,
@@ -86,6 +147,13 @@ class AVAssetTrackMeta with IMappable {
     required this.segments,
   });
 
+  /// {@macro av_asset_track_meta}
+  ///
+  /// Creates a new `AVAssetTrackMeta` instance from a JSON map.
+  ///
+  /// The map should contain the keys `mediaType`, `timeRange`, `nominalFrameRate`,
+  /// and `segments`, which correspond to the `mediaType`, `timeRange`, `nominalFrameRate`,
+  /// and `segments` properties of the `AVAssetTrackMeta` class.
   factory AVAssetTrackMeta.fromJson(Map json) {
     return AVAssetTrackMeta(
       mediaType: json['mediaType'] as String,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -16,6 +16,7 @@ import '../internal/enums.dart';
 import '../internal/plugin.dart';
 import '../internal/progress_handler.dart';
 import '../utils/convert_utils.dart';
+import 'av_asset_meta.dart';
 import 'thumbnail.dart';
 import 'types.dart';
 
@@ -765,6 +766,16 @@ class AssetEntity {
   ///  * [mimeType] which is the synchronized getter of the MIME type.
   ///  * https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1
   Future<String?> get mimeTypeAsync => plugin.getMimeTypeAsync(this);
+
+  /// Get AVAssetMetadata for the asset.
+  ///  * Android: Always empty List.
+  ///  * iOS/macOS: [AVAssetMetadata].
+  Future<List<AVAssetTrackMeta>> getAvAssetTrackMetaList() async {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return plugin.getAvAssetTrackMeta(this);
+    }
+    return [];
+  }
 
   AssetEntity copyWith({
     String? id,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -769,7 +769,7 @@ class AssetEntity {
 
   /// Get AVAssetMetadata for the asset.
   ///  * Android: Always empty List.
-  ///  * iOS/macOS: [AVAssetMetadata].
+  ///  * iOS/macOS: [AVAssetTrack](https://developer.apple.com/documentation/avfoundation/avassettrack?language=objc).
   Future<List<AVAssetTrackMeta>> getAvAssetTrackMetaList() async {
     if (Platform.isIOS || Platform.isMacOS) {
       return plugin.getAvAssetTrackMeta(this);

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -100,7 +100,10 @@ class PermissionRequestOption {
 }
 
 mixin IMappable {
+
+  /// Convert this object to a map.
   Map<String, dynamic> toMap();
 
+  /// Convert this object to pretty JSON string.
   String prettyJson() => const JsonEncoder.withIndent('  ').convert(toMap());
 }

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -2,6 +2,8 @@
 // Use of this source code is governed by an Apache license that can be found
 // in the LICENSE file.
 
+import 'dart:convert';
+
 import 'package:flutter/foundation.dart';
 
 import '../internal/enums.dart';
@@ -95,4 +97,10 @@ class PermissionRequestOption {
 
   @override
   int get hashCode => iosAccessLevel.hashCode;
+}
+
+mixin IMappable {
+  Map<String, dynamic> toMap();
+
+  String prettyJson() => const JsonEncoder.withIndent('  ').convert(toMap());
 }

--- a/lib/src/types/types.dart
+++ b/lib/src/types/types.dart
@@ -100,7 +100,6 @@ class PermissionRequestOption {
 }
 
 mixin IMappable {
-
   /// Convert this object to a map.
   Map<String, dynamic> toMap();
 

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -4,6 +4,7 @@
 
 import '../filter/base_filter.dart';
 import '../filter/classical/filter_option_group.dart';
+import '../types/av_asset_meta.dart';
 import '../types/entity.dart';
 import '../types/types.dart';
 
@@ -88,6 +89,16 @@ class ConvertUtils {
       longitude: data['lng'] as double?,
       mimeType: data['mimeType'] as String?,
     );
+    return result;
+  }
+
+  static List<AVAssetTrackMeta> convertToAVAssetTrackList(
+    List list,
+  ) {
+    final result = <AVAssetTrackMeta>[];
+    for (final Map item in list) {
+      result.add(AVAssetTrackMeta.fromJson(item));
+    }
     return result;
   }
 }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 2.6.0
+version: 2.7.0
 
 environment:
   sdk: ">=2.13.0 <3.0.0"


### PR DESCRIPTION
Function introduction: Submitted for the metadata of slow-motion videos on the Darwin platform.
This function only supports iOS/macOS.

1. Obtain AVAsset corresponding to PHAsset
2. Obtain track information of AVAsset
3. Slice according to tracks and export timeMapping of each slice.

---
CheckList
- [x] Changelog
- [x] Readme
- [x] Docs for class

