### PR TITLE
fix: fix asset path entity copyWith to also allow custom filter

### DIFF
--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -265,7 +265,7 @@ class AssetPathEntity {
     DateTime? lastModified,
     RequestType? type,
     bool? isAll,
-    FilterOptionGroup? filterOption,
+    PMFilter? filterOption,
   }) {
     return AssetPathEntity(
       id: id ?? this.id,


### PR DESCRIPTION
AssetPathEntity constructor now takes `PMFilter` class as a result of the new custom filter feature.
This fixes `copyWith` accordingly.