### PR TITLE
fix(android): correct namespace typo from flutterandies to fluttercandies

### DIFF
--- a/android/build.gradle
+++ b/android/build.gradle
@@ -35,7 +35,7 @@ apply plugin: 'kotlin-android'
 
 android {
     if (project.android.hasProperty('namespace')) {
-        namespace 'com.flutterandies.photo_manager'
+        namespace 'com.fluttercandies.photo_manager'
     }
 
     compileSdkVersion 36


### PR DESCRIPTION
 ## Summary
Fix a typo in the Android namespace: `flutterandies` → `fluttercandies`.

## Problem
The namespace in `build.gradle` has a typo (`flutterandies` instead of `fluttercandies`). The namespace should match the Kotlin package for consistency.

Note: The "Unresolved reference 'IDBUtils'" build error reported in #1375 is related to Kotlin/Gradle's incremental build mechanism and can be resolved by `flutter clean`.

## Fix
Update `android/build.gradle` line 38:
- Before: `namespace 'com.flutterandies.photo_manager'`
- After: `namespace 'com.fluttercandies.photo_manager'`