### PR TITLE
feat: Implement `isFavorite` for Android R+

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/PhotoManagerPlugin.kt
@@ -84,6 +84,7 @@ class PhotoManagerPlugin : FlutterPlugin, ActivityAware {
         binding.addRequestPermissionsResultListener(listener)
         plugin?.let {
             binding.addActivityResultListener(it.deleteManager)
+            binding.addActivityResultListener(it.favoriteManager)
         }
     }
 
@@ -93,6 +94,7 @@ class PhotoManagerPlugin : FlutterPlugin, ActivityAware {
         }
         plugin?.let { p ->
             oldBinding.removeActivityResultListener(p.deleteManager)
+            oldBinding.removeActivityResultListener(p.favoriteManager)
         }
     }
 }

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -81,6 +81,7 @@ class Methods {
         const val saveImage = "saveImage"
         const val saveImageWithPath = "saveImageWithPath"
         const val saveVideo = "saveVideo"
+        const val favoriteAsset = "favoriteAsset"
         const val copyAsset = "copyAsset"
         const val moveAssetToPath = "moveAssetToPath"
         const val removeNoExistsAssets = "removeNoExistsAssets"

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -1,12 +1,9 @@
 package com.fluttercandies.photo_manager.core
 
-import android.app.Activity
-import android.app.RecoverableSecurityException
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
-import android.provider.MediaStore
 import android.util.Log
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.FutureTarget

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -1,9 +1,12 @@
 package com.fluttercandies.photo_manager.core
 
+import android.app.Activity
+import android.app.RecoverableSecurityException
 import android.content.Context
 import android.graphics.Bitmap
 import android.net.Uri
 import android.os.Build
+import android.provider.MediaStore
 import android.util.Log
 import com.bumptech.glide.Glide
 import com.bumptech.glide.request.FutureTarget

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerFavoriteManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerFavoriteManager.kt
@@ -1,0 +1,59 @@
+package com.fluttercandies.photo_manager.core
+
+import android.app.Activity
+import android.content.ContentResolver
+import android.content.Context
+import android.content.Intent
+import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import androidx.annotation.RequiresApi
+import com.fluttercandies.photo_manager.util.ResultHandler
+import io.flutter.plugin.common.PluginRegistry
+
+class PhotoManagerFavoriteManager(val context: Context) :
+    PluginRegistry.ActivityResultListener {
+
+    var activity: Activity? = null
+
+    fun bindActivity(activity: Activity?) {
+        this.activity = activity
+    }
+
+    private val requestCode = 40071
+
+    private var resultHandler: ResultHandler? = null
+
+    private val cr: ContentResolver
+        get() = context.contentResolver
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    fun favoriteAsset(assetUri: Uri, isFavorite: Boolean, resultHandler: ResultHandler) {
+        this.resultHandler = resultHandler
+
+        val pi = MediaStore.createFavoriteRequest(
+            context.contentResolver,
+            setOf(assetUri), isFavorite
+        )
+        activity?.startIntentSenderForResult(
+            pi.intentSender,
+            requestCode,
+            null,
+            0,
+            0,
+            0
+        )
+    }
+
+
+    override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
+        if (requestCode != this.requestCode)
+            return false
+
+        resultHandler?.reply(resultCode == Activity.RESULT_OK)
+        resultHandler = null
+        return true
+
+    }
+
+}

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -1,7 +1,6 @@
 package com.fluttercandies.photo_manager.core
 
 import android.app.Activity
