### PR TITLE
Refactor getSortOrder in IDBUtils.kt to ensure valid SQL query construction by providing a default ORDER BY clause when no filter option is specified.

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -38,7 +38,7 @@ object DBUtils : IDBUtils {
 
         var selection: String = "${MediaStore.MediaColumns.BUCKET_ID} IS NOT NULL"
         if (where != null) {
-            selection += "$selection $where"
+            selection += " $where"
         }
         selection += ") GROUP BY (${MediaStore.MediaColumns.BUCKET_ID}"
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -520,16 +520,13 @@ interface IDBUtils {
 
     // Nullable for implementations.
     fun getSortOrder(start: Int, pageSize: Int, filterOption: FilterOption?): String? {
-        val builder = StringBuilder()
-        if (filterOption != null) {
-            val orderBy = filterOption.orderByCondString()
-            if (orderBy != null) {
-                builder.append(orderBy)
-                builder.append(" ")
-            }
-        }
-        builder.append("LIMIT $pageSize OFFSET $start")
-        return builder.toString()
+        // MediaStore expects an ORDER BY before LIMIT/OFFSET. When no filter option is
+        // provided we need a deterministic default or Android will generate an invalid
+        // query such as `ORDER BY LIMIT 30 OFFSET 0`.
+        val orderBy = filterOption?.orderByCondString()
+            ?: "${MediaStore.MediaColumns.DATE_ADDED} DESC, ${MediaStore.MediaColumns.DATE_MODIFIED} DESC"
+
+        return "$orderBy LIMIT $pageSize OFFSET $start"
     }
 
     fun copyToGallery(context: Context, assetId: String, galleryId: String): AssetEntity


### PR DESCRIPTION
Tested with Xiaomi Mi Mix 2

### Fix Android album query SQL ( DBUtils#getAssetPathList )

* Previously, the selection string was concatenated without a separating space/parenthesis, generating invalid SQL like `BUCKET_ID IS NOT NULLbucket_id IS NOT NULL … GROUP BY`. On stricter OEM MediaStore implementations this caused SQLiteException: no such column: NULLbucket_id when loading albums.
* Updated to build the selection as `BUCKET_ID IS NOT NULL` plus the filter clause, with proper spacing and grouping, eliminating the malformed column token.

### Ensure valid sort clause for paging ( IDBUtils#getSortOrder )

* When no explicit order was provided, the plugin emitted `ORDER BY LIMIT … OFFSET …`, which is invalid SQL and produced `near "LIMIT": syntax error` on some devices when paging assets.
* Added a default order (`DATE_ADDED DESC, DATE_MODIFIED DESC`) before `LIMIT/OFFSET`, so paging queries are syntactically correct across devices.

