### PR TITLE
fix(iOS): use QOS_CLASS_USER_INITIATED for destructive operations

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Fix delayed native deletion confirmation dialogs on iOS by elevating the dispatch queue priority of `deleteWithIds`, `removeInAlbum`, and `deleteAlbum` to `QOS_CLASS_USER_INITIATED`.
 - Fix Android 14+ permission requests incorrectly short-circuiting when only part of the requested media access was already granted.
 - Fix Darwin video durations being truncated instead of rounded, so `AssetEntity.duration` matches the system album display more closely.
 - Fix Darwin `getTitleAsync` returning a null channel result by falling back to an empty string.

--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -356,7 +356,10 @@
         [method isEqualToString:@"getAssetListRange"] ||
         [method isEqualToString:@"getFullFile"] ||
         [method isEqualToString:@"getMediaUrl"] ||
-        [method isEqualToString:@"fetchEntityProperties"]) {
+        [method isEqualToString:@"fetchEntityProperties"] ||
+        [method isEqualToString:@"deleteWithIds"] ||
+        [method isEqualToString:@"removeInAlbum"] ||
+        [method isEqualToString:@"deleteAlbum"]) {
         return QOS_CLASS_USER_INITIATED;
     }
 
@@ -371,10 +374,7 @@
     }
 
     if ([method isEqualToString:@"clearFileCache"] ||
-        [method isEqualToString:@"releaseMemoryCache"] ||
-        [method isEqualToString:@"deleteWithIds"] ||
-        [method isEqualToString:@"removeInAlbum"] ||
-        [method isEqualToString:@"deleteAlbum"]) {
+        [method isEqualToString:@"releaseMemoryCache"]) {
         return QOS_CLASS_BACKGROUND;
     }
 


### PR DESCRIPTION
Fixes #1379 