### PR TITLE
🐛 Fix request permissions for images and videos on Android API 33+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+### Fixes
+
+- Fix request permissions for images and videos on Android API 33+.
 
 ## 3.6.1
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+*None.*
+
+## 3.6.2
+
 ### Fixes
 
 - Fix request permissions for images and videos on Android API 33+.

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -806,10 +806,12 @@ rootProject.allprojects {
 就算你的 `targetSdkVersion` 和 `compileSdkVersion` 不是 `33`，
 你也需要在清单文件中添加以下权限配置：
 
+> 注意：`READ_MEDIA_IMAGES` 和 `READ_MEDIA_VIDEO` 无论在请求图片还是请求视频时都需要。
+
 ```xml
 <manifest>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> <!-- 如果需要读取图片 -->
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" /> <!-- 如果需要读取视频 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> <!-- 如果需要读取图片或视频 -->
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" /> <!-- 如果需要读取视频或图片 -->
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" /> <!-- 如果需要读取音频 -->
 </manifest>
 ```

--- a/README.md
+++ b/README.md
@@ -866,10 +866,12 @@ When running on Android 13 (API level 33),
 the following permissions needs to be added to the manifest
 even if your `targetSdkVersion` and `compileSdkVersion` is not `33`:
 
+> Note: `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` are both required whether requesting images or videos.
+
 ```xml
 <manifest>
-    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> <!-- If you want to read images-->
-    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" /> <!-- If you want to read videos-->
+    <uses-permission android:name="android.permission.READ_MEDIA_IMAGES" /> <!-- If you want to read images or videos-->
+    <uses-permission android:name="android.permission.READ_MEDIA_VIDEO" /> <!-- If you want to read videos or images-->
     <uses-permission android:name="android.permission.READ_MEDIA_AUDIO" /> <!-- If you want to read audio-->
 </manifest>
 ```

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate19.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate19.kt
@@ -3,9 +3,10 @@ package com.fluttercandies.photo_manager.permission.impl
 import android.app.Application
 import android.content.Context
 import com.fluttercandies.photo_manager.core.entity.PermissionResult
+import com.fluttercandies.photo_manager.permission.PermissionDelegate
 import com.fluttercandies.photo_manager.permission.PermissionsUtils
 
-class PermissionDelegate19 : com.fluttercandies.photo_manager.permission.PermissionDelegate() {
+class PermissionDelegate19 : PermissionDelegate() {
     override fun requestPermission(
         permissionsUtils: PermissionsUtils,
         context: Context,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate23.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate23.kt
@@ -5,11 +5,11 @@ import android.app.Application
 import android.content.Context
 import androidx.annotation.RequiresApi
 import com.fluttercandies.photo_manager.core.entity.PermissionResult
+import com.fluttercandies.photo_manager.permission.PermissionDelegate
 import com.fluttercandies.photo_manager.permission.PermissionsUtils
 
 @RequiresApi(23)
-open class PermissionDelegate23 : com.fluttercandies.photo_manager.permission.PermissionDelegate() {
-
+class PermissionDelegate23 : PermissionDelegate() {
     companion object {
         private const val readPermission = Manifest.permission.READ_EXTERNAL_STORAGE
         private const val writePermission = Manifest.permission.WRITE_EXTERNAL_STORAGE

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate33.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate33.kt
@@ -11,7 +11,6 @@ import com.fluttercandies.photo_manager.permission.PermissionsUtils
 
 @RequiresApi(33)
 class PermissionDelegate33 : PermissionDelegate() {
-
     companion object {
         private const val mediaVideo = Manifest.permission.READ_MEDIA_VIDEO
         private const val mediaImage = Manifest.permission.READ_MEDIA_IMAGES
@@ -26,24 +25,19 @@ class PermissionDelegate33 : PermissionDelegate() {
         requestType: Int,
         mediaLocation: Boolean
     ) {
-        val containsVideo = RequestTypeUtils.containsVideo(requestType)
-        val containsImage = RequestTypeUtils.containsImage(requestType)
-        val containsAudio = RequestTypeUtils.containsAudio(requestType)
-
         val permissions = mutableListOf<String>()
 
-        if (containsVideo) {
+        val containsImage = RequestTypeUtils.containsImage(requestType)
+        val containsVideo = RequestTypeUtils.containsVideo(requestType)
+        val containsAudio = RequestTypeUtils.containsAudio(requestType)
+
+        if (containsImage || containsVideo) {
+            permissions.add(mediaImage)
             permissions.add(mediaVideo)
         }
-
-        if (containsImage) {
-            permissions.add(mediaImage)
-        }
-
         if (containsAudio) {
             permissions.add(mediaAudio)
         }
-
         if (mediaLocation) {
             permissions.add(mediaLocationPermission)
         }
@@ -60,21 +54,19 @@ class PermissionDelegate33 : PermissionDelegate() {
         val containsImage = RequestTypeUtils.containsImage(requestType)
         val containsAudio = RequestTypeUtils.containsAudio(requestType)
 
-        var result = true
-
-        if (containsVideo) {
-            result = result && havePermission(context, mediaVideo)
-        }
+        var granted = true
 
         if (containsImage) {
-            result = result && havePermission(context, mediaImage)
+            granted = granted && havePermission(context, mediaImage)
         }
-
+        if (containsVideo) {
+            granted = granted && havePermission(context, mediaVideo)
+        }
         if (containsAudio) {
-            result = result && havePermission(context, mediaAudio)
+            granted = granted && havePermission(context, mediaAudio)
         }
 
-        return result
+        return granted
     }
 
     override fun haveMediaLocation(context: Context): Boolean {

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides album assets abstraction management APIs on Android, iOS, macOS, and OpenHarmony.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 3.6.1
+version: 3.6.2
 
 environment:
   sdk: ">=2.13.0 <4.0.0"


### PR DESCRIPTION
`READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` are both required whether requesting images or videos.