### PR TITLE
feat: Add includeHiddenAssets option (新增包含隐藏资源选项)

### DIFF
--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -232,6 +232,7 @@ class PhotoProvider extends ChangeNotifier {
       videoOption: filterOption,
       audioOption: filterOption,
       containsPathModified: containsPathModified,
+      // ignore: deprecated_member_use
       containsLivePhotos: containsLivePhotos,
       onlyLivePhotos: onlyLivePhotos,
       createTimeCond: createDtCond,

--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -56,6 +56,15 @@ class PhotoProvider extends ChangeNotifier {
     _onlyLivePhotos = value;
     notifyListeners();
   }
+  
+  bool _includeHiddenAssets = false;
+  
+  bool get includeHiddenAssets => _includeHiddenAssets;
+  
+  set includeHiddenAssets(bool value) {
+    _includeHiddenAssets = value;
+    notifyListeners();
+  }
 
   DateTime _startDt = DateTime(2005); // Default Before 8 years
 
@@ -191,13 +200,13 @@ class PhotoProvider extends ChangeNotifier {
   }
 
   FilterOptionGroup makeOption() {
-    final FilterOption option = FilterOption(
+    final FilterOption filterOption = FilterOption(
       sizeConstraint: SizeConstraint(
         minWidth: int.tryParse(minWidth) ?? 0,
         maxWidth: int.tryParse(maxWidth) ?? 100000,
         minHeight: int.tryParse(minHeight) ?? 0,
         maxHeight: int.tryParse(maxHeight) ?? 100000,
-        ignoreSize: ignoreSize,
+        ignoreSize: _ignoreSize,
       ),
       durationConstraint: DurationConstraint(
         min: minDuration,
@@ -211,15 +220,20 @@ class PhotoProvider extends ChangeNotifier {
       max: endDt,
     );
 
-    return FilterOptionGroup()
-      ..setOption(AssetType.video, option)
-      ..setOption(AssetType.image, option)
-      ..setOption(AssetType.audio, option)
-      ..createTimeCond = createDtCond
-      ..containsPathModified = _containsPathModified
-      // ignore: deprecated_member_use
-      ..containsLivePhotos = _containsLivePhotos
-      ..onlyLivePhotos = onlyLivePhotos;
+    final FilterOptionGroup optionGroup = FilterOptionGroup(
+      imageOption: filterOption,
+      videoOption: filterOption,
+      audioOption: filterOption,
+      containsPathModified: containsPathModified,
+      containsLivePhotos: containsLivePhotos,
+      onlyLivePhotos: onlyLivePhotos,
+      createTimeCond: createDtCond,
+    );
+    
+    // 设置 includeHiddenAssets 属性（iOS 平台特有）
+    optionGroup.includeHiddenAssets = includeHiddenAssets;
+    
+    return optionGroup;
   }
 
   Future<void> refreshAllGalleryProperties() async {

--- a/example/lib/model/photo_provider.dart
+++ b/example/lib/model/photo_provider.dart
@@ -56,11 +56,11 @@ class PhotoProvider extends ChangeNotifier {
     _onlyLivePhotos = value;
     notifyListeners();
   }
-  
+
   bool _includeHiddenAssets = false;
-  
+
   bool get includeHiddenAssets => _includeHiddenAssets;
-  
+
   set includeHiddenAssets(bool value) {
     _includeHiddenAssets = value;
     notifyListeners();
@@ -177,6 +177,13 @@ class PhotoProvider extends ChangeNotifier {
     containsPathModified = value;
   }
 
+  void changeIncludeHiddenAssets(bool? value) {
+    if (value == null) {
+      return;
+    }
+    includeHiddenAssets = value;
+  }
+
   void reset() {
     list.clear();
   }
@@ -228,11 +235,9 @@ class PhotoProvider extends ChangeNotifier {
       containsLivePhotos: containsLivePhotos,
       onlyLivePhotos: onlyLivePhotos,
       createTimeCond: createDtCond,
+      includeHiddenAssets: includeHiddenAssets, // iOS 平台特有
     );
-    
-    // 设置 includeHiddenAssets 属性（iOS 平台特有）
-    optionGroup.includeHiddenAssets = includeHiddenAssets;
-    
+
     return optionGroup;
   }
 

--- a/example/lib/page/custom_filter/include_hidden_test_page.dart
+++ b/example/lib/page/custom_filter/include_hidden_test_page.dart
@@ -1,0 +1,54 @@
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+class IncludeHiddenTestPage extends StatefulWidget {
+  const IncludeHiddenTestPage({super.key});
+
+  @override
+  State<IncludeHiddenTestPage> createState() => _IncludeHiddenTestPageState();
+}
+
+class _IncludeHiddenTestPageState extends State<IncludeHiddenTestPage> {
+  final List<String> _logs = [];
+
+  Future<void> _test() async {
+    final option = CustomFilter.sql(where: '');
+    final count = await PhotoManager.getAssetCount(filterOption: option);
+
+    setState(() {
+      _logs.add('Not include hidden count: $count');
+    });
+
+    final option2 = CustomFilter.sql(where: '');
+    option2.includeHiddenAssets = true;
+    final count2 = await PhotoManager.getAssetCount(filterOption: option2);
+
+    setState(() {
+      _logs.add('Include hidden count: $count2');
+    });
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(
+        title: const Text('Include Hidden Test'),
+      ),
+      body: Column(
+        children: [
+          ElevatedButton(
+            onPressed: _test,
+            child: const Text('Test the count of hidden and not hidden'),
+          ),
+          Expanded(
+            child: ListView(
+              children: [
+                ..._logs.reversed.map((e) => ListTile(title: Text(e))),
+              ],
+            ),
+          ),
+        ],
+      ),
+    );
+  }
+}

--- a/example/lib/page/custom_filter_example_page.dart
+++ b/example/lib/page/custom_filter_example_page.dart
@@ -1,3 +1,5 @@
+import 'dart:io';
+
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager_example/page/custom_filter/path_list.dart';
@@ -6,6 +8,7 @@ import 'custom_filter/advance_filter_page.dart';
 import 'custom_filter/custom_filter_sql_gif_image.dart';
 import 'custom_filter/custom_filter_sql_page.dart';
 import 'custom_filter/filter_assets_page.dart';
+import 'custom_filter/include_hidden_test_page.dart';
 
 class CustomFilterExamplePage extends StatelessWidget {
   const CustomFilterExamplePage({super.key});
@@ -69,6 +72,11 @@ class CustomFilterExamplePage extends StatelessWidget {
                 },
               ),
             ),
+            if (Platform.isIOS || Platform.isMacOS)
+              buildItem(
+                'Include hidden test',
+                const IncludeHiddenTestPage(),
+              ),
           ],
         ),
       ),

