### PR TITLE
[IOS] FIX: Return original filename instead of FullSizeRender

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,18 +4,13 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
-## 2.7.3
-
-### Fixes
-
-- [iOS] Add PHAsset extension method `getUntouchedResource` to retrieve original media instead of one with adjustments / filters.
-- [iOS] Fix: When retrieving an asset title, now returns original file name instead of `FullSizeRender.*` if this has adjustments. (#976)
-
 ## 2.7.2
 
 ### Fixes
 
 - Correct the key when fetching video info with MMR on Android. (#997)
+- Retrieve original media instead of one with adjustments/filters for subtype files on iOS. (#976)
+- Returns original file name instead of `FullSizeRender.*` if this has adjustments on iOS. (#976)
 
 ### Improvements
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,13 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 2.7.3
+
+### Fixes
+
+- [iOS] Add PHAsset extension method `getUntouchedResource` to retrieve original media instead of one with adjustments / filters.
+- [iOS] Fix: When retrieving an asset title, now returns original file name instead of `FullSizeRender.*` if this has adjustments. (#976)
+
 ## 2.7.2
 
 ### Fixes

--- a/ios/Classes/core/PHAsset+PM_COMMON.h
+++ b/ios/Classes/core/PHAsset+PM_COMMON.h
@@ -29,6 +29,7 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString*)mimeType;
 - (BOOL)isAdjust;
 - (PHAssetResource *)getAdjustResource;
+- (PHAssetResource *)getUntouchedResource;
 - (void)requestAdjustedData:(void (^)(NSData *_Nullable result))block;
 - (PHAssetResource *)getLivePhotosResource;
 

--- a/ios/Classes/core/PHAsset+PM_COMMON.m
+++ b/ios/Classes/core/PHAsset+PM_COMMON.m
@@ -68,7 +68,7 @@
             return [self getLivePhotosResource].originalFilename;
         }
     }
-    PHAssetResource *resource = [self getAdjustResource];
+    PHAssetResource *resource = [self getUntouchedResource];
     if (resource) {
         return resource.originalFilename;
     }
@@ -118,6 +118,31 @@
         }
     }
     return NO;
+}
+
+- (PHAssetResource *)getUntouchedResource {
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:self];
+    if (resources.count == 0) {
+        return nil;
+    }
+
+    if (resources.count == 1) {
+        return resources[0];
+    }
+
+    for (PHAssetResource *res in resources) {
+        if (self.mediaType == PHAssetMediaTypeImage
+            && res.type == PHAssetResourceTypePhoto) {
+            return res;
+        }
+        
+        if (self.mediaType == PHAssetMediaTypeVideo
+            && res.type == PHAssetResourceTypeVideo) {
+            return res;
+        }
+    }
+    
+    return nil;
 }
 
 - (PHAssetResource *)getAdjustResource {


### PR DESCRIPTION
- Add method **_getUntouchedResource_** to retrieve original photo/video instead of altered one (with adjustments / filters)
- **Fix**: When retrieving an asset title ( with _entity.title_ or _entity.titleAsync_) now returns original file name instead of '**_FullSizeRender.*_**' if this has adjustments.

Related Issues:
Fixes #976
Fixes https://github.com/immich-app/immich/issues/4088 