### PR TITLE
🐛 Fix export session file type with videos at the first time

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ To know more about breaking changes, see the [Migration Guide][].
 ### Improvements
 
 - Reuse files when saving images on Darwin.
+- Fix export session file type with videos at the first time on Darwin.
 
 ## 3.5.0
 

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -164,6 +164,11 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
               child: const Text('Get file'),
               onPressed: () => getFile(entity),
             ),
+            if (entity.type == AssetType.video || entity.isLivePhoto)
+              ElevatedButton(
+                child: const Text('Get MP4 file'),
+                onPressed: () => getFileWithMP4(entity),
+              ),
             ElevatedButton(
               child: const Text('Show detail page'),
               onPressed: () => routeToDetailPage(entity),
@@ -249,6 +254,15 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
 
   Future<void> getFile(AssetEntity entity) async {
     final file = await entity.file;
+    print(file);
+  }
+
+  Future<void> getFileWithMP4(AssetEntity entity) async {
+    final file = await entity.loadFile(
+      isOrigin: false,
+      withSubtype: true,
+      darwinFileType: PMDarwinAVFileType.mp4,
+    );
     print(file);
   }
 


### PR DESCRIPTION
When the video resource is read for the first time, it will fetch the resource and write corresponding files. But if the file type is specified, the previous code does not make an exportation but uses copying only, which results in incorrect video files.

The request fixes the issue, it also raises an error when the exported file's extension does not match with the target.