-import android.app.RecoverableSecurityException
 import android.content.Context
 import android.net.Uri
 import android.os.Build

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
@@ -16,6 +16,7 @@ data class AssetEntity(
     val displayName: String,
     val modifiedDate: Long,
     val orientation: Int,
+    val isFavorite: Boolean = false,
     val lat: Double? = null,
     val lng: Double? = null,
     val androidQRelativePath: String? = null,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
@@ -50,6 +50,7 @@ object ConvertUtils {
             "width" to entity.width,
             "height" to entity.height,
             "orientation" to entity.orientation,
+            "is_favorite" to entity.isFavorite,
             "modifiedDt" to entity.modifiedDate,
             "lat" to entity.lat,
             "lng" to entity.lng,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -19,6 +19,7 @@ import android.provider.MediaStore.MediaColumns.DATE_TAKEN
 import android.provider.MediaStore.MediaColumns.DISPLAY_NAME
 import android.provider.MediaStore.MediaColumns.DURATION
 import android.provider.MediaStore.MediaColumns.HEIGHT
+import android.provider.MediaStore.MediaColumns.IS_FAVORITE
 import android.provider.MediaStore.MediaColumns.MIME_TYPE
 import android.provider.MediaStore.MediaColumns.ORIENTATION
 import android.provider.MediaStore.MediaColumns.RELATIVE_PATH
@@ -27,6 +28,7 @@ import android.provider.MediaStore.MediaColumns.WIDTH
 import android.provider.MediaStore.MediaColumns._ID
 import android.provider.MediaStore.VOLUME_EXTERNAL
 import androidx.annotation.ChecksSdkIntAtLeast
+import androidx.annotation.RequiresApi
 import androidx.exifinterface.media.ExifInterface
 import com.fluttercandies.photo_manager.core.PhotoManager
 import com.fluttercandies.photo_manager.core.entity.AssetEntity
@@ -61,6 +63,7 @@ interface IDBUtils {
             DATE_TAKEN //日期
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) add(IS_FAVORITE)
         }
 
         val storeVideoKeys = mutableListOf(
@@ -79,6 +82,7 @@ interface IDBUtils {
             DURATION //时长
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) add(IS_FAVORITE)
         }
 
         val typeKeys = arrayOf(
@@ -199,6 +203,7 @@ interface IDBUtils {
         val displayName = getString(DISPLAY_NAME)
         val modifiedDate = getLong(DATE_MODIFIED)
         var orientation: Int = getInt(ORIENTATION)
+        val isFavorite = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && getInt(IS_FAVORITE) == 1
         val relativePath: String? = if (isAboveAndroidQ) {
             getString(RELATIVE_PATH)
         } else null
@@ -240,6 +245,7 @@ interface IDBUtils {
             displayName,
             modifiedDate,
             orientation,
+            isFavorite,
             androidQRelativePath = relativePath,
             mimeType = mimeType
         )

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -15,7 +15,6 @@ import '../util/log.dart';
 import '../widget/dialog/list_dialog.dart';
 import '../widget/image_item_widget.dart';
 import '../widget/loading_widget.dart';
-
 import 'copy_to_another_gallery_example.dart';
 import 'detail_page.dart';
 import 'move_to_another_gallery_example.dart';
@@ -207,36 +206,40 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
                 <int>[500, 600, 700, 1000, 1500, 2000],
               ),
             ),
-            if (Platform.isIOS || Platform.isMacOS || PlatformUtils.isOhos)
-              ElevatedButton(
-                child: const Text('Toggle isFavorite'),
-                onPressed: () async {
-                  final bool isFavorite = entity.isFavorite;
-                  print('Current isFavorite: $isFavorite');
-                  if (PlatformUtils.isOhos) {
-                    await PhotoManager.editor.ohos.favoriteAsset(
-                      entity: entity,
-                      favorite: !isFavorite,
-                    );
-                  } else {
-                    await PhotoManager.editor.darwin.favoriteAsset(
-                      entity: entity,
-                      favorite: !isFavorite,
-                    );
-                  }
-                  final AssetEntity? newEntity =
-                      await entity.obtainForNewProperties();
-                  print('New isFavorite: ${newEntity?.isFavorite}');
-                  if (!mounted) {
-                    return;
-                  }
-                  if (newEntity != null) {
-                    entity = newEntity;
-                    readPathProvider(context).list[index] = newEntity;
-                    setState(() {});
-                  }
-                },
-              ),
+            ElevatedButton(
+              child: const Text('Toggle isFavorite'),
+              onPressed: () async {
+                final bool isFavorite = entity.isFavorite;
+                print('Current isFavorite: $isFavorite');
+                if (PlatformUtils.isOhos) {
+                  await PhotoManager.editor.ohos.favoriteAsset(
+                    entity: entity,
+                    favorite: !isFavorite,
+                  );
+                } else if (Platform.isAndroid) {
+                  await PhotoManager.editor.android.favoriteAsset(
+                    entity: entity,
+                    favorite: !isFavorite,
+                  );
+                } else {
+                  await PhotoManager.editor.darwin.favoriteAsset(
+                    entity: entity,
+                    favorite: !isFavorite,
+                  );
+                }
+                final AssetEntity? newEntity =
+                    await entity.obtainForNewProperties();
+                print('New isFavorite: ${newEntity?.isFavorite}');
+                if (!mounted) {
+                  return;
+                }
+                if (newEntity != null) {
+                  entity = newEntity;
+                  readPathProvider(context).list[index] = newEntity;
+                  setState(() {});
+                }
+              },
+            ),
             if ((Platform.isIOS || Platform.isMacOS) && entity.isLivePhoto)
               ElevatedButton(
                 onPressed: () {

--- a/example/lib/util/common_util.dart
+++ b/example/lib/util/common_util.dart
@@ -49,6 +49,7 @@ class CommonUtil {
               _buildInfoItemAsync('title', entity.titleAsync),
               _buildInfoItem('lat', lat.toString()),
               _buildInfoItem('lng', lng.toString()),
+              _buildInfoItem('is favorite', entity.isFavorite.toString()),
               _buildInfoItem('relative path', entity.relativePath ?? 'null'),
               _buildInfoItemAsync('mimeType', entity.mimeTypeAsync),
             ],

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -259,12 +259,19 @@ class DarwinEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns `true` if the operation was successful; otherwise, `false`.
-  Future<bool> favoriteAsset({
+  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
+  Future<AssetEntity> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
-    return plugin.favoriteAsset(entity.id, favorite);
+    final bool result = await plugin.favoriteAsset(entity.id, favorite);
+    if (result) {
+      return entity.copyWith(isFavorite: favorite);
+    }
+    throw StateError(
+      'Failed to favorite the asset '
+      '${entity.id} for unknown reason',
+    );
   }
 
   /// Save Live Photo to the gallery from the given [imageFile] and [videoFile].
@@ -300,12 +307,19 @@ class AndroidEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns `true` if the operation was successful; otherwise, `false`.
-  Future<bool> favoriteAsset({
+  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
+  Future<AssetEntity> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
-    return plugin.favoriteAsset(entity.id, favorite);
+    final bool result = await plugin.favoriteAsset(entity.id, favorite);
+    if (result) {
+      return entity.copyWith(isFavorite: favorite);
+    }
+    throw StateError(
+      'Failed to favorite the asset '
+      '${entity.id} for unknown reason',
+    );
   }
 
   /// Moves the given [entity] to the specified [target] path.
@@ -344,11 +358,18 @@ class OhosEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns `true` if the operation was successful; otherwise, `false`.
-  Future<bool> favoriteAsset({
+  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
+  Future<AssetEntity> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
-    return plugin.favoriteAsset(entity.id, favorite);
+    final bool result = await plugin.favoriteAsset(entity.id, favorite);
+    if (result) {
+      return entity.copyWith(isFavorite: favorite);
+    }
+    throw StateError(
+      'Failed to favorite the asset '
+      '${entity.id} for unknown reason',
+    );
   }
 }

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -307,7 +307,7 @@ class AndroidEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
+  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, throws a state error to indicate the failure.
   Future<AssetEntity> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -259,19 +259,12 @@ class DarwinEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
-  Future<AssetEntity> favoriteAsset({
+  /// Returns `true` if the operation was successful; otherwise, `false`.
+  Future<bool> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
-    final bool result = await plugin.favoriteAsset(entity.id, favorite);
-    if (result) {
-      return entity.copyWith(isFavorite: favorite);
-    }
-    throw StateError(
-      'Failed to favorite the asset '
-      '${entity.id} for unknown reason',
-    );
+    return plugin.favoriteAsset(entity.id, favorite);
   }
 
   /// Save Live Photo to the gallery from the given [imageFile] and [videoFile].
@@ -304,6 +297,16 @@ class DarwinEditor {
 class AndroidEditor {
   /// Creates a new [AndroidEditor] object.
   const AndroidEditor();
+
+  /// Sets the favorite status of the given [entity].
+  ///
+  /// Returns `true` if the operation was successful; otherwise, `false`.
+  Future<bool> favoriteAsset({
+    required AssetEntity entity,
+    required bool favorite,
+  }) async {
+    return plugin.favoriteAsset(entity.id, favorite);
+  }
 
   /// Moves the given [entity] to the specified [target] path.
   ///
@@ -341,18 +344,11 @@ class OhosEditor {
 
   /// Sets the favorite status of the given [entity].
   ///
-  /// Returns the updated [AssetEntity] if the operation was successful; otherwise, `null`.
-  Future<AssetEntity> favoriteAsset({
+  /// Returns `true` if the operation was successful; otherwise, `false`.
+  Future<bool> favoriteAsset({
     required AssetEntity entity,
     required bool favorite,
   }) async {
-    final bool result = await plugin.favoriteAsset(entity.id, favorite);
-    if (result) {
-      return entity.copyWith(isFavorite: favorite);
-    }
-    throw StateError(
-      'Failed to favorite the asset '
-      '${entity.id} for unknown reason',
-    );
+    return plugin.favoriteAsset(entity.id, favorite);
   }
 }

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -852,11 +852,13 @@ class AssetEntity {
   final int orientation;
 
   /// Whether the asset is favorite on the device.
-  ///  * Android: Always false.
+  ///  * Android 11 and above: `MediaStore.MediaColumns.IS_FAVORITE`.
+  ///  * Android 10 and below: Always false.
   ///  * iOS/macOS: `PHAsset.isFavorite`.
   ///
   /// See also:
   ///  * [DarwinEditor.favoriteAsset] to update the favorite status.
+  ///  * [AndroidEditor.favoriteAsset] to update the favorite status.
   final bool isFavorite;
 
   /// The relative path abstraction of the asset.

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -7,6 +7,7 @@ import 'dart:io';
 import 'package:photo_manager/platform_utils.dart';
 
 import '../filter/base_filter.dart';
+import '../filter/custom/custom_columns.dart';
 import '../filter/path_filter.dart';
 import '../internal/enums.dart';
 import '../types/entity.dart';
@@ -115,7 +116,7 @@ class ConvertUtils {
       height: data['height'] as int,
       duration: data['duration'] as int? ?? 0,
       orientation: data['orientation'] as int? ?? 0,
-      isFavorite: data['favorite'] as bool? ?? false,
+      isFavorite: data[CustomColumns.base.isFavorite] as bool? ?? false,
       title: data['title'] as String? ?? title,
       subtype: data['subtype'] as int? ?? 0,
       createDateSecond: data['createDt'] as int?,


### PR DESCRIPTION
## Description:
This PR implements the AssetEntity.isFavorite property for Android 11 (R) and above.

## Changes:

* Introduces a `PhotoManagerFavoriteManager` class to handle the new MediaStore.MediaColumns.IS_FAVORITE column.

* Populates the `isFavorite` property by querying the IS_FAVORITE value from the MediaStore. For Android 10 and below, it is always false as before.

* Updates the example project with a functional "Toggle isFavorite" button to demonstrate the feature.


CLOSES: #1311 