### PR TITLE
⚡️ Reorg input streams when saving asset on Android

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,9 +8,14 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+### Breaking changes
+
+`saveImage` now requires `filename` rather than `title` other save methods do not require `title` anymore.
+
 ### Improvements
 
 - Allows saving assets with a given orientation value.
+- Improves the reading sequence when saving assets, which likely fixes issues with wrong orientation value.
 - Reads image size from EXIF rather than decoding from the bitmap factory.
 - Upgrades Android EXIF library.
 

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -5,20 +5,23 @@ If you want to see the new feature support, please refer to [readme][] and [chan
 
 <!-- TOC -->
 * [Migration Guide](#migration-guide)
-  * [3.0.x to 3.1](#30x-to-31)
+  * [3.x to 3.3](#3x-to-33)
     * [Overall](#overall)
+      * [`saveImage`](#saveimage)
+  * [3.0.x to 3.1](#30x-to-31)
+    * [Overall](#overall-1)
       * [`containsLivePhotos`](#containslivephotos)
       * [`AlbumType`](#albumtype)
   * [2.x to 3.0](#2x-to-30)
-    * [Overall](#overall-1)
+    * [Overall](#overall-2)
       * [`AssetEntityImage` and `AssetEntityImageProvider`](#assetentityimage-and-assetentityimageprovider)
   * [2.x to 2.8](#2x-to-28)
-    * [Overall](#overall-2)
-  * [2.x to 2.2](#2x-to-22)
     * [Overall](#overall-3)
+  * [2.x to 2.2](#2x-to-22)
+    * [Overall](#overall-4)
       * [`assetCount`](#assetcount)
   * [1.x to 2.0](#1x-to-20)
-    * [Overall](#overall-4)
+    * [Overall](#overall-5)
     * [API migrations](#api-migrations)
       * [`getAssetListPaged`](#getassetlistpaged)
       * [Filtering only videos](#filtering-only-videos)
@@ -27,6 +30,25 @@ If you want to see the new feature support, please refer to [readme][] and [chan
   * [0.6 to 1.0](#06-to-10)
   * [0.5 To 0.6](#05-to-06)
 <!-- TOC -->
+
+## 3.x to 3.3
+
+### Overall
+
+In order to let developers write the most precise API usage,
+the `title` of `saveImage` has migrated to `filename`.
+
+#### `saveImage`
+
+Before:
+```dart
+final entity = await PhotoManager.editor.saveImage(bytes, title: 'new.jpg');
+```
+
+After:
+```dart
+final entity = await PhotoManager.editor.saveImage(bytes, filename: 'new.jpg');
+```
 
 ## 3.0.x to 3.1
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -18,7 +18,6 @@ import com.fluttercandies.photo_manager.core.utils.IDBUtils
 import com.fluttercandies.photo_manager.thumb.ThumbnailUtil
 import com.fluttercandies.photo_manager.util.LogUtils
 import com.fluttercandies.photo_manager.util.ResultHandler
-import java.io.File
 import java.util.concurrent.Executors
 
 class PhotoManager(private val context: Context) {
@@ -167,36 +166,33 @@ class PhotoManager(private val context: Context) {
     }
 
     fun saveImage(
-        image: ByteArray,
-        title: String,
+        bytes: ByteArray,
+        filename: String,
         description: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        return dbUtils.saveImage(context, image, title, description, relativePath, orientation)
+        return dbUtils.saveImage(context, bytes, filename, description, relativePath, orientation)
     }
 
     fun saveImage(
-        path: String,
+        filePath: String,
         title: String,
         description: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        return dbUtils.saveImage(context, path, title, description, relativePath, orientation)
+        return dbUtils.saveImage(context, filePath, title, description, relativePath, orientation)
     }
 
     fun saveVideo(
-        path: String,
+        filePath: String,
         title: String,
         desc: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        if (!File(path).exists()) {
-            return null
-        }
-        return dbUtils.saveVideo(context, path, title, desc, relativePath, orientation)
+        return dbUtils.saveVideo(context, filePath, title, desc, relativePath, orientation)
     }
 
     fun assetExists(id: String, resultHandler: ResultHandler) {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -168,11 +168,12 @@ class PhotoManager(private val context: Context) {
     fun saveImage(
         bytes: ByteArray,
         filename: String,
+        title: String,
         description: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        return dbUtils.saveImage(context, bytes, filename, description, relativePath, orientation)
+        return dbUtils.saveImage(context, bytes, filename, title, description, relativePath, orientation)
     }
 
     fun saveImage(

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -465,14 +465,14 @@ class PhotoManagerPlugin(
 
             Methods.saveImage -> {
                 try {
-                    val image = call.argument<ByteArray>("image")!!
-                    val title = call.argument<String>("title") ?: ""
+                    val bytes = call.argument<ByteArray>("image")!!
+                    val filename = call.argument<String>("title") ?: ""
                     val desc = call.argument<String>("desc") ?: ""
                     val relativePath = call.argument<String>("relativePath") ?: ""
                     val orientation = call.argument<Int?>("orientation")
                     val entity = photoManager.saveImage(
-                        image,
-                        title,
+                        bytes,
+                        filename,
                         desc,
                         relativePath,
                         orientation,
@@ -491,13 +491,13 @@ class PhotoManagerPlugin(
 
             Methods.saveImageWithPath -> {
                 try {
-                    val imagePath = call.argument<String>("path")!!
+                    val filePath = call.argument<String>("path")!!
                     val title = call.argument<String>("title") ?: ""
                     val desc = call.argument<String>("desc") ?: ""
                     val relativePath = call.argument<String>("relativePath") ?: ""
                     val orientation = call.argument<Int?>("orientation")
                     val entity = photoManager.saveImage(
-                        imagePath,
+                        filePath,
                         title,
                         desc,
                         relativePath,
@@ -517,13 +517,13 @@ class PhotoManagerPlugin(
 
             Methods.saveVideo -> {
                 try {
-                    val videoPath = call.argument<String>("path")!!
+                    val filePath = call.argument<String>("path")!!
                     val title = call.argument<String>("title")!!
                     val desc = call.argument<String>("desc") ?: ""
                     val relativePath = call.argument<String>("relativePath") ?: ""
                     val orientation = call.argument<Int?>("orientation")
                     val entity = photoManager.saveVideo(
-                        videoPath,
+                        filePath,
                         title,
                         desc,
                         relativePath,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -466,7 +466,7 @@ class PhotoManagerPlugin(
             Methods.saveImage -> {
                 try {
                     val bytes = call.argument<ByteArray>("image")!!
-                    val filename = call.argument<String>("title") ?: ""
+                    val filename = call.argument<String>("filename") ?: ""
                     val desc = call.argument<String>("desc") ?: ""
                     val relativePath = call.argument<String>("relativePath") ?: ""
                     val orientation = call.argument<Int?>("orientation")

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -467,12 +467,14 @@ class PhotoManagerPlugin(
                 try {
                     val bytes = call.argument<ByteArray>("image")!!
                     val filename = call.argument<String>("filename") ?: ""
+                    val title = call.argument<String>("title") ?: ""
                     val desc = call.argument<String>("desc") ?: ""
                     val relativePath = call.argument<String>("relativePath") ?: ""
                     val orientation = call.argument<Int?>("orientation")
                     val entity = photoManager.saveImage(
                         bytes,
                         filename,
+                        title,
                         desc,
                         relativePath,
                         orientation,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
@@ -7,7 +7,7 @@ import java.io.File
 
 data class AssetEntity(
     val id: Long,
-    var path: String,
+    val path: String,
     val duration: Long,
     val createDt: Long,
     val width: Int,
@@ -15,9 +15,9 @@ data class AssetEntity(
     val type: Int,
     val displayName: String,
     val modifiedDate: Long,
-    var orientation: Int,
-    var lat: Double? = null,
-    var lng: Double? = null,
+    val orientation: Int,
+    val lat: Double? = null,
+    val lng: Double? = null,
     val androidQRelativePath: String? = null,
     val mimeType: String? = null
 ) {
@@ -26,10 +26,9 @@ data class AssetEntity(
         MediaStoreUtils.convertTypeToMediaType(type)
     )
 
-    val relativePath: String?
-        get() = if (isAboveAndroidQ) {
-            androidQRelativePath
-        } else {
-            File(path).parent
-        }
+    val relativePath: String? = if (isAboveAndroidQ) {
+        androidQRelativePath
+    } else {
+        File(path).parent
+    }
 }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/CommonExt.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/CommonExt.kt
@@ -13,13 +13,3 @@ fun String.checkDirs() {
         targetFile.parentFile!!.mkdirs()
     }
 }
-
-fun InputStream.getOrientationDegrees(): Int {
-    return try {
-        this.use {
-            return@use ExifInterface(it).rotationDegrees
-        }
-    } catch (ignored: Throwable) {
-        0
-    }
-}

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -251,6 +251,7 @@ interface IDBUtils {
         context: Context,
         bytes: ByteArray,
         filename: String,
+        title: String,
         desc: String,
         relativePath: String,
         orientation: Int?
@@ -286,9 +287,9 @@ interface IDBUtils {
                 MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE
             )
             put(MediaStore.Images.ImageColumns.DESCRIPTION, desc)
-            put(DISPLAY_NAME, filename)
+            put(DISPLAY_NAME, title)
             put(MIME_TYPE, typeFromStream)
-            put(TITLE, filename)
+            put(TITLE, title)
             put(DATE_ADDED, timestamp)
             put(DATE_MODIFIED, timestamp)
             put(WIDTH, width)

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -395,21 +395,21 @@ interface IDBUtils {
 
     fun saveVideo(
         context: Context,
-        fromPath: String,
+        filePath: String,
         title: String,
         desc: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        fromPath.checkDirs()
-        val file = File(fromPath)
+        filePath.checkDirs()
+        val file = File(filePath)
         var inputStream = FileInputStream(file)
         fun refreshStream() {
             inputStream = FileInputStream(file)
         }
 
         val typeFromStream = URLConnection.guessContentTypeFromName(title)
-            ?: URLConnection.guessContentTypeFromName(fromPath)
+            ?: URLConnection.guessContentTypeFromName(filePath)
             ?: inputStream.let {
                 val type = URLConnection.guessContentTypeFromStream(inputStream)
                 refreshStream()
@@ -417,7 +417,7 @@ interface IDBUtils {
             }
             ?: "video/*"
 
-        val info = VideoUtils.getPropertiesUseMediaPlayer(fromPath)
+        val info = VideoUtils.getPropertiesUseMediaPlayer(filePath)
 
         val (rotationDegrees, latLong) = ExifInterface(inputStream).let { exif ->
             Pair(
@@ -459,7 +459,7 @@ interface IDBUtils {
                 put(MediaStore.Video.VideoColumns.LONGITUDE, latLong.last())
             }
             if (shouldKeepPath) {
-                put(DATA, fromPath)
+                put(DATA, filePath)
             }
         }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -5,7 +5,6 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
-import android.graphics.BitmapFactory
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
@@ -251,14 +250,22 @@ interface IDBUtils {
     fun saveImage(
         context: Context,
         bytes: ByteArray,
-        title: String,
+        filename: String,
         desc: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
         var inputStream = ByteArrayInputStream(bytes)
-        val typeFromStream: String = URLConnection.guessContentTypeFromName(title)
-            ?: URLConnection.guessContentTypeFromStream(inputStream)
+        fun refreshStream() {
+            inputStream = ByteArrayInputStream(bytes)
+        }
+
+        val typeFromStream: String = URLConnection.guessContentTypeFromName(filename)
+            ?: inputStream.let {
+                val type = URLConnection.guessContentTypeFromStream(inputStream)
+                refreshStream()
+                type
+            }
             ?: "image/*"
 
         val exif = ExifInterface(inputStream)
@@ -270,6 +277,7 @@ interface IDBUtils {
             orientation ?: if (isAboveAndroidQ) exif.rotationDegrees else 0,
             if (isAboveAndroidQ) null else exif.latLong
         )
+        refreshStream()
 
         val timestamp = System.currentTimeMillis() / 1000
         val values = ContentValues().apply {
@@ -278,9 +286,9 @@ interface IDBUtils {
                 MediaStore.Files.FileColumns.MEDIA_TYPE_IMAGE
             )
             put(MediaStore.Images.ImageColumns.DESCRIPTION, desc)
-            put(DISPLAY_NAME, title)
+            put(DISPLAY_NAME, filename)
             put(MIME_TYPE, typeFromStream)
-            put(TITLE, title)
+            put(TITLE, filename)
             put(DATE_ADDED, timestamp)
             put(DATE_MODIFIED, timestamp)
             put(WIDTH, width)
@@ -298,33 +306,36 @@ interface IDBUtils {
             }
         }
 
-        inputStream = ByteArrayInputStream(bytes)
-        val entity = insertUri(
+        return insertUri(
             context,
             inputStream,
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             values,
         )
-        entity?.let {
-            it.orientation = orientation ?: it.orientation
-        }
-        return entity
     }
 
     fun saveImage(
         context: Context,
-        fromPath: String,
+        filePath: String,
         title: String,
         desc: String,
         relativePath: String,
         orientation: Int?
     ): AssetEntity? {
-        fromPath.checkDirs()
-        val file = File(fromPath)
+        filePath.checkDirs()
+        val file = File(filePath)
         var inputStream = FileInputStream(file)
+        fun refreshStream() {
+            inputStream = FileInputStream(file)
+        }
+
         val typeFromStream: String = URLConnection.guessContentTypeFromName(title)
-            ?: URLConnection.guessContentTypeFromName(fromPath)
-            ?: URLConnection.guessContentTypeFromStream(inputStream)
+            ?: URLConnection.guessContentTypeFromName(filePath)
+            ?: inputStream.let {
+                val type = URLConnection.guessContentTypeFromStream(inputStream)
+                refreshStream()
+                type
+            }
             ?: "image/*"
 
         val exif = ExifInterface(inputStream)
@@ -336,6 +347,7 @@ interface IDBUtils {
             orientation ?: if (isAboveAndroidQ) exif.rotationDegrees else 0,
             if (isAboveAndroidQ) null else exif.latLong
         )
+        refreshStream()
 
         val shouldKeepPath = if (!isAboveAndroidQ) {
             val dir = Environment.getExternalStorageDirectory()
@@ -368,22 +380,17 @@ interface IDBUtils {
                 put(MediaStore.Images.ImageColumns.LONGITUDE, latLong.last())
             }
             if (shouldKeepPath) {
-                put(DATA, fromPath)
+                put(DATA, filePath)
             }
         }
 
-        inputStream = FileInputStream(file)
-        val entity = insertUri(
+        return insertUri(
             context,
             inputStream,
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             values,
             shouldKeepPath
         )
-        entity?.let {
-            it.orientation = orientation ?: it.orientation
-        }
-        return entity
     }
 
     fun saveVideo(
@@ -397,31 +404,35 @@ interface IDBUtils {
         fromPath.checkDirs()
         val file = File(fromPath)
         var inputStream = FileInputStream(file)
-        fun refreshInputStream() {
+        fun refreshStream() {
             inputStream = FileInputStream(file)
         }
 
-        val timestamp = System.currentTimeMillis() / 1000
-        val info = VideoUtils.getPropertiesUseMediaPlayer(fromPath)
         val typeFromStream = URLConnection.guessContentTypeFromName(title)
             ?: URLConnection.guessContentTypeFromName(fromPath)
+            ?: inputStream.let {
+                val type = URLConnection.guessContentTypeFromStream(inputStream)
+                refreshStream()
+                type
+            }
             ?: "video/*"
-        val (rotationDegrees, latLong) = try {
-            val exif = ExifInterface(inputStream)
+
+        val info = VideoUtils.getPropertiesUseMediaPlayer(fromPath)
+
+        val (rotationDegrees, latLong) = ExifInterface(inputStream).let { exif ->
             Pair(
                 orientation ?: if (isAboveAndroidQ) exif.rotationDegrees else 0,
                 if (isAboveAndroidQ) null else exif.latLong
             )
-        } catch (e: Exception) {
-            Pair(orientation ?: 0, null)
         }
-        refreshInputStream()
+        refreshStream()
 
         val shouldKeepPath = if (!isAboveAndroidQ) {
             val dir = Environment.getExternalStorageDirectory()
             file.absolutePath.startsWith(dir.path)
         } else false
 
+        val timestamp = System.currentTimeMillis() / 1000
         val values = ContentValues().apply {
             put(
                 MediaStore.Files.FileColumns.MEDIA_TYPE,
@@ -452,17 +463,13 @@ interface IDBUtils {
             }
         }
 
-        val entity = insertUri(
+        return insertUri(
             context,
             inputStream,
             MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
             values,
             shouldKeepPath
         )
-        entity?.let {
-            it.orientation = orientation ?: it.orientation
-        }
-        return entity
     }
 
     private fun insertUri(

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -311,7 +311,7 @@ interface IDBUtils {
             inputStream,
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             values,
-        )
+        )?.copy(orientation = orientation ?: rotationDegrees)
     }
 
     fun saveImage(
@@ -390,7 +390,7 @@ interface IDBUtils {
             MediaStore.Images.Media.EXTERNAL_CONTENT_URI,
             values,
             shouldKeepPath
-        )
+        )?.copy(orientation = orientation ?: rotationDegrees)
     }
 
     fun saveVideo(
@@ -469,7 +469,7 @@ interface IDBUtils {
             MediaStore.Video.Media.EXTERNAL_CONTENT_URI,
             values,
             shouldKeepPath
-        )
+        )?.copy(orientation = orientation ?: rotationDegrees)
     }
 
     private fun insertUri(

--- a/example/lib/page/developer/develop_index_page.dart
+++ b/example/lib/page/developer/develop_index_page.dart
@@ -262,7 +262,7 @@ class _DeveloperIndexPageState extends State<DeveloperIndexPage> {
       final assets = await PhotoManager.editor.darwin.saveLivePhoto(
         imageFile: imgFile,
         videoFile: videoFile,
-        title: 'preview_0',
+        filename: 'preview_0',
       );
       print('save live photo result : ${assets?.id}');
     } finally {

--- a/example/lib/page/save_image_example.dart
+++ b/example/lib/page/save_image_example.dart
@@ -195,7 +195,7 @@ class _SaveMediaExampleState extends State<SaveMediaExample> {
     await checkRequest(() async {
       final AssetEntity? asset = await PhotoManager.editor.saveImage(
         uint8List,
-        title: '${DateTime.now().millisecondsSinceEpoch}.jpg',
+        filename: '${DateTime.now().millisecondsSinceEpoch}.jpg',
       );
       Log.d('saved asset: $asset');
     });

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -446,11 +446,11 @@
     } else if ([call.method isEqualToString:@"saveLivePhoto"]) {
         NSString *videoPath = call.arguments[@"videoPath"];
         NSString *imagePath = call.arguments[@"imagePath"];
-        NSString *title = call.arguments[@"title"];
+        NSString *filename = call.arguments[@"filename"];
         NSString *desc = call.arguments[@"desc"];
         [manager saveLivePhoto:imagePath
                      videoPath:videoPath
-                         title:title
+                      filename:filename
                           desc:desc
                          block:^(PMAssetEntity *asset) {
                            if (!asset) {

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -417,10 +417,10 @@
                      }];
     } else if ([call.method isEqualToString:@"saveImageWithPath"]) {
         NSString *path = call.arguments[@"path"];
-        NSString *title = call.arguments[@"title"];
+        NSString *filename = call.arguments[@"title"];
         NSString *desc = call.arguments[@"desc"];
         [manager saveImageWithPath:path
-                             title:title
+                          filename:filename
                               desc:desc
                              block:^(PMAssetEntity *asset) {
                                if (!asset) {
@@ -431,10 +431,10 @@
                              }];
     } else if ([call.method isEqualToString:@"saveVideo"]) {
         NSString *videoPath = call.arguments[@"path"];
-        NSString *title = call.arguments[@"title"];
+        NSString *filename = call.arguments[@"title"];
         NSString *desc = call.arguments[@"desc"];
         [manager saveVideo:videoPath
-                     title:title
+                  filename:filename
                       desc:desc
                      block:^(PMAssetEntity *asset) {
                        if (!asset) {

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -403,10 +403,10 @@
                   }];
     } else if ([call.method isEqualToString:@"saveImage"]) {
         NSData *data = [call.arguments[@"image"] data];
-        NSString *title = call.arguments[@"title"];
+        NSString *filename = call.arguments[@"filename"];
         NSString *desc = call.arguments[@"desc"];
         [manager saveImage:data
-                     title:title
+                  filename:filename
                       desc:desc
                      block:^(PMAssetEntity *asset) {
                        if (!asset) {

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -53,18 +53,18 @@ typedef void (^AssetResult)(PMAssetEntity *);
 - (void)deleteWithIds:(NSArray<NSString *> *)ids changedBlock:(ChangeIds)block;
 
 - (void)saveImage:(NSData *)data
-            title:(NSString *)title
+         filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block;
 
 - (void)saveVideo:(NSString *)path
-            title:(NSString *)title
+         filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block;
 
 - (void)saveLivePhoto:(NSString *)imagePath
             videoPath:(NSString *)videoPath
-            title:(NSString *)title
+            filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block;
 

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -53,12 +53,12 @@ typedef void (^AssetResult)(PMAssetEntity *);
 - (void)deleteWithIds:(NSArray<NSString *> *)ids changedBlock:(ChangeIds)block;
 
 - (void)saveImage:(NSData *)data
-         filename:(NSString *)filename
+            filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block;
 
 - (void)saveVideo:(NSString *)path
-         filename:(NSString *)filename
+            filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block;
 

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -57,6 +57,11 @@ typedef void (^AssetResult)(PMAssetEntity *);
             desc:(NSString *)desc
             block:(AssetResult)block;
 
+- (void)saveImageWithPath:(NSString *)path
+            filename:(NSString *)filename
+            desc:(NSString *)desc
+            block:(void (^)(PMAssetEntity *))block;
+
 - (void)saveVideo:(NSString *)path
             filename:(NSString *)filename
             desc:(NSString *)desc
@@ -79,8 +84,6 @@ typedef void (^AssetResult)(PMAssetEntity *);
 - (void)getMediaUrl:(NSString *)assetId resultHandler:(NSObject <PMResultHandler> *)handler;
 
 - (NSArray<PMAssetPathEntity *> *)getSubPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(NSObject<PMBaseFilter> *)option;
-
-- (void)saveImageWithPath:(NSString *)path title:(NSString *)title desc:(NSString *)desc block:(void (^)(PMAssetEntity *))block;
 
 - (void)copyAssetWithId:(NSString *)id toGallery:(NSString *)gallery block:(void (^)(PMAssetEntity *entity, NSString *msg))block;
 

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -126,14 +126,14 @@
 - (NSArray<PMAssetEntity *> *)getAssetsWithType:(int)type option:(NSObject<PMBaseFilter> *)option start:(int)start end:(int)end {
     PHFetchOptions *options = [option getFetchOptions:type];
     PHFetchResult<PHAsset *> *result = [PHAsset fetchAssetsWithOptions:options];
-    
+
     NSUInteger endOffset = end;
     if (endOffset > result.count) {
         endOffset = result.count;
     }
-    
+
     NSMutableArray<PMAssetEntity*>* array = [NSMutableArray new];
-    
+
     for (NSUInteger i = start; i < endOffset; i++){
         if (i >= result.count) {
             break;
@@ -142,7 +142,7 @@
         PMAssetEntity *pmAsset = [self convertPHAssetToAssetEntity:asset needTitle:[option needTitle]];
         [array addObject: pmAsset];
     }
-    
+
     return array;
 }
 
@@ -1022,11 +1022,11 @@
 
 - (void)saveLivePhoto:(NSString *)imagePath
             videoPath:(NSString *)videoPath
-            title:(NSString *)title
+            filename:(NSString *)filename
             desc:(NSString *)desc
             block:(AssetResult)block {
-    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save LivePhoto with imagePath: %@, videoPath: %@, title: %@, desc %@",
-                                     imagePath, videoPath, title, desc]];
+    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save LivePhoto with imagePath: %@, videoPath: %@, filename: %@, desc %@",
+                                     imagePath, videoPath, filename, desc]];
     NSURL *videoURL = [NSURL fileURLWithPath:videoPath];
     NSURL *imageURL = [NSURL fileURLWithPath:imagePath];
     __block NSString *assetId = nil;
@@ -1034,7 +1034,7 @@
      performChanges:^{
         PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
         PHAssetResourceCreationOptions *options = [PHAssetResourceCreationOptions new];
-        [options setOriginalFilename:title];
+        [options setOriginalFilename:filename];
         [request addResourceWithType:PHAssetResourceTypePhoto fileURL:imageURL options:options];
         [request addResourceWithType:PHAssetResourceTypePairedVideo fileURL:videoURL options:options];
         assetId = request.placeholderForCreatedAsset.localIdentifier;

--- a/ios/Classes/core/PMManager.m
+++ b/ios/Classes/core/PMManager.m
@@ -934,11 +934,11 @@
 }
 
 - (void)saveImage:(NSData *)data
-            title:(NSString *)title
+         filename:(NSString *)filename
              desc:(NSString *)desc
             block:(AssetResult)block {
     __block NSString *assetId = nil;
-    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with data, length: %lu, title:%@, desc: %@", (unsigned long)data.length, title, desc]];
+    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with data, length: %lu, filename:%@, desc: %@", (unsigned long)data.length, filename, desc]];
 
     [[PHPhotoLibrary sharedPhotoLibrary]
      performChanges:^{
@@ -946,7 +946,7 @@
         [PHAssetCreationRequest creationRequestForAsset];
         PHAssetResourceCreationOptions *options =
         [PHAssetResourceCreationOptions new];
-        [options setOriginalFilename:title];
+        [options setOriginalFilename:filename];
         [request addResourceWithType:PHAssetResourceTypePhoto
                                 data:data
                              options:options];
@@ -963,8 +963,11 @@
     }];
 }
 
-- (void)saveImageWithPath:(NSString *)path title:(NSString *)title desc:(NSString *)desc block:(void (^)(PMAssetEntity *))block {
-    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with path: %@ title:%@, desc: %@", path, title, desc]];
+- (void)saveImageWithPath:(NSString *)path
+                 filename:(NSString *)filename
+                     desc:(NSString *)desc
+                    block:(void (^)(PMAssetEntity *))block {
+    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save image with path: %@ filename:%@, desc: %@", path, filename, desc]];
 
     __block NSString *assetId = nil;
     [[PHPhotoLibrary sharedPhotoLibrary]
@@ -973,7 +976,7 @@
         [PHAssetCreationRequest creationRequestForAsset];
         PHAssetResourceCreationOptions *options =
         [PHAssetResourceCreationOptions new];
-        [options setOriginalFilename:title];
+        [options setOriginalFilename:filename];
         NSData *data = [NSData dataWithContentsOfFile:path];
         [request addResourceWithType:PHAssetResourceTypePhoto
                                 data:data
@@ -992,18 +995,17 @@
 }
 
 - (void)saveVideo:(NSString *)path
-            title:(NSString *)title
+         filename:(NSString *)filename
              desc:(NSString *)desc
             block:(AssetResult)block {
-    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save video with path: %@, title: %@, desc %@",
-                                     path, title, desc]];
+    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"save video with path: %@, filename: %@, desc %@", path, filename, desc]];
     NSURL *fileURL = [NSURL fileURLWithPath:path];
     __block NSString *assetId = nil;
     [[PHPhotoLibrary sharedPhotoLibrary]
      performChanges:^{
         PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
         PHAssetResourceCreationOptions *options = [PHAssetResourceCreationOptions new];
-        [options setOriginalFilename:title];
+        [options setOriginalFilename:filename];
         [request addResourceWithType:PHAssetResourceTypeVideo fileURL:fileURL options:options];
         assetId = request.placeholderForCreatedAsset.localIdentifier;
     }

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -283,14 +283,14 @@ class DarwinEditor {
   Future<AssetEntity?> saveLivePhoto({
     required File imageFile,
     required File videoFile,
-    required String title,
+    required String filename,
     String? desc,
     String? relativePath,
   }) {
     return plugin.saveLivePhoto(
       imageFile: imageFile,
       videoFile: videoFile,
-      title: title,
+      filename: filename,
       desc: desc,
       relativePath: relativePath,
     );

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -51,8 +51,8 @@ class Editor {
   /// Save image to gallery from the given [data].
   ///
   /// {@template photo_manager.Editor.TitleWhenSaving}
-  /// [title] typically means the filename of the saving entity, which can be
-  /// obtained by `basename(file.path)`.
+  /// [filename] ([title]) typically means the filename of the saving entity,
+  /// which can be obtained by `basename(file.path)`.
   /// {@endtemplate}
   ///
   /// {@template photo_manager.Editor.DescriptionWhenSaving}
@@ -72,14 +72,14 @@ class Editor {
   /// {@endtemplate}
   Future<AssetEntity?> saveImage(
     typed_data.Uint8List data, {
-    required String title,
+    required String filename,
     String? desc,
     String? relativePath,
     int? orientation,
   }) {
     return plugin.saveImage(
       data,
-      title: title,
+      filename: filename,
       desc: desc,
       relativePath: relativePath,
       orientation: orientation,

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -53,7 +53,7 @@ class Editor {
   /// [filename] will be helpful to evaluate the MIME type from the [data].
   ///
   /// {@template photo_manager.Editor.TitleWhenSaving}
-  /// [title] is the title field that only works on Android.
+  /// [title] is the title field on Android, and the original filename on iOS.
   /// {@endtemplate}
   ///
   /// {@template photo_manager.Editor.DescriptionWhenSaving}

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -50,9 +50,10 @@ class Editor {
 
   /// Save image to gallery from the given [data].
   ///
+  /// [filename] will be helpful to evaluate the MIME type from the [data].
+  ///
   /// {@template photo_manager.Editor.TitleWhenSaving}
-  /// [filename] ([title]) typically means the filename of the saving entity,
-  /// which can be obtained by `basename(file.path)`.
+  /// [title] is the title field that only works on Android.
   /// {@endtemplate}
   ///
   /// {@template photo_manager.Editor.DescriptionWhenSaving}
@@ -73,6 +74,7 @@ class Editor {
   Future<AssetEntity?> saveImage(
     typed_data.Uint8List data, {
     required String filename,
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,
@@ -80,13 +82,14 @@ class Editor {
     return plugin.saveImage(
       data,
       filename: filename,
+      title: title,
       desc: desc,
       relativePath: relativePath,
       orientation: orientation,
     );
   }
 
-  /// Save image to gallery from the given [path].
+  /// Save image to gallery from the given [filePath].
   ///
   /// {@macro photo_manager.Editor.TitleWhenSaving}
   ///
@@ -96,14 +99,14 @@ class Editor {
   ///
   /// {@macro photo_manager.Editor.OrientationWhenSaving}
   Future<AssetEntity?> saveImageWithPath(
-    String path, {
-    required String title,
+    String filePath, {
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,
   }) {
     return plugin.saveImageWithPath(
-      path,
+      filePath,
       title: title,
       desc: desc,
       relativePath: relativePath,
@@ -122,7 +125,7 @@ class Editor {
   /// {@macro photo_manager.Editor.OrientationWhenSaving}
   Future<AssetEntity?> saveVideo(
     File file, {
-    required String title,
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -671,7 +671,7 @@ mixin IosPlugin on BasePlugin {
   Future<AssetEntity?> saveLivePhoto({
     required File imageFile,
     required File videoFile,
-    required String? title,
+    required String? filename,
     String? desc,
     String? relativePath,
   }) async {
@@ -687,13 +687,13 @@ mixin IosPlugin on BasePlugin {
       <String, dynamic>{
         'imagePath': imageFile.absolute.path,
         'videoPath': videoFile.absolute.path,
-        'title': title,
-        'desc': desc ?? '',
+        'filename': filename,
+        'desc': desc,
         'relativePath': relativePath,
         ...onlyAddPermission,
       },
     );
-    return ConvertUtils.convertMapToAsset(result.cast(), title: title);
+    return ConvertUtils.convertMapToAsset(result.cast(), title: filename);
   }
 
   Future<AssetPathEntity?> iosCreateAlbum(

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -347,7 +347,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
 
   Future<AssetEntity?> saveImage(
     typed_data.Uint8List data, {
-    required String? title,
+    required String? filename,
     String? desc,
     String? relativePath,
     int? orientation,
@@ -357,7 +357,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
       PMConstants.mSaveImage,
       <String, dynamic>{
         'image': data,
-        'title': title,
+        'filename': filename,
         'desc': desc ?? '',
         'relativePath': relativePath,
         'orientation': orientation,
@@ -369,7 +369,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     }
     return ConvertUtils.convertMapToAsset(
       result.cast<String, dynamic>(),
-      title: title,
+      title: filename,
     );
   }
 

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -347,7 +347,8 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
 
   Future<AssetEntity?> saveImage(
     typed_data.Uint8List data, {
-    required String? filename,
+    required String filename,
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,
@@ -358,7 +359,8 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
       <String, dynamic>{
         'image': data,
         'filename': filename,
-        'desc': desc ?? '',
+        'title': title,
+        'desc': desc,
         'relativePath': relativePath,
         'orientation': orientation,
         ...onlyAddPermission,
@@ -374,23 +376,23 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
   }
 
   Future<AssetEntity?> saveImageWithPath(
-    String path, {
-    required String title,
+    String filePath, {
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,
   }) async {
     _throwIfOrientationInvalid(orientation);
-    final File file = File(path);
+    final File file = File(filePath);
     if (!file.existsSync()) {
-      throw ArgumentError('$path does not exists');
+      throw ArgumentError('$filePath does not exists');
     }
     final Map<dynamic, dynamic>? result = await _channel.invokeMethod(
       PMConstants.mSaveImageWithPath,
       <String, dynamic>{
-        'path': path,
+        'path': file.absolute.path,
         'title': title,
-        'desc': desc ?? '',
+        'desc': desc,
         'relativePath': relativePath,
         'orientation': orientation,
         ...onlyAddPermission,
@@ -407,7 +409,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
 
   Future<AssetEntity?> saveVideo(
     File file, {
-    required String? title,
+    String? title,
     String? desc,
     String? relativePath,
     int? orientation,


### PR DESCRIPTION
The request reorg all input streams after each of its usages. This likely solves the EXIF problem that occasionally happens on devices, such as invalid orientation values. Also, to help with the `saveImage` success rate on Android, the `title` parameter has been changed to `filename`.