### PR TITLE
Try catch request cache thumbnail

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -264,7 +264,12 @@ class PhotoManager(private val context: Context) {
                 if (cacheFuture.isCancelled) {
                     return@execute
                 }
-                cacheFuture.get()
+
+                try {
+                    cacheFuture.get()
+                } catch (e: Exception) {
+                    LogUtils.error(e)
+                }
             }
         }
     }


### PR DESCRIPTION
App crashes when photo_manager tries to request a cache thumbnail for a broken image file, like this one:
https://drive.google.com/file/d/1-8C4w2fhbHh2EmsJPF2SN0de3NiTNiCN/view?usp=drivesdk

Catch the thrown exception so that the main app does not crash. 