### PR TITLE
feat: add fileSize property to AssetEntity

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+**Features**
+
+- Add `fileSize` property to `AssetEntity` — returns the file size in bytes read from platform metadata, without downloading files from iCloud or other cloud storage. Supported on iOS/macOS (via `PHAssetResource`), Android (via `MediaStore.MediaColumns.SIZE`), and OHOS.
+
 **Fixes**
 
 - Fix the `AssetEntity.duration` API docs to clarify that audio and video durations are returned in seconds across supported platforms, preserving the existing API behavior.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+**Features**
+
+- Add `fileSize` property to `AssetEntity` — returns the file size in bytes read from platform metadata, without downloading files from iCloud or other cloud storage. Supported on iOS/macOS (via `PHAssetResource`), Android (via `MediaStore.MediaColumns.SIZE`), and OHOS.
 
 ## 3.8.3
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/entity/AssetEntity.kt
@@ -20,7 +20,8 @@ data class AssetEntity(
     val lat: Double? = null,
     val lng: Double? = null,
     val androidQRelativePath: String? = null,
-    val mimeType: String? = null
+    val mimeType: String? = null,
+    val fileSize: Long = 0
 ) {
     fun getUri(): Uri = MediaStoreUtils.getUri(
         id,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/ConvertUtils.kt
@@ -60,6 +60,9 @@ object ConvertUtils {
         if (entity.mimeType != null) {
             data["mimeType"] = entity.mimeType
         }
+        if (entity.fileSize > 0) {
+            data["fileSize"] = entity.fileSize
+        }
         return data
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -60,6 +60,7 @@ interface IDBUtils {
             DATE_ADDED, // 创建时间
             DATE_MODIFIED, // 修改时间
             MIME_TYPE, // mime type
+            MediaStore.MediaColumns.SIZE, // file size in bytes
             DATE_TAKEN //日期
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间
@@ -79,6 +80,7 @@ interface IDBUtils {
             ORIENTATION, // 角度
             DATE_MODIFIED, // 修改时间
             MIME_TYPE, // mime type
+            MediaStore.MediaColumns.SIZE, // file size in bytes
             DURATION //时长
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -23,6 +23,7 @@ import android.provider.MediaStore.MediaColumns.IS_FAVORITE
 import android.provider.MediaStore.MediaColumns.MIME_TYPE
 import android.provider.MediaStore.MediaColumns.ORIENTATION
 import android.provider.MediaStore.MediaColumns.RELATIVE_PATH
+import android.provider.MediaStore.MediaColumns.SIZE
 import android.provider.MediaStore.MediaColumns.TITLE
 import android.provider.MediaStore.MediaColumns.WIDTH
 import android.provider.MediaStore.MediaColumns._ID
@@ -60,6 +61,7 @@ interface IDBUtils {
             DATE_ADDED, // 创建时间
             DATE_MODIFIED, // 修改时间
             MIME_TYPE, // mime type
+            SIZE, // file size in bytes
             DATE_TAKEN //日期
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间
@@ -79,6 +81,7 @@ interface IDBUtils {
             ORIENTATION, // 角度
             DATE_MODIFIED, // 修改时间
             MIME_TYPE, // mime type
+            SIZE, // file size in bytes
             DURATION //时长
         ).apply {
             if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q) add(DATE_TAKEN) // 拍摄时间

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/extension/CursorExtensions.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/extension/CursorExtensions.kt
@@ -86,6 +86,7 @@ fun Cursor.toAssetEntity(
     val displayName = getString(DISPLAY_NAME)
     val modifiedDate = getLong(DATE_MODIFIED)
     var orientation: Int = getInt(ORIENTATION)
+    val fileSize = getLong(MediaStore.MediaColumns.SIZE)
     val isFavorite = Build.VERSION.SDK_INT >= Build.VERSION_CODES.R && getInt(IS_FAVORITE) == 1
     val relativePath: String? = if (isAboveAndroidQ) {
         getString(RELATIVE_PATH)
@@ -132,7 +133,8 @@ fun Cursor.toAssetEntity(
         orientation,
         isFavorite,
         androidQRelativePath = relativePath,
-        mimeType = mimeType
+        mimeType = mimeType,
+        fileSize = fileSize
     )
 }
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
@@ -35,7 +35,7 @@
 @property(nonatomic, assign) NSUInteger subtype;
 @property(nonatomic, assign) BOOL favorite;
 @property(nonatomic, assign) BOOL isLocallyAvailable;
-@property(nonatomic, assign) long long fileSize;
+@property(nonatomic, assign) int64_t fileSize;
 
 - (instancetype)initWithId:(NSString *)id
                   createDt:(long)createDt

--- a/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
@@ -35,7 +35,7 @@
 @property(nonatomic, assign) NSUInteger subtype;
 @property(nonatomic, assign) BOOL favorite;
 @property(nonatomic, assign) BOOL isLocallyAvailable;
-@property(nonatomic, assign) int64_t fileSize;
+@property(nonatomic, assign) long fileSize;
 
 - (instancetype)initWithId:(NSString *)id
                   createDt:(long)createDt

--- a/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
@@ -35,6 +35,7 @@
 @property(nonatomic, assign) NSUInteger subtype;
 @property(nonatomic, assign) BOOL favorite;
 @property(nonatomic, assign) BOOL isLocallyAvailable;
+@property(nonatomic, assign) long long fileSize;
 
 - (instancetype)initWithId:(NSString *)id
                   createDt:(long)createDt

--- a/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
@@ -81,7 +81,7 @@
         typeInt = 3;
     }
     
-    return @{
+    NSMutableDictionary *dict = [@{
         @"id": asset.localIdentifier,
         @"createDt": @(createDt),
         @"width": @(asset.pixelWidth),
@@ -94,12 +94,36 @@
         @"lat": @(asset.location.coordinate.latitude),
         @"title": needTitle ? [asset title] : @"",
         @"subtype": @(asset.mediaSubtypes),
-    };
+    } mutableCopy];
+
+    // Read file size from PHAssetResource metadata.
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:asset];
+    PHAssetResource *primaryResource = nil;
+    for (PHAssetResource *r in resources) {
+        if (r.type == PHAssetResourceTypePhoto ||
+            r.type == PHAssetResourceTypeVideo ||
+            r.type == PHAssetResourceTypeFullSizePhoto ||
+            r.type == PHAssetResourceTypeFullSizeVideo) {
+            primaryResource = r;
+            break;
+        }
+    }
+    if (!primaryResource) {
+        primaryResource = resources.firstObject;
+    }
+    if (primaryResource) {
+        NSNumber *size = [primaryResource valueForKey:@"fileSize"];
+        if (size && [size longLongValue] > 0) {
+            dict[@"fileSize"] = size;
+        }
+    }
+
+    return dict;
 }
 
 + (NSDictionary *)convertPMAssetToMap:(PMAssetEntity *)asset
                             needTitle:(BOOL)needTitle {
-    return @{
+    NSMutableDictionary *dict = [@{
         @"id": asset.id,
         @"createDt": @(asset.createDt),
         @"width": @(asset.width),
@@ -112,7 +136,11 @@
         @"lat": @(asset.lat),
         @"title": needTitle ? asset.title : @"",
         @"subtype": @(asset.subtype),
-    };
+    } mutableCopy];
+    if (asset.fileSize > 0) {
+        dict[@"fileSize"] = @(asset.fileSize);
+    }
+    return dict;
 }
 
 + (NSObject <PMBaseFilter> *)convertMapToOptionContainer:(NSDictionary *)map {

--- a/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
@@ -86,7 +86,7 @@
         typeInt = 3;
     }
     
-    return @{
+    NSMutableDictionary *dict = [@{
         @"id": asset.localIdentifier,
         @"createDt": @(createDt),
         @"width": @(asset.pixelWidth),
@@ -99,12 +99,26 @@
         @"lat": @(asset.location.coordinate.latitude),
         @"title": needTitle ? [asset title] : @"",
         @"subtype": @(asset.mediaSubtypes),
-    };
+    } mutableCopy];
+
+    // Use the current resource so size semantics match `AssetEntity.file`.
+    PHAssetResource *resource = [asset getCurrentResource];
+    if (!resource) {
+        resource = [asset getRawResource];
+    }
+    if (resource) {
+        NSNumber *size = [resource valueForKey:@"fileSize"];
+        if (size && [size longLongValue] > 0) {
+            dict[@"fileSize"] = size;
+        }
+    }
+
+    return dict;
 }
 
 + (NSDictionary *)convertPMAssetToMap:(PMAssetEntity *)asset
                             needTitle:(BOOL)needTitle {
-    return @{
+    NSMutableDictionary *dict = [@{
         @"id": asset.id,
         @"createDt": @(asset.createDt),
         @"width": @(asset.width),
@@ -117,7 +131,11 @@
         @"lat": @(asset.lat),
         @"title": needTitle ? asset.title : @"",
         @"subtype": @(asset.subtype),
-    };
+    } mutableCopy];
+    if (asset.fileSize > 0) {
+        dict[@"fileSize"] = @(asset.fileSize);
+    }
+    return dict;
 }
 
 + (NSObject <PMBaseFilter> *)convertMapToOptionContainer:(NSDictionary *)map {

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -402,7 +402,19 @@
     entity.title = needTitle ? [asset title] : @"";
     entity.favorite = asset.isFavorite;
     entity.subtype = asset.mediaSubtypes;
-    
+
+    // Use the current resource so size semantics match `AssetEntity.file`.
+    PHAssetResource *resource = [asset getCurrentResource];
+    if (!resource) {
+        resource = [asset getRawResource];
+    }
+    if (resource) {
+        NSNumber *size = [resource valueForKey:@"fileSize"];
+        if (size) {
+            entity.fileSize = [size longLongValue];
+        }
+    }
+
     return entity;
 }
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -402,7 +402,29 @@
     entity.title = needTitle ? [asset title] : @"";
     entity.favorite = asset.isFavorite;
     entity.subtype = asset.mediaSubtypes;
-    
+
+    // Read file size from PHAssetResource metadata (no iCloud download required).
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:asset];
+    PHAssetResource *primaryResource = nil;
+    for (PHAssetResource *r in resources) {
+        if (r.type == PHAssetResourceTypePhoto ||
+            r.type == PHAssetResourceTypeVideo ||
+            r.type == PHAssetResourceTypeFullSizePhoto ||
+            r.type == PHAssetResourceTypeFullSizeVideo) {
+            primaryResource = r;
+            break;
+        }
+    }
+    if (!primaryResource) {
+        primaryResource = resources.firstObject;
+    }
+    if (primaryResource) {
+        NSNumber *size = [primaryResource valueForKey:@"fileSize"];
+        if (size) {
+            entity.fileSize = [size longLongValue];
+        }
+    }
+
     return entity;
 }
 

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -385,6 +385,7 @@ class AssetEntity {
     LatLng? latLng,
     this.mimeType,
     this.subtype = 0,
+    this.fileSize,
   }) : _latLng = latLng ??
             LatLng.fromValues(latitude: latitude, longitude: longitude);
 
