### PR TITLE
🐛 Fix no returned ids after successful deletion on Android API 29+

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerDeleteManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerDeleteManager.kt
@@ -25,6 +25,7 @@ class PhotoManagerDeleteManager(val context: Context, private var activity: Acti
     private var androidQDeleteRequestCode = 40070
     private val androidQUriMap = mutableMapOf<String, Uri?>()
     private val androidQSuccessIds = mutableListOf<String>()
+    private val androidQRemovedIds = mutableListOf<String>()
 
     @RequiresApi(Build.VERSION_CODES.Q)
     inner class AndroidQDeleteTask(
@@ -149,6 +150,7 @@ class PhotoManagerDeleteManager(val context: Context, private var activity: Acti
         androidQUriMap.clear()
         androidQUriMap.putAll(uris)
         androidQSuccessIds.clear()
+        androidQRemovedIds.clear()
         waitPermissionQueue.clear()
 
         for (entry in uris) {
@@ -156,6 +158,7 @@ class PhotoManagerDeleteManager(val context: Context, private var activity: Acti
             val id = entry.key
             try {
                 cr.delete(uri, null, null)
+                androidQRemovedIds.add(id)
             } catch (e: Exception) {
                 // request delete permission
                 if (e is RecoverableSecurityException) {
@@ -181,8 +184,9 @@ class PhotoManagerDeleteManager(val context: Context, private var activity: Acti
             }
         }
 
-        androidQHandler?.reply(androidQSuccessIds.toList())
+        androidQHandler?.reply(androidQSuccessIds.toList() + androidQRemovedIds.toList())
         androidQSuccessIds.clear()
+        androidQRemovedIds.clear()
         androidQHandler = null
     }
 


### PR DESCRIPTION
When the file is created by the application itself, the uri can be deleted successfully without causing a RecoverableSecurityException.

[Note]: I tried Android 13 and the same way can also delete files created by the application without triggering the dialog. Maybe developers can decide in the future whether to force the use of createDeleteRequest method. (optional)