### PR TITLE
fix exmaple not work

### DIFF
--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -1,4 +1,5 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+<manifest xmlns:android="http://schemas.android.com/apk/res/android"
+    package="com.fluttercandies.photo_manager_example">
     <uses-permission android:name="android.permission.INTERNET"/>
     <uses-permission
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"


### PR DESCRIPTION
When I run example for the first time or after executing flutter clean, android studio prompts
`package identifier or launch activity not found.
Please check /Users/10457/flutter_project/flutter_photo_manager/example/android/app/src/main/AndroidManifest.xml for errors.
No application found for TargetPlatform.android_arm64.
Is your project missing an android/app/src/main/AndroidManifest.xml?
Consider running "flutter create ." to create one.`

add `package="com.fluttercandies.photo_manager_example"` to exmaple/androidMainfest.xml 
run work right
