### PR TITLE
🐛 [iOS] Add `__IPHONE_17_0` pragma

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,7 +14,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ### Fixes
 
-* Fix compile exceptions with Xcode versions which is not compatible with iOS 17.0.
+* Fixes compile exceptions with Xcode versions that are not compatible with iOS 17.0.
 
 ## 3.2.0
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ that can be found in the LICENSE file. -->
 
 To know more about breaking changes, see the [Migration Guide][].
 
+## 3.2.1
+
+### Improvements
+
+* Declare `NSPrivacyAccessedAPICategoryFileTimestamp` for iOS privacy policies.
+
+### Fixes
+
+* Fix compile exceptions with Xcode versions which is not compatible with iOS 17.0.
+
 ## 3.2.0
 
 ### Improvements

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager_example
 description: Demonstrates how to use the photo_manager plugin.
-version: 3.2.0+27
+version: 3.2.1+28
 publish_to: none
 
 environment:

--- a/ios/Classes/core/PHAssetResource+PM_COMMON.m
+++ b/ios/Classes/core/PHAssetResource+PM_COMMON.m
@@ -39,9 +39,13 @@
 
 - (bool)isValid {
     bool isResource = self.type != PHAssetResourceTypeAdjustmentData;
+
+#if __IPHONE_17_0
     if (@available(iOS 17.0, *)) {
         isResource = isResource && self.type != PHAssetResourceTypePhotoProxy;
     }
+#endif
+
     return isResource;
 }
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides album assets abstraction management APIs on Android, iOS, macOS, and OpenHarmony.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 3.2.0
+version: 3.2.1
 
 environment:
   sdk: ">=2.13.0 <4.0.0"


### PR DESCRIPTION
Fixes #1151. Fixes compile exceptions with Xcode versions that are not compatible with iOS 17.0.