### PR TITLE
feat: Fetch assets by specific type within an album

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -125,6 +125,7 @@ class _SimpleExamplePageState extends State<_SimpleExamplePage> {
     final List<AssetEntity> entities = await _path!.getAssetListPaged(
       page: 0,
       size: _sizePerPage,
+      type: RequestType.common, // Switch to .video or .image to filter album assets by format
     );
     if (!mounted) {
       return;
@@ -140,6 +141,7 @@ class _SimpleExamplePageState extends State<_SimpleExamplePage> {
     final List<AssetEntity> entities = await _path!.getAssetListPaged(
       page: _page + 1,
       size: _sizePerPage,
+      type: RequestType.common,  // Switch to .video or .image to filter album assets by format
     );
     if (!mounted) {
       return;

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -195,6 +195,7 @@ class AssetPathEntity {
   Future<List<AssetEntity>> getAssetListPaged({
     required int page,
     required int size,
+    RequestType? type, // allow overriding the album type per call
   }) {
     assert(albumType == 1, 'Only album can request for assets.');
     assert(size > 0, 'Page size must be greater than 0.');
@@ -202,7 +203,7 @@ class AssetPathEntity {
       id,
       page: page,
       size: size,
-      type: type,
+      type: type ?? RequestType.common, // use album type by default
       optionGroup: filterOption,
     );
   }

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -1,7 +1,7 @@
 name: photo_manager
 description: A Flutter plugin that provides album assets abstraction management APIs on Android, iOS, macOS, and OpenHarmony.
 repository: https://github.com/fluttercandies/flutter_photo_manager
-version: 3.7.1
+version: 3.7.2
 
 environment:
   sdk: ">=2.13.0 <4.0.0"


### PR DESCRIPTION
**Background & Need**
- The GitHub issue ”[Filter Resource By Type] How to use `RequestType` to filter inside a specific album? #1257” confirms the lack of this feature.
- Currently, developers can specify a `RequestType` globally, but not when fetching assets from a specific album.

**Proposed Enhancement:**
- Add an optional `RequestType`? `requestType` parameter to album-scoped methods like `getAssetListPaged`.
- If `requestType` is provided, pass it to native code; otherwise, fallback to `RequestType.common`.

**[entity.dart]**
- Allow overriding album type per call, enabling filtering for a specific asset type within an album.

**[PMManager.m]**
- Enforce type filtering. A change to native code is required only for the iOS platform.

**[main.dart]**
- Add `type` parameter to `getAssetListPaged()` for testing the new feature.

**[pubspec.yaml]**
- Bump build number.