### PR TITLE
fix: Fix inconsistent thumbnail resizing on iOS (修复 iOS 缩略图尺寸不一致)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ To know more about breaking changes, see the [Migration Guide][].
 ### Fixes
 
 - Fix `SizeConstraint` not working for videos on Android. (#1275)
+- Fix inconsistent resizing behavior between iOS and Android in `thumbnailDataWithSize`. (#1271)
 
 ## 3.6.4
 

--- a/example/lib/page/developer/issues_page/issue_1271_demo.dart
+++ b/example/lib/page/developer/issues_page/issue_1271_demo.dart
@@ -1,0 +1,171 @@
+import 'dart:typed_data';
+
+import 'package:flutter/material.dart';
+import 'package:image/image.dart' as img;
+import 'package:photo_manager/photo_manager.dart';
+
+import 'issue_index_page.dart';
+
+/// 复现 issue 1271: iOS 和 Android 上 thumbnailDataWithSize 行为不一致
+/// 问题：同样的图片，使用 thumbnailDataWithSize 获取缩略图时：
+/// - Android 将最小边缩放到 200px（正确）
+/// - iOS 将最大边缩放到 200px（错误）
+class Issue1271DemoPage extends StatefulWidget {
+  const Issue1271DemoPage({super.key});
+
+  @override
+  State<Issue1271DemoPage> createState() => _Issue1271DemoPageState();
+}
+
+class _Issue1271DemoPageState extends State<Issue1271DemoPage>
+    with IssueBase<Issue1271DemoPage> {
+  AssetEntity? _asset;
+  Uint8List? _thumbData;
+  int? _thumbWidth;
+  int? _thumbHeight;
+  int? _originWidth;
+  int? _originHeight;
+  String _platformName = '';
+
+  @override
+  int get issueNumber => 1271;
+
+  @override
+  Widget build(BuildContext context) {
+    return buildScaffold([
+      buildButton('测试缩略图尺寸', _testThumbnailSize),
+      if (_asset != null) _buildResultWidget(),
+      buildLogWidget(),
+    ]);
+  }
+
+  Widget _buildResultWidget() {
+    return Column(
+      crossAxisAlignment: CrossAxisAlignment.start,
+      children: [
+        Text('平台: $_platformName'),
+        Text('原图尺寸: $_originWidth x $_originHeight'),
+        if (_thumbWidth != null && _thumbHeight != null)
+          Text('缩略图尺寸: $_thumbWidth x $_thumbHeight'),
+        const SizedBox(height: 8),
+        if (_thumbData != null)
+          SizedBox(
+            height: 150,
+            child: Image.memory(_thumbData!),
+          ),
+        const SizedBox(height: 8),
+        const Text('说明：'),
+        const Text(
+          '- 选择一张宽高比大于2:1的图片\n'
+          '- 使用 thumbnailDataWithSize(ThumbnailSize(200, 200)) 获取缩略图\n'
+          '- 预期：缩略图应保持原图宽高比，最小边为200\n'
+          '- 实际：Android 最小边为200，iOS 最大边为200',
+        ),
+      ],
+    );
+  }
+
+  Future<void> _testThumbnailSize() async {
+    addLog('开始测试缩略图尺寸...');
+
+    // 请求权限
+    final pmResult = await PhotoManager.requestPermissionExtend();
+    if (!pmResult.isAuth) {
+      addLog('没有相册权限！');
+      return;
+    }
+
+    // 获取相册列表
+    addLog('获取相册列表...');
+    final List<AssetPathEntity> paths = await PhotoManager.getAssetPathList(
+      type: RequestType.image,
+    );
+    if (paths.isEmpty) {
+      addLog('没有找到相册！');
+      return;
+    }
+
+    // 获取第一个相册的图片
+    addLog('获取相册图片...');
+    final List<AssetEntity> assets = await paths[0].getAssetListPaged(
+      page: 0,
+      size: 20,
+    );
+    if (assets.isEmpty) {
+      addLog('相册中没有图片！');
+      return;
+    }
+
+    // 查找宽高比大于2的图片
+    AssetEntity? targetAsset;
+    for (final asset in assets) {
+      final ratio = asset.width / asset.height;
+      if (ratio > 2 || ratio < 0.5) {
+        targetAsset = asset;
+        addLog('找到宽高比例为 ${ratio.toStringAsFixed(2)} 的图片');
+        break;
+      }
+    }
+
+    // 如果没找到宽高比大于2的图片，就用第一张
+    targetAsset ??= assets[0];
+    final originWidth = targetAsset.width;
+    final originHeight = targetAsset.height;
+    addLog('选择图片: $originWidth x $originHeight');
+
+    // 获取缩略图
+    addLog('获取缩略图 ThumbnailSize(200, 200)...');
+    final thumbData = await targetAsset.thumbnailDataWithSize(
+      const ThumbnailSize(200, 200),
+    );
+
+    if (thumbData == null) {
+      addLog('获取缩略图失败！');
+      return;
+    }
+
+    // 解码缩略图获取实际尺寸
+    final decodedImage = img.decodeImage(thumbData);
+    if (decodedImage == null) {
+      addLog('解码缩略图失败！');
+      return;
+    }
+
+    final thumbWidth = decodedImage.width;
+    final thumbHeight = decodedImage.height;
+    addLog('缩略图实际尺寸: $thumbWidth x $thumbHeight');
+
+    // 计算缩放比例
+    final widthRatio = thumbWidth / originWidth;
+    final heightRatio = thumbHeight / originHeight;
+    addLog('宽度缩放比例: ${widthRatio.toStringAsFixed(3)}');
+    addLog('高度缩放比例: ${heightRatio.toStringAsFixed(3)}');
+
+    // 判断是按最小边还是最大边缩放
+    if (originWidth > originHeight) {
+      // 横向图片
+      if ((thumbHeight - 200).abs() < 5) {
+        addLog('结论: 最小边(高)被缩放到接近200，符合预期');
+      } else if ((thumbWidth - 200).abs() < 5) {
+        addLog('结论: 最大边(宽)被缩放到接近200，不符合预期');
+      }
+    } else {
+      // 纵向图片
+      if ((thumbWidth - 200).abs() < 5) {
+        addLog('结论: 最小边(宽)被缩放到接近200，符合预期');
+      } else if ((thumbHeight - 200).abs() < 5) {
+        addLog('结论: 最大边(高)被缩放到接近200，不符合预期');
+      }
+    }
+
+    setState(() {
+      _asset = targetAsset;
+      _thumbData = thumbData;
+      _originWidth = originWidth;
+      _originHeight = originHeight;
+      _thumbWidth = thumbWidth;
+      _thumbHeight = thumbHeight;
+      _platformName = Theme.of(context).platform.toString();
+    });
+  }
+}

--- a/example/lib/page/developer/issues_page/issue_index_page.dart
+++ b/example/lib/page/developer/issues_page/issue_index_page.dart
@@ -12,6 +12,7 @@ import 'issue_1031.dart';
 import 'issue_1051.dart';
 import 'issue_1053.dart';
 import 'issue_1152.dart';
+import 'issue_1271_demo.dart';
 import 'issue_734.dart';
 import 'issue_918.dart';
 import 'issue_962.dart';
@@ -75,6 +76,7 @@ class IssuePage extends StatelessWidget {
             Issus1051(),
             Issus1053(),
             Issus1152(),
+            Issue1271DemoPage(),
           ],
         ),
       ),