--- a/example/lib/page/filter_option_page.dart
+++ b/example/lib/page/filter_option_page.dart
@@ -205,9 +205,9 @@ class _FilterOptionPageState extends State<FilterOptionPage> {
       },
     );
   }
-  
+
   /// 构建包含隐藏资源的复选框
-  /// 
+  ///
   /// 此选项仅在 iOS 平台上有效
   Widget buildIncludeHiddenAssetsCheck(PhotoProvider provider) {
     return AnimatedBuilder(

--- a/example/lib/page/filter_option_page.dart
+++ b/example/lib/page/filter_option_page.dart
@@ -34,6 +34,7 @@ class _FilterOptionPageState extends State<FilterOptionPage> {
           }),
           buildIgnoreSize(provider),
           buildNeedTitleCheck(provider),
+          buildIncludeHiddenAssetsCheck(provider),
           buildDurationWidget(
             provider,
             'minDuration',
@@ -201,6 +202,27 @@ class _FilterOptionPageState extends State<FilterOptionPage> {
       value: provider.asc,
       onChanged: (bool? value) {
         provider.asc = value;
+      },
+    );
+  }
+  
+  /// 构建包含隐藏资源的复选框
+  /// 
+  /// 此选项仅在 iOS 平台上有效
+  Widget buildIncludeHiddenAssetsCheck(PhotoProvider provider) {
+    return AnimatedBuilder(
+      animation: provider,
+      builder: (BuildContext context, Widget? snapshot) {
+        return CheckboxListTile(
+          title: const Text('Include hidden assets (iOS only)'),
+          subtitle: const Text('包含隐藏的资源（仅 iOS 平台有效）'),
+          onChanged: (bool? value) {
+            if (value != null) {
+              provider.includeHiddenAssets = value;
+            }
+          },
+          value: provider.includeHiddenAssets,
+        );
       },
     );
   }

--- a/example/lib/page/home_page.dart
+++ b/example/lib/page/home_page.dart
@@ -64,6 +64,8 @@ class _NewHomePageState extends State<NewHomePage> {
             _buildContainsLivePhotos(),
             _buildOnlyLivePhotos(),
             _buildPathContainsModifiedDateCheck(),
+            if (Platform.isIOS || Platform.isMacOS)
+              _buildIncludeHiddenAssetsCheck(),
             _buildPngCheck(),
             _buildNotifyCheck(),
             _buildFilterOption(watchProvider),
@@ -210,7 +212,17 @@ class _NewHomePageState extends State<NewHomePage> {
       onChanged: (bool? value) {
         readProvider.changeContainsPathModified(value);
       },
-      title: const Text('contains path modified date'),
+      title: const Text('Contains path modified date'),
+    );
+  }
+
+  Widget _buildIncludeHiddenAssetsCheck() {
+    return CheckboxListTile(
+      value: watchProvider.includeHiddenAssets,
+      onChanged: (bool? value) {
+        readProvider.changeIncludeHiddenAssets(value);
+      },
+      title: const Text('Include hidden assets'),
     );
   }
 

--- a/ios/Classes/core/PMConvertUtils.m
+++ b/ios/Classes/core/PMConvertUtils.m
@@ -133,6 +133,7 @@
         container.containsModified = [map[@"containsPathModified"] boolValue];
         container.containsLivePhotos = [map[@"containsLivePhotos"] boolValue];
         container.onlyLivePhotos = [map[@"onlyLivePhotos"] boolValue];
+        container.includeHiddenAssets = [map[@"includeHiddenAssets"] boolValue];
         
         NSArray *sortArray = map[@"orders"];
         [container injectSortArray:sortArray];

--- a/ios/Classes/core/PMFilterOption.h
+++ b/ios/Classes/core/PMFilterOption.h
@@ -58,6 +58,7 @@ typedef struct PMDurationConstraint {
 @property(nonatomic, assign) BOOL containsLivePhotos;
 @property(nonatomic, assign) BOOL onlyLivePhotos;
 @property(nonatomic, assign) BOOL containsModified;
+@property(nonatomic, assign) BOOL includeHiddenAssets;
 @property(nonatomic, strong) NSArray<NSSortDescriptor *> *sortArray;
 
 - (NSArray<NSSortDescriptor *> *)sortCond;

--- a/ios/Classes/core/PMFilterOption.m
+++ b/ios/Classes/core/PMFilterOption.m
@@ -52,6 +52,9 @@
 
     PHFetchOptions *options = [PHFetchOptions new];
     options.sortDescriptors = [optionGroup sortCond];
+    
+    // 获取 includeHiddenAssets 属性
+    options.includeHiddenAssets = optionGroup.includeHiddenAssets;
 
     NSMutableString *cond = [NSMutableString new];
     NSMutableArray *args = [NSMutableArray new];
@@ -255,6 +258,9 @@
 
 - (PHFetchOptions *)getFetchOptions:(int)type {
     PHFetchOptions *options = [PHFetchOptions new];
+    
+    // 从 params 中获取 includeHiddenAssets 属性
+    options.includeHiddenAssets = self.params[@"includeHiddenAssets"] ? [self.params[@"includeHiddenAssets"] boolValue] : NO;
 
     BOOL containsImage = [PMRequestTypeUtils containsImage:type];
     BOOL containsVideo = [PMRequestTypeUtils containsVideo:type];

--- a/lib/src/filter/base_filter.dart
+++ b/lib/src/filter/base_filter.dart
@@ -60,9 +60,9 @@ abstract class PMFilter {
   bool containsPathModified = false;
 
   /// Whether to include hidden assets in the results.
-  /// 
+  ///
   /// This option only takes effect on iOS.
-  /// 
+  ///
   /// See also:
   ///  * [PHFetchOptions.includeHiddenAssets](https://developer.apple.com/documentation/photos/phfetchoptions/includehiddenassets).
   bool includeHiddenAssets = false;

--- a/lib/src/filter/base_filter.dart
+++ b/lib/src/filter/base_filter.dart
@@ -62,6 +62,9 @@ abstract class PMFilter {
   /// Whether to include hidden assets in the results.
   ///
   /// This option only takes effect on iOS.
+  /// Beginning with iOS 16, users can require authentication to view the
+  /// hidden album, and the user setting is true by default. When true,
+  /// the system doesn’t return hidden assets even if the option is true.
   ///
   /// See also:
   ///  * [PHFetchOptions.includeHiddenAssets](https://developer.apple.com/documentation/photos/phfetchoptions/includehiddenassets).

--- a/lib/src/filter/base_filter.dart
+++ b/lib/src/filter/base_filter.dart
@@ -38,6 +38,7 @@ abstract class PMFilter {
   /// Construct a default filter.
   factory PMFilter.defaultValue({
     bool containsPathModified = false,
+    bool includeHiddenAssets = false,
   }) {
     return CustomFilter.sql(
       where: '',
@@ -57,6 +58,14 @@ abstract class PMFilter {
   /// See also:
   ///  * [AssetPathEntity.lastModified].
   bool containsPathModified = false;
+
+  /// Whether to include hidden assets in the results.
+  /// 
+  /// This option only takes effect on iOS.
+  /// 
+  /// See also:
+  ///  * [PHFetchOptions.includeHiddenAssets](https://developer.apple.com/documentation/photos/phfetchoptions/includehiddenassets).
+  bool includeHiddenAssets = false;
 
   /// The type of the filter.
   BaseFilterType get type;
@@ -83,6 +92,7 @@ abstract class PMFilter {
   Map<String, dynamic> _paramMap() {
     return <String, dynamic>{
       'containsPathModified': containsPathModified,
+      'includeHiddenAssets': includeHiddenAssets,
     };
   }
 }

--- a/lib/src/filter/classical/filter_option_group.dart
+++ b/lib/src/filter/classical/filter_option_group.dart
@@ -47,8 +47,10 @@ class FilterOptionGroup extends PMFilter {
     DateTimeCond? createTimeCond,
     DateTimeCond? updateTimeCond,
     List<OrderOption> orders = const <OrderOption>[],
+    bool includeHiddenAssets = false,
   }) {
     super.containsPathModified = containsPathModified;
+    super.includeHiddenAssets = includeHiddenAssets;
     _map[AssetType.image] = imageOption;
     _map[AssetType.video] = videoOption;
     _map[AssetType.audio] = audioOption;
@@ -140,6 +142,7 @@ class FilterOptionGroup extends PMFilter {
     }
     containsPathModified = other.containsPathModified;
     containsLivePhotos = other.containsLivePhotos;
+    includeHiddenAssets = other.includeHiddenAssets;
     onlyLivePhotos = other.onlyLivePhotos;
     createTimeCond = other.createTimeCond;
     updateTimeCond = other.updateTimeCond;
@@ -197,6 +200,7 @@ class FilterOptionGroup extends PMFilter {
     FilterOption? videoOption,
     FilterOption? audioOption,
     bool? containsPathModified,
+    bool? includeHiddenAssets,
     @Deprecated(
       'The option will be enabled by default. '
       'This will be removed in v4.0.0',
@@ -216,12 +220,14 @@ class FilterOptionGroup extends PMFilter {
     createTimeCond ??= this.createTimeCond;
     updateTimeCond ??= this.updateTimeCond;
     orders ??= this.orders;
+    includeHiddenAssets ??= this.includeHiddenAssets;
 
     final FilterOptionGroup result = FilterOptionGroup()
       ..setOption(AssetType.image, imageOption!)
       ..setOption(AssetType.video, videoOption!)
       ..setOption(AssetType.audio, audioOption!)
       ..containsPathModified = containsPathModified
+      ..includeHiddenAssets = includeHiddenAssets
       ..containsLivePhotos = containsLivePhotos
       ..onlyLivePhotos = onlyLivePhotos
       ..createTimeCond = createTimeCond


### PR DESCRIPTION
- Add `includeHiddenAssets` property to `FilterOptionGroup` and `PMFilter` classes. (在 `FilterOptionGroup` 和 `PMFilter` 类中添加 `includeHiddenAssets` 属性。)
- Add `includeHiddenAssets` checkbox to `FilterOptionPage` to control the visibility of hidden assets on iOS. (在 `FilterOptionPage` 中添加 `includeHiddenAssets` 复选框，用于控制 iOS 上隐藏资源的可见性。)
- Create `IncludeHiddenTestPage` to test the count of hidden and non-hidden assets. (创建 `IncludeHiddenTestPage` 页面，用于测试 隐藏和非隐藏资源的计数。)
- Modify `PMConvertUtils.m` and `PMFilterOption.m` to handle the `includeHiddenAssets` option on iOS. (修改 `PMConvertUtils.m` 和 `PMFilterOption.m` 以处理 iOS 上的 `includeHiddenAssets` 选项。)
- Update example app to include the new test page in `CustomFilterExamplePage`. (更新示例应用程序，在 `CustomFilterExamplePage` 中包含新的测试页面。)