### PR TITLE
[iOS] Handle error when fetching thumbnail

### DIFF
--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -440,6 +440,12 @@
                       contentMode:option.contentMode
                           options:requestOptions
                     resultHandler:^(PMImage *result, NSDictionary *info) {
+        if (info[PHImageErrorKey]) {
+            [handler reply: nil];
+            [self notifySuccess:progressHandler];
+            return;
+        }
+
         BOOL downloadFinished = [PMManager isDownloadFinish:info];
 
         if (!downloadFinished) {


### PR DESCRIPTION
One of my videos can't generate a thumbnail and it causes the error `Domain=PHPhotosErrorDomain Code=3303`, resulting in `fetchThumb` never calling back.
We should handle this case probably the same way as when `imageData` is `nil`.

I'm attaching the video I have issue with.

https://github.com/fluttercandies/flutter_photo_manager/assets/11507974/b2d3d444-072a-4e50-8060-ef61e172fe88