--- a/example/macos/Runner/AppDelegate.swift
+++ b/example/macos/Runner/AppDelegate.swift
@@ -1,7 +1,7 @@
 import Cocoa
 import FlutterMacOS
 
-@NSApplicationMain
+@main
 class AppDelegate: FlutterAppDelegate {
   override func applicationShouldTerminateAfterLastWindowClosed(_ sender: NSApplication) -> Bool {
     return true

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -5,23 +5,31 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: "16e298750b6d0af7ce8a3ba7c18c69c3785d11b15ec83f6dcd0ad2a0009b3cab"
+      sha256: f256b0c0ba6c7577c15e2e4e114755640a875e885099367bf6e012b19314c834
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "76.0.0"
+    version: "72.0.0"
   _macros:
     dependency: transitive
     description: dart
     source: sdk
-    version: "0.3.3"
+    version: "0.3.2"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: "1f14db053a8c23e260789e9b0980fa27f2680dd640932cae5e1137cce0e46e1e"
+      sha256: b652861553cd3990d8ed361f7979dc6d7053a9ac8843fa73820ab68ce5410139
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.11.0"
+    version: "6.7.0"
+  archive:
+    dependency: transitive
+    description:
+      name: archive
+      sha256: "2fde1607386ab523f7a36bb3e7edb43bd58e6edaf2ffb29d8a6d578b297fdbbd"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.0.7"
   args:
     dependency: transitive
     description:
@@ -74,10 +82,10 @@ packages:
     dependency: transitive
     description:
       name: collection
-      sha256: a1ace0a119f20aabc852d165077c036cd864315bd99b7eaa10a60100341941bf
+      sha256: ee67cb0715911d28db6bf4af1026078bd6f0128b07a5f66fb2ed94ec6783c09a
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.19.0"
+    version: "1.18.0"
   convert:
     dependency: transitive
     description:
@@ -201,10 +209,18 @@ packages:
     dependency: transitive
     description:
       name: http_parser
-      sha256: "178d74305e7866013777bab2c3d8726205dc5a4dd935297175b19a23a2e66571"
+      sha256: "2aa08ce0341cc9b354a498388e30986515406668dbcc4f7c950c3e715496693b"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "4.1.2"
+    version: "4.0.2"
+  image:
+    dependency: "direct main"
+    description:
+      name: image
+      sha256: "4e973fcf4caae1a4be2fa0a13157aa38a8f9cb049db6529aa00b4d71abc4d928"
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "4.5.4"
   io:
     dependency: transitive
     description:
@@ -225,18 +241,18 @@ packages:
     dependency: transitive
     description:
       name: leak_tracker
-      sha256: "7bb2830ebd849694d1ec25bf1f44582d6ac531a57a365a803a6034ff751d2d06"
+      sha256: "3f87a60e8c63aecc975dda1ceedbc8f24de75f09e4856ea27daf8958f2f0ce05"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "10.0.7"
+    version: "10.0.5"
   leak_tracker_flutter_testing:
     dependency: transitive
     description:
       name: leak_tracker_flutter_testing
-      sha256: "9491a714cca3667b60b5c420da8217e6de0d1ba7a5ec322fab01758f6998f379"
+      sha256: "932549fb305594d82d7183ecd9fa93463e9914e1b67cacc34bc40906594a1806"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "3.0.8"
+    version: "3.0.5"
   leak_tracker_testing:
     dependency: transitive
     description:
@@ -249,10 +265,10 @@ packages:
     dependency: transitive
     description:
       name: lints
-      sha256: c35bb79562d980e9a453fc715854e1ed39e24e7d0297a880ef54e17f9874a9d7
+      sha256: "3315600f3fb3b135be672bf4a178c55f274bebe368325ae18462c89ac1e3b413"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "5.1.1"
+    version: "5.0.0"
   logging:
     dependency: transitive
     description:
@@ -265,10 +281,10 @@ packages:
     dependency: transitive
     description:
       name: macros
-      sha256: "1d9e801cd66f7ea3663c45fc708450db1fa57f988142c64289142c9b7ee80656"
+      sha256: "0acaed5d6b7eab89f63350bccd82119e6c602df0f391260d0e32b5e23db79536"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.1.3-main.0"
+    version: "0.1.2-main.4"
   matcher:
     dependency: transitive
     description:
@@ -353,10 +369,10 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "4adf4fd5423ec60a29506c76581bc05854c55e3a0b72d35bb28d661c9686edf2"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.15"
   path_provider_foundation:
     dependency: transitive
     description:
@@ -389,6 +405,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "2.3.0"
+  petitparser:
+    dependency: transitive
+    description:
+      name: petitparser
+      sha256: c15605cd28af66339f8eb6fbe0e541bfe2d1b72d5825efc6598f3e0a31b9ad27
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "6.0.2"
   photo_manager:
     dependency: "direct main"
     description:
@@ -428,6 +452,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.5.1"
+  posix:
+    dependency: transitive
+    description:
+      name: posix
+      sha256: f0d7856b6ca1887cfa6d1d394056a296ae33489db914e365e2044fdada449e62
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "6.0.2"
   provider:
     dependency: "direct main"
     description:
@@ -448,10 +480,10 @@ packages:
     dependency: transitive
     description:
       name: shelf
-      sha256: e7dd780a7ffb623c57850b33f43309312fc863fb6aa3d276a754bb299839ef12
+      sha256: ad29c505aee705f41a4d8963641f91ac4cee3c8fad5947e033390a7bd8180fa4
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.4.2"
+    version: "1.4.1"
   shelf_packages_handler:
     dependency: transitive
     description:
@@ -480,7 +512,7 @@ packages:
     dependency: transitive
     description: flutter
     source: sdk
-    version: "0.0.0"
+    version: "0.0.99"
   source_map_stack_trace:
     dependency: transitive
     description:
@@ -509,10 +541,10 @@ packages:
     dependency: transitive
     description:
       name: stack_trace
-      sha256: "9f47fd3630d76be3ab26f0ee06d213679aa425996925ff3feffdec504931c377"
+      sha256: "73713990125a6d93122541237550ee3352a2d84baad52d375a4cad2eb9b7ce0b"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.12.0"
+    version: "1.11.1"
   stream_channel:
     dependency: transitive
     description:
@@ -525,10 +557,10 @@ packages:
     dependency: transitive
     description:
       name: string_scanner
-      sha256: "688af5ed3402a4bde5b3a6c15fd768dbf2621a614950b17f04626c431ab3c4c3"
+      sha256: "556692adab6cfa87322a115640c11f13cb77b3f076ddcc5d6ae3c20242bedcde"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.3.0"
+    version: "1.2.0"
   term_glyph:
     dependency: transitive
     description:
@@ -541,26 +573,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "713a8789d62f3233c46b4a90b174737b2c04cb6ae4500f2aa8b1be8f03f5e67f"
+      sha256: "7ee44229615f8f642b68120165ae4c2a75fe77ae2065b1e55ae4711f6cf0899e"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "1.25.8"
+    version: "1.25.7"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "664d3a9a64782fcdeb83ce9c6b39e78fd2971d4e37827b9b06c3aa1edc5e760c"
+      sha256: "5b8a98dafc4d5c4c9c72d8b31ab2b23fc13422348d2997120294d3bac86b4ddb"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.7.3"
+    version: "0.7.2"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "12391302411737c176b0b5d6491f466b0dd56d4763e347b6714efbaa74d7953d"
+      sha256: "55ea5a652e38a1dfb32943a7973f3681a60f872f8c3a05a14664ad54ef9c6696"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "0.6.5"
+    version: "0.6.4"
   typed_data:
     dependency: transitive
     description:
@@ -581,10 +613,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_android
-      sha256: "8582d7f6fe14d2652b4c45c9b6c14c0b678c2af2d083a11b604caeba51930d79"
+      sha256: "6fc2f56536ee873eeb867ad176ae15f304ccccc357848b351f6f0d8d4a40d193"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "6.3.16"
+    version: "6.3.14"
   url_launcher_ios:
     dependency: transitive
     description:
@@ -621,10 +653,10 @@ packages:
     dependency: transitive
     description:
       name: url_launcher_web
-      sha256: "4bd2b7b4dc4d4d0b94e5babfffbca8eac1a126c7f3d6ecbc1a11013faa3abba2"
+      sha256: "772638d3b34c779ede05ba3d38af34657a05ac55b06279ea6edd409e323dca8e"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.4.1"
+    version: "2.3.3"
   url_launcher_windows:
     dependency: transitive
     description:
@@ -653,10 +685,10 @@ packages:
     dependency: transitive
     description:
       name: video_player_android
-      sha256: "1f4e8e0e02403452d699ef7cf73fe9936fac8f6f0605303d111d71acb375d1bc"
+      sha256: "391e092ba4abe2f93b3e625bd6b6a6ec7d7414279462c1c0ee42b5ab8d0a0898"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "2.8.3"
+    version: "2.7.16"
   video_player_avfoundation:
     dependency: transitive
     description:
@@ -685,10 +717,10 @@ packages:
     dependency: transitive
     description:
       name: vm_service
-      sha256: f6be3ed8bd01289b34d679c2b62226f63c0e69f9fd2e50a6b3c1c729a961041b
+      sha256: "5c5f338a667b4c644744b661f309fb8080bb94b18a7e91ef1dbd343bed00ed6d"
       url: "https://pub.flutter-io.cn"
     source: hosted
-    version: "14.3.0"
+    version: "14.2.5"
   watcher:
     dependency: transitive
     description:
@@ -737,6 +769,14 @@ packages:
       url: "https://pub.flutter-io.cn"
     source: hosted
     version: "1.1.0"
+  xml:
+    dependency: transitive
+    description:
+      name: xml
+      sha256: b015a8ad1c488f66851d762d3090a21c600e479dc75e68328c52774040cf9226
+      url: "https://pub.flutter-io.cn"
+    source: hosted
+    version: "6.5.0"
   yaml:
     dependency: transitive
     description:
@@ -746,5 +786,5 @@ packages:
     source: hosted
     version: "3.1.3"
 sdks:
-  dart: ">=3.6.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.5.0 <4.0.0"
+  flutter: ">=3.24.0"

--- a/example/pubspec.yaml
+++ b/example/pubspec.yaml
@@ -19,6 +19,7 @@ dependencies:
   provider: ^6.0.0
   url_launcher: ^6.1.10
   video_player: ^2.1.14
+  image: ^4.5.4
 
 dev_dependencies:
   flutter_lints: any

--- a/ios/Classes/core/PMThumbLoadOption.m
+++ b/ios/Classes/core/PMThumbLoadOption.m
@@ -69,7 +69,10 @@
             resizeContentMode = PHImageContentModeDefault;
             break;
         default:
-            resizeContentMode = PHImageContentModeAspectFit;
+            // 修改默认值为 PHImageContentModeAspectFill，使 iOS 行为与 Android 一致
+            // 原来是 PHImageContentModeAspectFit，这会将图片的最大边缩放到指定尺寸
+            // 现在改为 PHImageContentModeAspectFill，这会将图片的最小边缩放到指定尺寸
+            resizeContentMode = PHImageContentModeAspectFill;
             
     }
     option.contentMode = resizeContentMode;

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -642,6 +642,7 @@ class AssetEntity {
         size: size,
         format: format,
         quality: quality,
+        resizeContentMode: ResizeContentMode.fill,
       );
     } else {
       option = ThumbnailOption(


### PR DESCRIPTION
- Fix inconsistent resizing behavior between iOS and Android in `thumbnailDataWithSize`. (#1271) (修复 `thumbnailDataWithSize` 在 iOS 和 Android 上的尺寸调整行为不一致的问题)
- Add a demo page `issue_1271_demo.dart` to reproduce the issue (添加一个 demo 页面 `issue_1271_demo.dart` 来复现此问题)
- Modify the default value to `PHImageContentModeAspectFill` in `PMThumbLoadOption.m` to align iOS behavior with Android (在 `PMThumbLoadOption.m` 中修改默认值为 `PHImageContentModeAspectFill`，使 iOS 行为与 Android 一致)
- Set `resizeContentMode: ResizeContentMode.fill` in `AssetEntity.dart` (在 `AssetEntity.dart` 中设置 `resizeContentMode: ResizeContentMode.fill`)
- Upgrade `image` version to `4.5.4` (升级 `image` 版本到 `4.5.4`)
- Fix `example/macos/Runner/AppDelegate.swift` to use `@main` (修复 `example/macos/Runner/AppDelegate.swift` 使用 `@main`)