@@ -894,6 +895,20 @@ class AssetEntity {
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#MIME_TYPE
   final String? mimeType;
 
+  /// The file size of the asset in bytes.
+  ///  * Android: `MediaStore.MediaColumns.SIZE`.
+  ///  * iOS/macOS: Obtained from the current `PHAssetResource` metadata.
+  ///  * OHOS: `photoAccessHelper.PhotoKeys.SIZE`.
+  ///
+  /// On iOS/macOS, this corresponds to [file] (current resource), and might
+  /// differ from [originFile] when the original resource is different.
+  ///
+  /// This value is read from metadata at query time, without downloading from
+  /// iCloud or other cloud storage.
+  ///
+  /// Returns `null` if the file size is unavailable.
+  final int? fileSize;
+
   /// Get the mime type async.
   ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
   ///  * iOS/macOS: MIME type from `PHAssetResource.uniformTypeIdentifier`.
@@ -922,6 +937,7 @@ class AssetEntity {
     double? longitude,
     String? mimeType,
     int? subtype,
+    int? fileSize,
   }) {
     return AssetEntity(
       id: id ?? this.id,
@@ -939,6 +955,7 @@ class AssetEntity {
       longitude: longitude ?? this.longitude,
       mimeType: mimeType ?? this.mimeType,
       subtype: subtype ?? this.subtype,
+      fileSize: fileSize ?? this.fileSize,
     );
   }
 

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -385,6 +385,7 @@ class AssetEntity {
     LatLng? latLng,
     this.mimeType,
     this.subtype = 0,
+    this.fileSize,
   }) : _latLng = latLng ??
             LatLng.fromValues(latitude: latitude, longitude: longitude);
 
