### PR TITLE
Feat: (iOS and macOS) Add interface to get hasAdjustments property and base adjustment files

### DIFF
--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -355,6 +355,8 @@
     if ([method isEqualToString:@"getAssetListPaged"] ||
         [method isEqualToString:@"getAssetListRange"] ||
         [method isEqualToString:@"getFullFile"] ||
+        [method isEqualToString:@"getAdjustmentBaseFile"] ||
+        [method isEqualToString:@"getAdjustmentBaseLivePhotoFile"] ||
         [method isEqualToString:@"getMediaUrl"] ||
         [method isEqualToString:@"fetchEntityProperties"]) {
         return QOS_CLASS_USER_INITIATED;
@@ -461,6 +463,24 @@
         [manager getFullSizeFileWithId:assetId
                               isOrigin:isOrigin
                                subtype:subtype
+                              fileType:fileType
+                         resultHandler:handler
+                       progressHandler:progressHandler];
+    } else if ([call.method isEqualToString:@"getAdjustmentBaseFile"]) {
+        NSString *assetId = call.arguments[@"id"];
+        int subtype = [call.arguments[@"subtype"] intValue];
+        AVFileType fileType = [PMConvertUtils convertNumberToAVFileType:[call.arguments[@"darwinFileType"] intValue]];
+        PMProgressHandler *progressHandler = [self getProgressHandlerFromDict:call.arguments];
+        [manager getAdjustmentBaseFileWithId:assetId
+                               subtype:subtype
+                              fileType:fileType
+                         resultHandler:handler
+                       progressHandler:progressHandler];
+    } else if ([call.method isEqualToString:@"getAdjustmentBaseLivePhotoFile"]) {
+        NSString *assetId = call.arguments[@"id"];
+        AVFileType fileType = [PMConvertUtils convertNumberToAVFileType:[call.arguments[@"darwinFileType"] intValue]];
+        PMProgressHandler *progressHandler = [self getProgressHandlerFromDict:call.arguments];
+        [manager getAdjustmentBaseLivePhotosFileWithId:assetId
                               fileType:fileType
                          resultHandler:handler
                        progressHandler:progressHandler];
@@ -609,6 +629,10 @@
         NSString *assetId = call.arguments[@"id"];
         NSString *mimeType = [manager getMimeTypeAsyncWithAssetId:assetId];
         [handler reply:mimeType];
+    } else if ([call.method isEqualToString:@"getHasAdjustmentsAsync"]) {
+        NSString *assetId = call.arguments[@"id"];
+        BOOL hasAdjustments = [manager getHasAdjustmentsAsyncWithAssetId:assetId];
+        [handler reply:@(hasAdjustments)];
     } else if ([@"getMediaUrl" isEqualToString:call.method]) {
         PMProgressHandler *progressHandler = [self getProgressHandlerFromDict:call.arguments];
         [manager getMediaUrl:call.arguments[@"id"]

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -28,8 +28,10 @@ NS_ASSUME_NONNULL_BEGIN
  */
 - (nullable NSString*)mimeType;
 - (PHAssetResource *)getCurrentResource;
+- (PHAssetResource *)getAdjustmentBaseResource;
 - (void)requestCurrentResourceData:(void (^)(NSData *_Nullable result))block;
 - (PHAssetResource *)getLivePhotosResource;
+- (PHAssetResource *)getAdjustmentBaseLivePhotosResource;
 
 @end
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
@@ -55,6 +55,17 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
                 resultHandler:(PMResultHandler *)handler
               progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;
 
+- (void)getAdjustmentBaseFileWithId:(NSString *)assetId
+                      subtype:(int)subtype
+                     fileType:(AVFileType)fileType
+                resultHandler:(PMResultHandler *)handler
+              progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;
+
+- (void)getAdjustmentBaseLivePhotosFileWithId:(NSString *)assetId
+                     fileType:(AVFileType)fileType
+                resultHandler:(PMResultHandler *)handler
+              progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;              
+
 - (PMAssetPathEntity *)fetchPathProperties:(NSString *)id type:(int)type filterOption:(NSObject<PMBaseFilter> *)filterOption;
 
 - (void)deleteWithIds:(NSArray<NSString *> *)ids changedBlock:(ChangeIds)block;
@@ -107,6 +118,7 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
                              fileType:(AVFileType)fileType;
 
 - (NSString*)getMimeTypeAsyncWithAssetId: (NSString *) assetId;
+- (BOOL)getHasAdjustmentsAsyncWithAssetId: (NSString *) assetId;
 
 - (void)getMediaUrl:(NSString *)assetId
       resultHandler:(PMResultHandler *)handler

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -27,6 +27,8 @@ class PMConstants {
   static const String mGetThumb = 'getThumb';
   static const String mGetOriginBytes = 'getOriginBytes';
   static const String mGetFullFile = 'getFullFile';
+  static const String mGetAdjustmentBaseFile = 'getAdjustmentBaseFile';
+  static const String mGetAdjustmentBaseLivePhotoFile = 'getAdjustmentBaseLivePhotoFile';
   static const String mReleaseMemoryCache = 'releaseMemoryCache';
   static const String mLog = 'log';
   static const String mOpenSetting = 'openSetting';
@@ -43,6 +45,7 @@ class PMConstants {
   static const String mGetLatLngAndroidQ = 'getLatLngAndroidQ';
   static const String mGetTitleAsync = 'getTitleAsync';
   static const String mGetMimeTypeAsync = 'getMimeTypeAsync';
+  static const String mGetHasAdjustmentsAsync = 'getHasAdjustmentsAsync';
   static const String mGetMediaUrl = 'getMediaUrl';
   static const String mGetSubPath = 'getSubPath';
   static const String mCopyAsset = 'copyAsset';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -325,6 +325,39 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     return _channel.invokeMethod(PMConstants.mGetFullFile, params);
   }
 
+  Future<String?> getAdjustmentBaseFile(
+    String id, {
+    PMProgressHandler? progressHandler,
+    int subtype = 0,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+    final params = <String, dynamic>{
+      'id': id,
+      'subtype': subtype,
+      'darwinFileType': darwinFileType?.value ?? 0,
+    };
+    _injectProgressHandlerParams(params, progressHandler);
+    _setCancelToken(params, cancelToken);
+    return _channel.invokeMethod(PMConstants.mGetAdjustmentBaseFile, params);
+  }
+
+    Future<String?> getAdjustmentBaseLivePhotoFile(
+    String id, {
+    PMProgressHandler? progressHandler,
+    int subtype = 0,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+    final params = <String, dynamic>{
+      'id': id,
+      'darwinFileType': darwinFileType?.value ?? 0,
+    };
+    _injectProgressHandlerParams(params, progressHandler);
+    _setCancelToken(params, cancelToken);
+    return _channel.invokeMethod(PMConstants.mGetAdjustmentBaseLivePhotoFile, params);
+  }
+
   Future<void> setLog(bool isLog) {
     return _channel.invokeMethod(PMConstants.mLog, isLog);
   }
@@ -683,6 +716,18 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     }
     return null;
   }
+
+  Future<bool> getHasAdjustmentsAsync(AssetEntity entity) async {    
+    if (Platform.isIOS || Platform.isMacOS) {
+      return await _channel.invokeMethod(
+        PMConstants.mGetHasAdjustmentsAsync,
+        <String, dynamic>{'id': entity.id},
+      );          
+    }
+
+    return false;
+  }
+
 
   Future<int> getAssetCount({
     PMFilter? filterOption,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -851,6 +851,68 @@ class AssetEntity {
     return file?.readAsBytes();
   }
 
+  /// Obtain the 'adjustment base' of the asset.
+  /// This is the unaltered version of the asset before any edits were applied.
+  ///  * Android: Always null.
+  ///  * iOS/macOS: `PHAssetResource` with type:
+  ///  * TypeAdjustmentBasePhoto || TypePhoto
+  ///  * TypeAdjustmentBaseVideo || TypeVideo
+  Future<File?> getAdjustmentBaseFile({
+    PMProgressHandler? progressHandler,
+    int subtype = 0,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+
+    if (Platform.operatingSystem != 'ios' &&
+        Platform.operatingSystem != 'macos') {
+      return null;
+    }
+    
+    final String? path = await plugin.getAdjustmentBaseFile(
+      id,
+      progressHandler: progressHandler,
+      subtype: subtype,
+      darwinFileType: darwinFileType,
+      cancelToken: cancelToken,
+    );
+    if (path == null) {
+      return null;
+    }
+    return File(path);
+  }
+
+  /// Obtain the 'adjustment base' of the live photo video paired with the asset.
+  /// This is the unaltered version of the live photo video before any edits were applied.
+  ///  * Android: Always null.
+  ///  * iOS/macOS: `PHAssetResource` with type:
+  ///  * TypeAdjustmentBasePairedVideo || TypePairedVideo
+  Future<File?> getAdjustmentBaseLivePhotoFile({
+    PMProgressHandler? progressHandler,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+
+    if (Platform.operatingSystem != 'ios' &&
+        Platform.operatingSystem != 'macos') {
+      return null;
+    }
+
+    final String? path = await plugin.getAdjustmentBaseLivePhotoFile(
+      id,
+      progressHandler: progressHandler,
+      darwinFileType: darwinFileType,
+      cancelToken: cancelToken,
+    );
+    if (path == null) {
+      return null;
+    }
+    return File(path);
+  }
+  
+  Future<File?> get adjustmentBaseFile => getAdjustmentBaseFile();
+  Future<File?> get adjustmentBaseLivePhotoFile => getAdjustmentBaseLivePhotoFile();  
+
   /// The orientation of the asset.
   ///  * Android: `MediaStore.MediaColumns.ORIENTATION`,
   ///    could be 0, 90, 180, 270.
@@ -896,6 +958,16 @@ class AssetEntity {
   ///  * [mimeType] which is the synchronized getter of the MIME type.
   ///  * https://developer.apple.com/library/archive/documentation/FileManagement/Conceptual/understanding_utis/understand_utis_conc/understand_utis_conc.html#//apple_ref/doc/uid/TP40001319-CH202-SW1
   Future<String?> get mimeTypeAsync => plugin.getMimeTypeAsync(this);
+
+
+  /// Whether the asset contains adjustment data (i.e. when the asset is edited).
+  ///  * Android: Always false.
+  ///  * iOS/macOS: `PHAsset.hasAdjustments`.
+  ///
+  /// See also:
+  ///  * https://developer.apple.com/documentation/photos/phasset/hasadjustments
+  ///  * https://developer.apple.com/documentation/photos/phadjustmentdata
+  Future<bool> get hasAdjustmentsAsync => plugin.getHasAdjustmentsAsync(this);
 
   AssetEntity copyWith({
     String? id,


### PR DESCRIPTION
**Summary**
Apple has the hasAdjustments property to indicate whether the asset contains adjustment data.
Base adjustment files are unaltered versions of the asset before any edits were applied. 

**Partially solves**
https://github.com/fluttercandies/flutter_photo_manager/issues/1070
Now able to get the 'original version' of files. Getting AAE sidecar would be a similar implementation but have left out for now.

**Motivation**
https://github.com/immich-app/immich/discussions/4750
https://github.com/immich-app/immich/issues/5818
Wanted ability to also upload the unedited image.

**Things to note**
PHAsset.hasAdjustments is only available on iOS and macOS 15.0+. Because this library targets 14.0, there is fallback implementation. The fallback implementation is very inefficient and could cause performance issues.

**References**
[PHAssetResourceType](https://developer.apple.com/documentation/photos/phassetresourcetype)
[PHAsset.hasAdjustments](https://developer.apple.com/documentation/photos/phasset/hasadjustments)