### PR TITLE
🔥 Get rid of try catch when toggling favorite on Darwin

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,12 @@ To know more about breaking changes, see the [Migration Guide][].
 
 *None.*
 
+## 3.5.2
+
+### Improvements
+
+- Get rid of `@try` `@catch` when toggling favorite on Darwin.
+
 ## 3.5.1
 
 ### Improvements

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager_example
 description: Demonstrates how to use the photo_manager plugin.
-version: 3.5.1+34
+version: 3.5.2+35
 publish_to: none
 
 environment:

--- a/example_ohos/pubspec.yaml
+++ b/example_ohos/pubspec.yaml
@@ -1,6 +1,6 @@
 name: photo_manager_example_ohos
 description: Demonstrates how to use the photo_manager plugin.
-version: 3.5.1+34
+version: 3.5.2+35
 publish_to: none
 
 environment:

--- a/ios/Classes/PMPlugin.m
+++ b/ios/Classes/PMPlugin.m
@@ -613,12 +613,13 @@
     } else if ([@"favoriteAsset" isEqualToString:call.method]) {
         NSString *id = call.arguments[@"id"];
         BOOL favorite = [call.arguments[@"favorite"] boolValue];
-        @try {
-            BOOL favoriteResult = [manager favoriteWithId:id favorite:favorite];
-            [handler reply:@(favoriteResult)];
-        } @catch (NSObject *error) {
-            [handler replyError:error];
-        }
+        [manager favoriteWithId:id favorite:favorite block:^(BOOL result, NSObject *error) {
+            if (error) {
+                [handler replyError:error];
+            } else {
+                [handler reply:@(result)];
+            }
+        }];
     } else if ([@"requestCacheAssetsThumb" isEqualToString:call.method]) {
         NSArray *ids = call.arguments[@"ids"];
         PMThumbLoadOption *option = [PMThumbLoadOption optionDict:call.arguments[@"option"]];

--- a/ios/Classes/core/PMManager.h
+++ b/ios/Classes/core/PMManager.h
@@ -111,7 +111,7 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
 
 - (void)removeCollectionWithId:(NSString *)id type:(int)type block:(void (^)(NSObject *))block;
 
-- (BOOL)favoriteWithId:(NSString *)id favorite:(BOOL)favorite;
+- (void)favoriteWithId:(NSString *)id favorite:(BOOL)favorite block:(void (^)(BOOL result, NSObject *))block;
 
 - (void)clearFileCache;
 

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides album assets abstraction management APIs on Android, iOS, macOS, and OpenHarmony.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 3.5.1
+version: 3.5.2
 
 environment:
   sdk: ">=2.13.0 <4.0.0"


### PR DESCRIPTION
To avoid crashes on specific Xcode versions, typically Xcode 15.0.x.

Fixes https://github.com/fluttercandies/flutter_photo_manager/issues/1208