### PR TITLE
Add async AssetEntity fileSize getter

### DIFF
--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -68,6 +68,7 @@ class Methods {
         const val cancelCacheRequests = "cancelCacheRequests"
         const val assetExists = "assetExists"
         const val getFullFile = "getFullFile"
+        const val getFileSize = "getFileSize"
         const val getOriginBytes = "getOriginBytes"
         const val getMediaUrl = "getMediaUrl"
         const val fetchEntityProperties = "fetchEntityProperties"

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -165,6 +165,10 @@ class PhotoManager(private val context: Context) {
         resultHandler.reply(path)
     }
 
+    fun getFileSize(id: String): Long {
+        return dbUtils.getFileSize(context, id)
+    }
+
     fun saveImage(
         bytes: ByteArray,
         filename: String,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -428,6 +428,11 @@ class PhotoManagerPlugin(
                 photoManager.getFile(id, isOrigin, resultHandler)
             }
 
+            Methods.getFileSize -> {
+                val id = call.argument<String>("id")!!
+                resultHandler.reply(photoManager.getFileSize(id))
+            }
+
             Methods.getOriginBytes -> {
                 val id = call.argument<String>("id")!!
                 photoManager.getOriginBytes(id, resultHandler, needLocationPermission)

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -23,6 +23,7 @@ import android.provider.MediaStore.MediaColumns.IS_FAVORITE
 import android.provider.MediaStore.MediaColumns.MIME_TYPE
 import android.provider.MediaStore.MediaColumns.ORIENTATION
 import android.provider.MediaStore.MediaColumns.RELATIVE_PATH
+import android.provider.MediaStore.MediaColumns.SIZE
 import android.provider.MediaStore.MediaColumns.TITLE
 import android.provider.MediaStore.MediaColumns.WIDTH
 import android.provider.MediaStore.MediaColumns._ID
@@ -130,6 +131,21 @@ interface IDBUtils {
     ): List<AssetEntity>
 
     fun getAssetEntity(context: Context, id: String, checkIfExists: Boolean = true): AssetEntity?
+
+    fun getFileSize(context: Context, id: String): Long {
+        context.contentResolver.logQuery(
+            allUri,
+            arrayOf(SIZE),
+            idSelection,
+            arrayOf(id),
+            null
+        ).use {
+            if (it.moveToNext()) {
+                return it.getLong(SIZE)
+            }
+        }
+        return 0
+    }
 
     fun getAssetPathEntityFromId(
         context: Context,

--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -355,6 +355,7 @@
     if ([method isEqualToString:@"getAssetListPaged"] ||
         [method isEqualToString:@"getAssetListRange"] ||
         [method isEqualToString:@"getFullFile"] ||
+        [method isEqualToString:@"getFileSize"] ||
         [method isEqualToString:@"getMediaUrl"] ||
         [method isEqualToString:@"fetchEntityProperties"] ||
         [method isEqualToString:@"deleteWithIds"] ||
@@ -605,6 +606,10 @@
                                                    isOrigin:isOrigin
                                                    fileType:fileType];
         [handler reply:title];
+    } else if ([call.method isEqualToString:@"getFileSize"]) {
+        NSString *assetId = call.arguments[@"id"];
+        NSUInteger fileSize = [manager getFileSizeWithAssetId:assetId];
+        [handler reply:@(fileSize)];
     } else if ([call.method isEqualToString:@"getMimeTypeAsync"]) {
         NSString *assetId = call.arguments[@"id"];
         NSString *mimeType = [manager getMimeTypeAsyncWithAssetId:assetId];

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
@@ -106,6 +106,8 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
                              isOrigin:(BOOL)isOrigin
                              fileType:(AVFileType)fileType;
 
+- (NSUInteger)getFileSizeWithAssetId:(NSString *)assetId;
+
 - (NSString*)getMimeTypeAsyncWithAssetId: (NSString *) assetId;
 
 - (void)getMediaUrl:(NSString *)assetId

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1529,6 +1529,27 @@
     return @"";
 }
 
+- (NSUInteger)getFileSizeWithAssetId:(NSString *)assetId {
+    PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:[self singleFetchOptions]];
+    PHAsset *asset = [self getFirstObjFromFetchResult:fetchResult];
+    if (!asset) {
+        return 0;
+    }
+    PHAssetResource *resource = [asset getCurrentResource];
+    if (!resource) {
+        return 0;
+    }
+    @try {
+        NSNumber *fileSize = [resource valueForKey:@"fileSize"];
+        if (![fileSize isKindOfClass:NSNumber.class]) {
+            return 0;
+        }
+        return fileSize.unsignedIntegerValue;
+    } @catch (NSException *exception) {
+        return 0;
+    }
+}
+
 - (NSString *)getMimeTypeAsyncWithAssetId:(NSString *)assetId {
     PHFetchResult *fetchResult = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:[self singleFetchOptions]];
     PHAsset *asset = [self getFirstObjFromFetchResult:fetchResult];

--- a/example/lib/page/image_list_page.dart
+++ b/example/lib/page/image_list_page.dart
@@ -190,6 +190,14 @@ class _GalleryContentListPageState extends State<GalleryContentListPage> {
               ),
             ),
             ElevatedButton(
+              child: const Text('fileSize'),
+              onPressed: () => CommonUtil.showResultDialog(
+                context,
+                'fileSize',
+                entity.fileSize.then((int size) => '$size bytes'),
+              ),
+            ),
+            ElevatedButton(
               child: const Text('show 500 size thumb '),
               onPressed: () => showThumb(entity, 500),
             ),

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -42,6 +42,7 @@ class PMConstants {
   static const String mSystemVersion = 'systemVersion';
   static const String mGetLatLngAndroidQ = 'getLatLngAndroidQ';
   static const String mGetTitleAsync = 'getTitleAsync';
+  static const String mGetFileSize = 'getFileSize';
   static const String mGetMimeTypeAsync = 'getMimeTypeAsync';
   static const String mGetPathRelativePath = 'getPathRelativePath';
   static const String mGetMediaUrl = 'getMediaUrl';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -565,6 +565,14 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     return entity.title ?? '';
   }
 
+  Future<int> getFileSize(AssetEntity entity) async {
+    final int? size = await _channel.invokeMethod<int>(
+      PMConstants.mGetFileSize,
+      <String, dynamic>{'id': entity.id},
+    );
+    return size ?? 0;
+  }
+
   Future<String?> getMediaUrl(
     AssetEntity entity, {
     PMProgressHandler? progressHandler,

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -735,6 +735,9 @@ class AssetEntity {
   /// The [Size] for the asset.
   Size get size => Size(width.toDouble(), height.toDouble());
 
+  /// The file size of the asset in bytes.
+  Future<int> get fileSize => plugin.getFileSize(this);
+
   /// The create time in unix timestamp of the asset.
   final int? createDateSecond;
 

--- a/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
+++ b/ohos/src/main/ets/components/plugin/handlers/PhotoAssetHandler.ets
@@ -55,6 +55,19 @@ export class PhotoAssetHandler extends HandlerBase implements MethodCallHandlerB
         }
       }
         break;
+      case 'getFileSize': {
+        let args: Map<string, ESObject> = call.args;
+        let id: string = args.get('id');
+        let photoAsset: photoAccessHelper.PhotoAsset | null = await PhotoAssetHandler.getPhotoAsset(id);
+        if (photoAsset != null) {
+          let size = PhotoAssetHandler.getAssetMember(photoAsset, photoAccessHelper.PhotoKeys.SIZE);
+          result.success(size ?? 0);
+        }
+        else {
+          result.error(`${call.method} failed`, `not find asset by ${id}`, null);
+        }
+      }
+        break;
       case 'getOriginBytes': {
         let args: Map<string, ESObject> = call.args;
         let id: string = args.get('id');

--- a/test/photo_manager_test.dart
+++ b/test/photo_manager_test.dart
@@ -3,8 +3,11 @@
 // in the LICENSE file.
 
 // ignore_for_file: use_named_constants
+
+import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:photo_manager/photo_manager.dart';
+import 'package:photo_manager/src/internal/constants.dart';
 
 class _TestPlugin extends PhotoManagerPlugin {
   @override
@@ -14,6 +17,16 @@ class _TestPlugin extends PhotoManagerPlugin {
 }
 
 void main() {
+  TestWidgetsFlutterBinding.ensureInitialized();
+
+  tearDown(() {
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(PMConstants.channelPrefix),
+      null,
+    );
+  });
+
   test('RequestType equality test', () {
     expect(RequestType.image == const RequestType(1), equals(true));
     expect(RequestType.video == const RequestType(2), equals(true));
@@ -28,5 +41,28 @@ void main() {
     final PermissionState permission =
         await PhotoManager.requestPermissionExtend();
     expect(permission == PermissionState.notDetermined, equals(true));
+  });
+
+  test('AssetEntity.fileSize resolves the asset file size', () async {
+    MethodCall? capturedCall;
+    TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+        .setMockMethodCallHandler(
+      const MethodChannel(PMConstants.channelPrefix),
+      (MethodCall call) async {
+        capturedCall = call;
+        return 12345;
+      },
+    );
+
+    final entity = AssetEntity(
+      id: 'asset-id',
+      typeInt: AssetType.image.index,
+      width: 1,
+      height: 1,
+    );
+
+    await expectLater(entity.fileSize, completion(12345));
+    expect(capturedCall?.method, PMConstants.mGetFileSize);
+    expect(capturedCall?.arguments['id'], 'asset-id');
   });
 }


### PR DESCRIPTION
## Summary
- Add an async `AssetEntity.fileSize` getter instead of storing file size on each entity.
- Add `getFileSize` platform methods for Darwin, Android, and OHOS.
- Keep list/entity conversion lightweight and fetch size on demand.

This supersedes the field-based approach discussed in #1370.