@@ -894,6 +895,17 @@ class AssetEntity {
   ///  * https://developer.android.com/reference/android/provider/MediaStore.MediaColumns#MIME_TYPE
   final String? mimeType;
 
+  /// The file size of the asset in bytes.
+  ///  * Android: `MediaStore.MediaColumns.SIZE`.
+  ///  * iOS/macOS: Obtained from `PHAssetResource` metadata.
+  ///  * OHOS: `photoAccessHelper.PhotoKeys.SIZE`.
+  ///
+  /// This value is read from metadata at query time, without downloading
+  /// the file from iCloud or other cloud storage.
+  ///
+  /// Returns `null` if the file size is unavailable.
+  final int? fileSize;
+
   /// Get the mime type async.
   ///  * Android: `MediaStore.MediaColumns.MIME_TYPE`.
   ///  * iOS/macOS: MIME type from `PHAssetResource.uniformTypeIdentifier`.
@@ -922,6 +934,7 @@ class AssetEntity {
     double? longitude,
     String? mimeType,
     int? subtype,
+    int? fileSize,
   }) {
     return AssetEntity(
       id: id ?? this.id,
@@ -939,6 +952,7 @@ class AssetEntity {
       longitude: longitude ?? this.longitude,
       mimeType: mimeType ?? this.mimeType,
       subtype: subtype ?? this.subtype,
+      fileSize: fileSize ?? this.fileSize,
     );
   }
 

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -128,6 +128,7 @@ class ConvertUtils {
       modifiedDateSecond: data['modifiedDt'] as int?,
       relativePath: data['relativePath'] as String?,
       mimeType: data['mimeType'] as String?,
+      fileSize: data['fileSize'] as int?,
       latitude: lat,
       longitude: lng,
     );

--- a/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
+++ b/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
@@ -65,6 +65,7 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
         if (photoAsset != null) {
           let file = await fs.open(photoAsset.uri, fs.OpenMode.READ_ONLY);
           // let stat = await fs.stat(photoAsset.uri);
+          // MediaLibraryKit documents PhotoKeys.SIZE as the asset size in bytes.
           let size = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.SIZE)
           let arrayBuffer: ArrayBuffer = new ArrayBuffer(size as number);
           await fs.read(file.fd, arrayBuffer);
@@ -427,6 +428,8 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
     // let date_taken = this.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.DATE_TAKEN);
     let orientation = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.ORIENTATION);
     let is_favorite = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.FAVORITE);
