### PR TITLE
🐛 Fix mediaLocation = true does not work on Android API 34

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate34.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate34.kt
@@ -32,7 +32,7 @@ class PermissionDelegate34 : PermissionDelegate() {
         requestType: Int,
         mediaLocation: Boolean
     ) {
-        if (havePermissions(context, requestType)) {
+        if (havePermissions(context, requestType) && (!mediaLocation || haveMediaLocation(context))) {
             permissionsUtils.permissionsListener?.onGranted(mutableListOf())
             return
         }


### PR DESCRIPTION
mediaLocation = true does not work when the app already has common permissions on Android API 34