### PR TITLE
fix: delete assets permanently deleted instead of trash in android R

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerDeleteManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerDeleteManager.kt
@@ -57,7 +57,7 @@ class PhotoManagerDeleteManager(val context: Context, private var activity: Acti
     @RequiresApi(Build.VERSION_CODES.R)
     fun deleteInApi30(uris: List<Uri?>, resultHandler: ResultHandler) {
         this.androidRHandler = resultHandler
-        val pendingIntent = MediaStore.createTrashRequest(cr, uris.mapNotNull { it }, true)
+        val pendingIntent = MediaStore.createDeleteRequest(cr, uris.mapNotNull { it })
         activity?.startIntentSenderForResult(
             pendingIntent.intentSender,
             androidRDeleteRequestCode,


### PR DESCRIPTION
### Changes made

The current implementation of trashing the asset instead of deleting it in Android 30 and above feels inconsistent with the rest of the behavior of the API in older versions of Android and iOS where the asset is irrevocably deleted.

It is changed in this PR to have the same behavior of deleting the asset using `MediaStore.createDeleteRequest` which based on the [documentation](https://developer.android.com/reference/android/provider/MediaStore#createDeleteRequest(android.content.ContentResolver,%20java.util.Collection%3Candroid.net.Uri%3E)) calls [ContentResolver#delete](https://developer.android.com/reference/android/content/ContentResolver#delete(android.net.Uri,%20android.os.Bundle)) similar to the [handling](https://github.com/fluttercandies/flutter_photo_manager/blob/ba688606fddaa910b1ee92b85ff7159c60ebf983/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerDeleteManager.kt#L48) used in older android versions


### Possible improvements
A new method named `trashAsset` can be added as an feature which would trash the asset instead of deleting it in Android 30 and above along with a method to fetch such assets as well