+    // Keep parity with MediaLibraryKit PhotoKeys.SIZE (bytes).
+    let file_size = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.SIZE);
     // let title = this.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.TITLE);
 
     return new Map<string, ESObject>(
@@ -452,6 +455,7 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
         // longitude: data['lng'] as double?,
         // ['lng', 1.0],
         ['mimeType', media_type?.toString()],
+        ['fileSize', file_size],
       ]
     );
   }

--- a/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
+++ b/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
@@ -427,6 +427,7 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
     // let date_taken = this.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.DATE_TAKEN);
     let orientation = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.ORIENTATION);
     let is_favorite = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.FAVORITE);
+    let file_size = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.SIZE);
     // let title = this.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.TITLE);
 
     return new Map<string, ESObject>(
@@ -452,6 +453,7 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
         // longitude: data['lng'] as double?,
         // ['lng', 1.0],
         ['mimeType', media_type?.toString()],
+        ['fileSize', file_size],
       ]
     );
   }

--- a/test/convert_utils_test.dart
+++ b/test/convert_utils_test.dart
@@ -1,0 +1,111 @@
+// Copyright 2018 The FlutterCandies author. All rights reserved.
+// Use of this source code is governed by an Apache license that can be found
+// in the LICENSE file.
+
+import 'package:flutter_test/flutter_test.dart';
+import 'package:photo_manager/photo_manager.dart';
+import 'package:photo_manager/src/utils/convert_utils.dart';
+
+void main() {
+  group('ConvertUtils.convertMapToAsset', () {
+    test('parses fileSize when present', () {
+      final data = <String, dynamic>{
+        'id': 'test-id-1',
+        'type': 1,
+        'width': 1920,
+        'height': 1080,
+        'duration': 0,
+        'orientation': 0,
+        'favorite': false,
+        'title': 'photo.jpg',
+        'subtype': 0,
+        'createDt': 1700000000,
+        'modifiedDt': 1700000001,
+        'fileSize': 4812345,
+      };
+
+      final asset = ConvertUtils.convertMapToAsset(data);
+
+      expect(asset.id, equals('test-id-1'));
+      expect(asset.width, equals(1920));
+      expect(asset.height, equals(1080));
+      expect(asset.fileSize, equals(4812345));
+    });
+
+    test('fileSize is null when not present in map', () {
+      final data = <String, dynamic>{
+        'id': 'test-id-2',
+        'type': 2,
+        'width': 3840,
+        'height': 2160,
+        'duration': 30,
+        'orientation': 0,
+        'favorite': true,
+        'title': 'video.mp4',
+        'subtype': 0,
+        'createDt': 1700000000,
+        'modifiedDt': 1700000001,
+      };
+
+      final asset = ConvertUtils.convertMapToAsset(data);
+
+      expect(asset.fileSize, isNull);
+    });
+
+    test('fileSize handles zero as null-like value from platform', () {
+      final data = <String, dynamic>{
+        'id': 'test-id-3',
+        'type': 1,
+        'width': 640,
+        'height': 480,
+        'fileSize': 0,
+      };
+
+      final asset = ConvertUtils.convertMapToAsset(data);
+
+      // 0 is a valid int value — the Dart side passes it through as-is.
+      // Platform layers only send fileSize when > 0, so 0 means "unknown".
+      expect(asset.fileSize, equals(0));
+    });
+  });
+
+  group('AssetEntity.copyWith', () {
+    test('preserves fileSize when not overridden', () {
+      final original = AssetEntity(
+        id: 'asset-1',
+        typeInt: 1,
+        width: 100,
+        height: 100,
+        fileSize: 5000000,
+      );
+      final copy = original.copyWith(width: 200);
+
+      expect(copy.width, equals(200));
+      expect(copy.fileSize, equals(5000000));
+    });
+
+    test('overrides fileSize when specified', () {
+      final original = AssetEntity(
+        id: 'asset-1',
+        typeInt: 1,
+        width: 100,
+        height: 100,
+        fileSize: 5000000,
+      );
+      final copy = original.copyWith(fileSize: 9000000);
+
+      expect(copy.fileSize, equals(9000000));
+    });
+
+    test('fileSize defaults to null', () {
+      final asset = AssetEntity(
+        id: 'asset-2',
+        typeInt: 1,
+        width: 100,
+        height: 100,
+      );
+
+      expect(asset.fileSize, isNull);
+    });
+  });
+}


