### PR TITLE
Update for ImageProvider deprecation

### DIFF
--- a/lib/src/internal/image_provider.dart
+++ b/lib/src/internal/image_provider.dart
@@ -66,9 +66,9 @@ class AssetEntityImageProvider extends ImageProvider<AssetEntityImageProvider> {
   ImageFileType get imageFileType => _getType();
 
   @override
-  ImageStreamCompleter load(
+  ImageStreamCompleter loadImage(
     AssetEntityImageProvider key,
-    DecoderCallback decode, // ignore: deprecated_member_use
+    ImageDecoderCallback decode,
   ) {
     return MultiFrameImageStreamCompleter(
       codec: _loadAsync(key, decode),
@@ -93,7 +93,7 @@ class AssetEntityImageProvider extends ImageProvider<AssetEntityImageProvider> {
 
   Future<ui.Codec> _loadAsync(
     AssetEntityImageProvider key,
-    DecoderCallback decode, // ignore: deprecated_member_use
+    ImageDecoderCallback decode,
   ) {
     if (_providerLocks.containsKey(key)) {
       return _providerLocks[key]!.future;
@@ -136,7 +136,7 @@ class AssetEntityImageProvider extends ImageProvider<AssetEntityImageProvider> {
         if (data == null) {
           throw StateError('The data of the entity is null: $entity');
         }
-        return decode(data);
+        return decode(await ui.ImmutableBuffer.fromUint8List(data));
       } catch (e, s) {
         if (kDebugMode) {
           FlutterError.presentError(


### PR DESCRIPTION
Now since flutter 3.15, we can't just override `ImageProvider.load`, and `DecoderCallback` is removed. The deprecation occured in flutter 2.13. So would have to also upgrade minimum flutter sdk version in pubspec.yaml I guess?