### PR TITLE
Fix the issue where album assets cannot be retrieved when selecting only and video or only and image conditions

### DIFF
--- a/ohos/src/main/ets/components/plugin/handlers/AlbumHandler.ets
+++ b/ohos/src/main/ets/components/plugin/handlers/AlbumHandler.ets
@@ -156,21 +156,18 @@ export class AlbumHandler extends HandlerBase implements MethodCallHandlerBase {
     if (!(await PermissionHandler.permissionReadCheck())) {
       return [];
     }
-    if (onlyAll) {
-      return [await AlbumHandler.getAllAlbum(RequestType.all)];
-    }
-
     let requestType: RequestType = new RequestType(args.get('type'));
-
-    if (!(requestType.containsImage() && requestType.containsVideo())) {
-      if (requestType.containsImage()) {
-        return [await AlbumHandler.getAllAlbum(RequestType.image)];
-      }
-      else if (requestType.containsVideo()) {
-        return [await AlbumHandler.getAllAlbum(RequestType.video)];
+    if (onlyAll || !(requestType.containsImage() && requestType.containsVideo())) {
+      if (!(requestType.containsImage() && requestType.containsVideo())) {
+        if (requestType.containsImage()) {
+          return [await AlbumHandler.getAllAlbum(RequestType.image)];
+        } else if (requestType.containsVideo()) {
+          return [await AlbumHandler.getAllAlbum(RequestType.video)];
+        }
+      } else {
+        return [await AlbumHandler.getAllAlbum(RequestType.all)];
       }
     }
-
     // hasAll 返回的列表里有一个代表所有的相册
     // onlyAll 只返回这个代表所有的相册
     // 在鸿蒙这边 这个相册 应该是 从 system 这个类型里面获取到的相册的集合


### PR DESCRIPTION
Fix the issue where album assets cannot be retrieved when selecting only and video or only and image
https://github.com/fluttercandies/flutter_photo_manager/issues/1230#issue-2685220253