### PR DESCRIPTION
## Summary

Adds a `fileSize` property to `AssetEntity` that reads the file size in bytes from platform metadata at query time, **without downloading files from iCloud or other cloud storage**.

### Motivation

Currently, the only way to get an asset's file size is via `asset.file` or `asset.originFile`, which triggers full file downloads on iOS (including from iCloud). This is prohibitively slow for apps that need to display or calculate file sizes for many assets — for example, photo declutter apps showing "freed space" estimates.

### Changes

| Layer | File | Change |
|-------|------|--------|
| **Dart** | `lib/src/types/entity.dart` | Add `fileSize` field (nullable `int?`) to `AssetEntity` constructor, field declaration, and `copyWith` |
| **Dart** | `lib/src/utils/convert_utils.dart` | Read `data['fileSize']` in `convertMapToAsset()` |
| **iOS/macOS** | `darwin/.../PMAssetPathEntity.h` | Add `fileSize` property to `PMAssetEntity` |
| **iOS/macOS** | `darwin/.../PMManager.m` | Populate `fileSize` from `PHAssetResource` metadata via `value(forKey: "fileSize")` |
| **iOS/macOS** | `darwin/.../PMConvertUtils.m` | Serialize `fileSize` in both `convertPMAssetToMap:` and `convertPHAssetToMap:` |
| **Android** | `core/entity/AssetEntity.kt` | Add `fileSize: Long` field |
| **Android** | `core/utils/IDBUtils.kt` | Add `MediaStore.MediaColumns.SIZE` to `storeImageKeys` and `storeVideoKeys` |
| **Android** | `extension/CursorExtensions.kt` | Read `SIZE` column from cursor, pass to entity |
| **Android** | `core/utils/ConvertUtils.kt` | Serialize `fileSize` to map |
| **OHOS** | `PhotoAssetHandler.ets` | Read `SIZE` (already in `fetchColumns`) and add `['fileSize', file_size]` to map |
| **Tests** | `test/convert_utils_test.dart` | New test file: `ConvertUtils.convertMapToAsset` fileSize parsing + `AssetEntity.copyWith` preservation |
| **Docs** | `CHANGELOG.md` | Add entry under Unreleased |

### iOS implementation note

On iOS/macOS, `PHAssetResource.value(forKey: "fileSize")` is used to read file size from the Photos database metadata. This is a well-known KVC technique that reads locally cached metadata — it does **not** trigger iCloud downloads. While the `fileSize` key is not part of Apple's documented public API for `PHAssetResource`, it has been stable since the Photos framework was introduced and is widely used in the iOS ecosystem.

The implementation selects the primary resource (`.photo`, `.video`, `.fullSizePhoto`, or `.fullSizeVideo`) to report the most relevant file size, falling back to the first available resource.

### Usage

```dart
final AssetEntity asset = ...;

// File size in bytes — available immediately, no download needed
final int? bytes = asset.fileSize;
if (bytes != null) {
  print('File size: ${(bytes / 1024 / 1024).toStringAsFixed(1)} MB');
}
```

### Testing

- [x] `dart analyze lib/ test/` — no issues
- [x] `flutter test` — all 15 tests pass (6 new tests added)
- [ ] Manual testing on iOS device with iCloud photos
- [ ] Manual testing on Android device

Closes #1369
Addresses #1366