### PR TITLE
fix: Fix `SizeConstraint` not working for videos on Android (修复Androi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+### Fixes
+
+- Fix `SizeConstraint` not working for videos on Android. (#1275)
 
 ## 3.6.4
 
@@ -669,27 +671,28 @@ and applied multiple ### Fixes which make this plugin as the most solid ever.
 
 ### Fixes
 
-- Fix `open` setting for macOS.
-- Fix `setLog` for iOS and macOS.
+- Delete assets in androidQ.
 
 ## 1.2.4
 
 ### Fixes
 
-- `saveImage` method missing file extension for the fallback title.
-- `openSettings` method.
+- Compatibility code, when the width and height of the video is empty, it can still be scanned.
+- Add a default value to `type` of `getAssetPathList`.
 
 ## 1.2.3
 
 ### Features
 
-- Add assets count change when notify on iOS.
-- Add some properties and methods for change notify.
+- Delete asset.
+- Add Image.
+- Add Video.
+- Add modifyDate property.
+- Fix videoDuration error.
 
 ### Fixes
 
-- Change notify issue on remove callback.
-- Reply result for `presentLimited` method.
+- CreateDate error.
 
 ## 1.2.2
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/filter/CommonFilterOption.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/filter/CommonFilterOption.kt
@@ -106,6 +106,14 @@ class CommonFilterOption(map: Map<*, *>) : FilterOption() {
             videoCondString = "$typeKey = ? AND $durationCond"
             args.add(MediaStore.Files.FileColumns.MEDIA_TYPE_VIDEO.toString())
             args.addAll(durationArgs)
+            
+            // 添加对视频的尺寸约束
+            if (!videoCond.sizeConstraint.ignoreSize) {
+                val sizeCond = videoCond.sizeCond()
+                val sizeArgs = videoCond.sizeArgs()
+                videoCondString = "$videoCondString AND $sizeCond"
+                args.addAll(sizeArgs)
+            }
         }
 
         if (haveAudio) {


### PR DESCRIPTION
…d视频尺寸约束失效)

- Fix `SizeConstraint` not working for videos on Android. (#1275) (修复了Android平台上视频的 `SizeConstraint` 不起作用的问题。(#1275))
- Add size constraint for video query (添加了视频查询的尺寸约束)
- Update video query logic to include size constraints (更新了视频查询逻辑以包含尺寸约束)
- Modified `CommonFilterOption.kt` (修改了 `CommonFilterOption.kt` 文件)