### PR TITLE
fix(android): stop auto-declaring READ_EXTERNAL_STORAGE

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Stop auto-declaring `READ_EXTERNAL_STORAGE` in the Android library manifest so host apps must opt in explicitly when they need broad media-library access on Android 12L and lower.
 - Fix the `AssetEntity.duration` API docs to clarify that audio and video durations are returned in seconds across supported platforms, preserving the existing API behavior.
 - Fix Android 14+ limited permission photo selection not reflecting deselection in Flutter layer. When users modify their photo selection via `presentLimited()`, the changes are now properly notified to the Flutter layer.
 - Fix delayed native deletion confirmation dialogs on iOS by elevating the dispatch queue priority of `deleteWithIds`, `removeInAlbum`, and `deleteAlbum` to `QOS_CLASS_USER_INITIATED`.

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -855,6 +855,10 @@ rootProject.allprojects {
 如果你想了解如何同时使用 ProGuard 和 Glide，请参阅
 [ProGuard for Glide](https://github.com/bumptech/glide#proguard)。
 
+> 从下一个版本开始，插件不再通过 Android library manifest 自动声明媒体/存储权限。
+> 如果你的应用确实需要广泛的媒体库访问能力，请在宿主应用自己的 manifest 中显式声明所需权限。
+> 如果你的应用只是一次性让用户选择文件，建议优先使用系统选择器，而不是申请广泛媒体权限。
+
 #### Android 14 (API level 34) 额外配置
 
 当你的应用在 API 34 (Android 14) 的设备上运行时，

--- a/README.md
+++ b/README.md
@@ -913,6 +913,12 @@ rootProject.allprojects {
 See [ProGuard for Glide](https://github.com/bumptech/glide#proguard)
 if you want to know more about using ProGuard and Glide together.
 
+> Starting from the next release, this plugin no longer auto-declares Android
+> media/storage permissions in its library manifest. If your app needs broad
+> media-library access, declare the required permissions in your own app
+> manifest explicitly. If your app only needs one-off user-selected files,
+> prefer a system picker instead of broad media permissions.
+
 #### Android 14 (API 34) extra configs
 
 When running on Android 14 (API level 34),

--- a/android/src/main/AndroidManifest.xml
+++ b/android/src/main/AndroidManifest.xml
@@ -1,5 +1,1 @@
-<manifest xmlns:android="http://schemas.android.com/apk/res/android">
-    <uses-permission
-        android:name="android.permission.READ_EXTERNAL_STORAGE"
-        android:maxSdkVersion="32"/>
-</manifest>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android" />

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -38,9 +38,12 @@ class PhotoManager {
   static base.PhotoManagerPlugin get plugin => base.plugin;
 
   /// ### Android (AndroidManifest.xml)
-  ///  * READ_EXTERNAL_STORAGE (REQUIRED)
-  ///  * WRITE_EXTERNAL_STORAGE
-  ///  * ACCESS_MEDIA_LOCATION
+  ///  * Declare `READ_EXTERNAL_STORAGE` in your app manifest when you need
+  ///    broad media-library access on Android 12L and lower.
+  ///  * Declare `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` in your app manifest
+  ///    when you need broad media-library access on Android 13 and higher.
+  ///  * Declare `WRITE_EXTERNAL_STORAGE` / `ACCESS_MEDIA_LOCATION` in your app
+  ///    manifest if your use case requires them.
   ///
   /// ### iOS (Info.plist)
   ///  * NSPhotoLibraryUsageDescription


### PR DESCRIPTION
## Summary

This PR stops `photo_manager` from auto-declaring `READ_EXTERNAL_STORAGE` in the Android library manifest.

That permission should be an explicit host-app decision, not a transitive dependency side effect.

Why this matters:
- Google Play now enforces minimum-scope access for photo/video permissions.
- Apps with one-time or infrequent photo usage are expected to use a system picker instead of broad media permissions.
- In a real affected app the Play Console flagged **Publishing overview → Invalid use of the photo and video permissions**.
- The associated bug report includes a summary of the attached Play Console screenshot and policy link: #1401.

Policy reference:
- https://support.google.com/googleplay/android-developer/answer/16935362

Related upstream history:
- Fixes #1401
- Related open issue: #1297
- Related closed issue: #1261
- Related closed implementation attempt: #1346

## Changes

- remove `READ_EXTERNAL_STORAGE` from `android/src/main/AndroidManifest.xml`
- update API docs to tell host apps to declare Android media permissions explicitly when they truly need broad media-library access
- add README / README-ZH guidance clarifying that one-off user selection should prefer a system picker
- add a changelog entry

## Validation

- `flutter pub get`
- `flutter analyze lib/src/managers/photo_manager.dart`

## Notes

This PR is intentionally narrow:
- it does **not** add a new Android system photo picker API
- it does **not** change existing permission-request logic
- it only removes the transitive manifest permission and makes host-app opt-in explicit

That keeps the change low-risk while still helping apps avoid unexpected permission inheritance during Play policy review.



## Screenshot

Play Console evidence referenced by this PR:

![Google Play Console invalid photo and video permissions warning](https://raw.githubusercontent.com/amrgetment/flutter_photo_manager/issue-assets/play-console-v722/.github/assets/play-console-invalid-photo-video-permissions-v722.png)
