### PR TITLE
chore(ci): bump Dart to 3.10

### DIFF
--- a/.github/workflows/issue-triage.yml
+++ b/.github/workflows/issue-triage.yml
@@ -16,13 +16,14 @@ jobs:
   triage-issues:
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           repository: fluttercandies/triage_bot_for_flutter_photo_manager
       - uses: dart-lang/setup-dart@v1
+        with:
+          sdk: '3.10'
       - run: dart pub get
         working-directory: pkgs/issue_triage_bot
-
       # Delay 2 minutes to allow a grace period between opening or transferring
       # an issue and assigning a label.
       - name: sleep 2m


### PR DESCRIPTION
Lock Dart version range: https://github.com/fluttercandies/triage_bot_for_flutter_photo_manager/blob/main/pkgs/issue_triage_bot/pubspec.yaml