### PR TITLE
fix: `deleteWithIds` method not working

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ that can be found in the LICENSE file. -->
 
 # CHANGELOG
 
+## 3.0.0-dev.2
+
+Fix:
+
+- Fix `PhotoManager.editor.deleteWithIds` method not working on Android API 29.
+
 ## 3.0.0-dev.1
 
 ***Breaking changes*** for remove some methods and classes.

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -2,6 +2,7 @@ package com.fluttercandies.photo_manager.core
 
 import android.app.Activity
 import android.content.Context
+import android.net.Uri
 import android.os.Build
 import android.os.Handler
 import android.os.Looper
@@ -537,6 +538,13 @@ class PhotoManagerPlugin(
                     if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
                         val uris = ids.map { photoManager.getUri(it) }.toList()
                         deleteManager.deleteInApi30(uris, resultHandler)
+                    } else if (Build.VERSION.SDK_INT == Build.VERSION_CODES.Q) {
+                        val idUriMap = HashMap<String, Uri?>()
+                        for (id in ids) {
+                            val uri = photoManager.getUri(id)
+                            idUriMap[id] = uri
+                        }
+                        deleteManager.deleteJustInApi29(idUriMap, resultHandler)
                     } else {
                         deleteManager.deleteInApi28(ids)
                         resultHandler.reply(ids)

--- a/example/lib/page/developer/issues_page/issue_988.dart
+++ b/example/lib/page/developer/issues_page/issue_988.dart
@@ -226,7 +226,11 @@ class __DeleteAssetImageListState extends State<_DeleteAssetImageList> {
             .deleteWithIds(checked.map((e) => e.id).toList());
 
         showToast('Delete success, ids: $ids');
-        
+
+        if (ids.isNotEmpty) {
+          checked.removeWhere((element) => ids.contains(element.id));
+        }
+
         // refresh the list
         loadAssets();
       },

--- a/example/lib/widget/nav_column.dart
+++ b/example/lib/widget/nav_column.dart
@@ -19,11 +19,13 @@ class NavColumn extends StatelessWidget {
   Widget build(BuildContext context) {
     return Padding(
       padding: const EdgeInsets.all(8.0),
-      child: Center(
-        child: Column(
-          children: <Widget>[
-            for (final Widget item in children) buildItem(context, item),
-          ],
+      child: SingleChildScrollView(
+        child: Center(
+          child: Column(
+            children: <Widget>[
+              for (final Widget item in children) buildItem(context, item),
+            ],
+          ),
         ),
       ),
     );

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides assets abstraction management APIs on Android, iOS, and macOS.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 3.0.0-dev.1
+version: 3.0.0-dev.2
 
 environment:
   sdk: ">=2.13.0 <4.0.0"


### PR DESCRIPTION
- Fix `PhotoManager.editor.deleteWithIds` method not working on Android API 29.

- Upgrade pubspec version

Signed-off-by: CaiJingLong <cjl_spy@163.com>