### PR TITLE
✨ Add Darwin-only cloud identifier, adjustments, and parent path APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,13 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+**Features**
+
+- Add Darwin (iOS/macOS) only namespaced accessors `AssetEntity.darwin` and `AssetPathEntity.darwin` that group PhotoKit-specific reads without bloating the shared entity classes:
+  - `asset.darwin.cloudIdentifier` and the batch `PhotoManager.plugin.getCloudIdentifiers` resolve stable cross-device cloud identifiers (iOS 15+/macOS 12+).
+  - `asset.darwin.hasAdjustments` reports whether an asset has edits, and `asset.darwin.baseFile()` exports the unedited base file.
+  - `path.darwin.getParentPathList()` returns the parent folders containing an album or folder.
+
 **Improvements**
 
 - Migrate the Android plugin to Flutter's built-in Kotlin integration with a compatibility fallback for projects that still require `kotlin-android`, without changing the package's public Flutter or Dart version constraints.

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -1060,6 +1060,31 @@ await PhotoManager.editor.darwin.removeAssetsInAlbum(
 PhotoManager.editor.darwin.deletePath();
 ```
 
+##### Darwin 专属只读接口（`AssetEntity.darwin` / `AssetPathEntity.darwin`）
+
+PhotoKit 专属的只读能力统一收拢在 `.darwin` 访问器下，避免让公共实体类膨胀。
+在非 Darwin 平台访问 `.darwin` 会抛出 `OSError`，请用 `Platform` 判断后再调用
+（或仅在 iOS/macOS 上使用）。
+
+```dart
+// 云标识在同一 iCloud 图库的多设备间保持稳定（iOS 15+/macOS 12+），
+// 不像每台设备各不相同的 `AssetEntity.id`。
+final String? cloudId = await entity.darwin.cloudIdentifier;
+
+// 批量解析多个资源时优先用批量接口，比在循环里逐个读取高效得多，
+// 返回以 localIdentifier 为键的 map。
+final Map<String, String?> cloudIds =
+    await PhotoManager.plugin.getCloudIdentifiers(<String>[entity.id, ...]);
+
+// 判断资源是否有编辑，以及导出未编辑的原始文件。
+if (await entity.darwin.hasAdjustments) {
+  final File? base = await entity.darwin.baseFile();
+}
+
+// 获取包含某相册/文件夹的父级文件夹，可用于面包屑导航。
+final List<AssetPathEntity> parents = await path.darwin.getParentPathList();
+```
+
 #### 适用于 OpenHarmony 的功能
 
 > 鸿蒙官方处于安全考虑已禁止相关资源能力。

--- a/README.md
+++ b/README.md
@@ -1131,6 +1131,31 @@ Smart albums can't be deleted.
 PhotoManager.editor.darwin.deletePath();
 ```
 
+##### Darwin-only reads (`AssetEntity.darwin` / `AssetPathEntity.darwin`)
+
+PhotoKit-specific reads are grouped under a `.darwin` accessor so the shared
+entity classes stay lean. Accessing `.darwin` on a non-Darwin platform throws
+an `OSError`, so guard with `Platform` (or only call it on iOS/macOS).
+
+```dart
+// Cloud identifiers are stable across devices sharing the same iCloud Photo
+// Library (iOS 15+/macOS 12+), unlike the per-device `AssetEntity.id`.
+final String? cloudId = await entity.darwin.cloudIdentifier;
+
+// Prefer the batch call when resolving many assets; it's far more efficient
+// than reading the getter in a loop. Returns a map keyed by localIdentifier.
+final Map<String, String?> cloudIds =
+    await PhotoManager.plugin.getCloudIdentifiers(<String>[entity.id, ...]);
+
+// Whether the asset has edits, plus the unedited base file.
+if (await entity.darwin.hasAdjustments) {
+  final File? base = await entity.darwin.baseFile();
+}
+
+// Parent folders containing an album/folder, for breadcrumb navigation.
+final List<AssetPathEntity> parents = await path.darwin.getParentPathList();
+```
+
 #### Features for OpenHarmony
 
 > The photo library feature is disabled in OpenHarmony officially because of the security concern.

--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -355,6 +355,7 @@
     if ([method isEqualToString:@"getAssetListPaged"] ||
         [method isEqualToString:@"getAssetListRange"] ||
         [method isEqualToString:@"getFullFile"] ||
+        [method isEqualToString:@"getBaseAdjustmentFile"] ||
         [method isEqualToString:@"getFileSize"] ||
         [method isEqualToString:@"getMediaUrl"] ||
         [method isEqualToString:@"fetchEntityProperties"] ||
@@ -635,6 +636,34 @@
         NSObject <PMBaseFilter> *option = [PMConvertUtils convertMapToOptionContainer:optionMap];
 
         NSArray<PMAssetPathEntity *> *array = [manager getSubPathWithId:galleryId type:type albumType:albumType option:option];
+        NSDictionary *pathData = [PMConvertUtils convertPathToMap:array];
+
+        [handler reply:@{@"list": pathData}];
+    } else if ([@"getCloudIdentifiers" isEqualToString:call.method]) {
+        NSArray<NSString *> *ids = call.arguments[@"ids"];
+        NSDictionary<NSString *, id> *mapping = [manager getCloudIdentifiersWithIds:ids];
+        [handler reply:mapping];
+    } else if ([@"hasAdjustments" isEqualToString:call.method]) {
+        NSString *assetId = call.arguments[@"id"];
+        BOOL hasAdjustments = [manager hasAdjustmentsWithId:assetId];
+        [handler reply:@(hasAdjustments)];
+    } else if ([@"getBaseAdjustmentFile" isEqualToString:call.method]) {
+        NSString *assetId = call.arguments[@"id"];
+        BOOL isOrigin = [call.arguments[@"isOrigin"] boolValue];
+        AVFileType fileType = [PMConvertUtils convertNumberToAVFileType:[call.arguments[@"darwinFileType"] intValue]];
+        PMProgressHandler *progressHandler = [self getProgressHandlerFromDict:call.arguments];
+        [manager getBaseAdjustmentFileWithId:assetId
+                                    isOrigin:isOrigin
+                                    fileType:fileType
+                               resultHandler:handler
+                             progressHandler:progressHandler];
+    } else if ([@"getParentPath" isEqualToString:call.method]) {
+        NSString *galleryId = call.arguments[@"id"];
+        int type = [call.arguments[@"type"] intValue];
+        int albumType = [call.arguments[@"albumType"] intValue];
+        NSObject <PMBaseFilter> *option = [PMConvertUtils convertMapToOptionContainer:call.arguments[@"option"]];
+
+        NSArray<PMAssetPathEntity *> *array = [manager getParentPathWithId:galleryId type:type albumType:albumType option:option];
         NSDictionary *pathData = [PMConvertUtils convertPathToMap:array];
 
         [handler reply:@{@"list": pathData}];

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -29,6 +29,12 @@ NS_ASSUME_NONNULL_BEGIN
 - (nullable NSString*)mimeType;
 - (PHAssetResource *)getCurrentResource;
 - (void)requestCurrentResourceData:(void (^)(NSData *_Nullable result))block;
+
+/// The base (unedited) resource of the asset, i.e. the original photo/video
+/// before any Photos.app adjustments were applied. Falls back to
+/// `getCurrentResource` when no distinct original resource exists.
+- (PHAssetResource *)getOriginalResource;
+
 - (PHAssetResource *)getLivePhotosResource;
 
 @end

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -209,6 +209,27 @@
     return nil;
 }
 
+- (PHAssetResource *)getOriginalResource {
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:self];
+    for (PHAssetResource *res in resources) {
+        if (!res.isValid) {
+            continue;
+        }
+        if (self.isImage && res.type == PHAssetResourceTypePhoto) {
+            return res;
+        }
+        if (self.isVideo && res.type == PHAssetResourceTypeVideo) {
+            return res;
+        }
+        if (self.isAudio && res.type == PHAssetResourceTypeAudio) {
+            return res;
+        }
+    }
+    // No distinct original resource (asset is unedited or only exposes a
+    // rendered resource), fall back to the current resource.
+    return [self getCurrentResource];
+}
+
 - (void)requestCurrentResourceData:(void (^)(NSData *_Nullable))block {
     PHAssetResource *res = [self getCurrentResource];
     

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
@@ -116,6 +116,24 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
 
 - (NSArray<PMAssetPathEntity *> *)getSubPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(NSObject<PMBaseFilter> *)option;
 
+/// Resolve stable cloud identifiers for the given local identifiers.
+/// Values are the `PHCloudIdentifier.stringValue`, or `NSNull` when absent.
+/// Returns an empty dictionary below iOS 15 / macOS 12.
+- (NSDictionary<NSString *, id> *)getCloudIdentifiersWithIds:(NSArray<NSString *> *)ids;
+
+/// Whether the asset with [assetId] contains adjustment (edit) data.
+- (BOOL)hasAdjustmentsWithId:(NSString *)assetId;
+
+/// Export the base (unedited) file of the asset with [assetId].
+- (void)getBaseAdjustmentFileWithId:(NSString *)assetId
+                           isOrigin:(BOOL)isOrigin
+                           fileType:(AVFileType)fileType
+                      resultHandler:(PMResultHandler *)handler
+                    progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;
+
+/// The parent folders containing the album/folder with [id].
+- (NSArray<PMAssetPathEntity *> *)getParentPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(NSObject<PMBaseFilter> *)option;
+
 - (void)copyAssetWithId:(NSString *)id toGallery:(NSString *)gallery block:(AssetBlockResult)block;
 
 - (void)createFolderWithName:(NSString *)name parentId:(NSString *)id block:(void (^)(NSString *newId, NSObject *error))block;

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1700,6 +1700,109 @@
     return [self convertPHCollectionToPMAssetPathArray:phCollectionArray option:options];
 }
 
+- (NSArray<PMAssetPathEntity *> *)getParentPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(NSObject<PMBaseFilter> *)option {
+    PHFetchOptions *options = [self getAssetOptions:type filterOption:option];
+
+    // The root and system albums (e.g. Recent, All Photos) have no parent.
+    if ([PMFolderUtils isRecentCollection:id]) {
+        return @[];
+    }
+
+    // Both albums (PHAssetCollection) and folders (PHCollectionList) can be
+    // contained by a parent folder, so resolve the input accordingly.
+    PHCollection *collection;
+    if (albumType == PM_TYPE_ALBUM) {
+        PHFetchResult<PHAssetCollection *> *result =
+            [PHAssetCollection fetchAssetCollectionsWithLocalIdentifiers:@[id] options:nil];
+        collection = result.firstObject;
+    } else {
+        PHFetchResult<PHCollectionList *> *result =
+            [PHCollectionList fetchCollectionListsWithLocalIdentifiers:@[id] options:nil];
+        collection = result.firstObject;
+    }
+    if (!collection) {
+        return @[];
+    }
+
+    PHFetchResult<PHCollectionList *> *parents =
+        [PHCollectionList fetchCollectionListsContainingCollection:collection options:nil];
+    NSMutableArray<PHCollection *> *parentArray = [NSMutableArray new];
+    for (PHCollectionList *parent in parents) {
+        [parentArray addObject:parent];
+    }
+    return [self convertPHCollectionToPMAssetPathArray:parentArray option:options];
+}
+
+- (NSDictionary<NSString *, id> *)getCloudIdentifiersWithIds:(NSArray<NSString *> *)ids {
+    NSMutableDictionary<NSString *, id> *result = [NSMutableDictionary dictionary];
+    if (@available(iOS 15.0, macOS 12.0, *)) {
+        NSDictionary<NSString *, PHCloudIdentifierMapping *> *mappings =
+            [PHPhotoLibrary.sharedPhotoLibrary cloudIdentifierMappingsForLocalIdentifiers:ids];
+        for (NSString *localId in ids) {
+            PHCloudIdentifierMapping *mapping = mappings[localId];
+            NSString *value = nil;
+            if (mapping && mapping.error == nil) {
+                value = mapping.cloudIdentifier.stringValue;
+            }
+            // Keep the key so callers can tell "resolved to nothing" from
+            // "not requested"; NSNull is decoded as null on the Dart side.
+            result[localId] = value ?: (id) [NSNull null];
+        }
+    }
+    return result;
+}
+
+- (BOOL)hasAdjustmentsWithId:(NSString *)assetId {
+    PMAssetEntity *entity = [self getAssetEntity:assetId];
+    if (!entity || !entity.phAsset) {
+        return NO;
+    }
+    // Detect the adjustment-data resource. This is reliable across OS versions,
+    // unlike `PHAsset.hasAdjustments` which is only exposed on newer systems.
+    NSArray<PHAssetResource *> *resources =
+        [PHAssetResource assetResourcesForAsset:entity.phAsset];
+    for (PHAssetResource *resource in resources) {
+        if (resource.type == PHAssetResourceTypeAdjustmentData) {
+            return YES;
+        }
+    }
+    return NO;
+}
+
+- (void)getBaseAdjustmentFileWithId:(NSString *)assetId
+                           isOrigin:(BOOL)isOrigin
+                           fileType:(AVFileType)fileType
+                      resultHandler:(PMResultHandler *)handler
+                    progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler {
+    PMAssetEntity *entity = [self getAssetEntity:assetId];
+    if (!entity || !entity.phAsset) {
+        [handler replyError:[NSString stringWithFormat:@"Asset %@ file cannot be obtained.", assetId]];
+        return;
+    }
+    PHAsset *asset = entity.phAsset;
+    PHAssetResource *resource = [asset getOriginalResource];
+    if (!resource) {
+        [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have a base resource.", assetId]];
+        return;
+    }
+    // `fetchVideoResourceToFile:` writes an arbitrary resource's bytes to disk
+    // (and only performs AV conversion when a fileType is supplied), so it works
+    // for images too.
+    [self fetchVideoResourceToFile:asset
+                          resource:resource
+                   progressHandler:progressHandler
+                        withScheme:NO
+                          isOrigin:isOrigin
+                          fileType:fileType
+                             block:^(NSString *path, NSObject *error) {
+        if (path) {
+            [handler reply:path];
+        } else {
+            [handler replyError:error];
+        }
+    }];
+}
+
 - (NSArray<PMAssetPathEntity *> *)convertPHCollectionToPMAssetPathArray:(NSArray<PHCollection *> *)phArray
                                                                  option:(PHFetchOptions *)option {
     NSMutableArray<PMAssetPathEntity *> *result = [NSMutableArray new];

--- a/example/lib/page/developer/develop_index_page.dart
+++ b/example/lib/page/developer/develop_index_page.dart
@@ -16,6 +16,7 @@ import '../../util/log_export.dart';
 import 'create_entity_by_id.dart';
 import 'dev_title_page.dart';
 import 'ios/create_folder_example.dart';
+import 'ios/darwin_features_page.dart';
 import 'ios/edit_asset.dart';
 import 'issues_page/issue_index_page.dart';
 import 'permission_state_page.dart';
@@ -87,6 +88,11 @@ class _DeveloperIndexPageState extends State<DeveloperIndexPage> {
             child: const Text('Show iOS create folder example.'),
             onPressed: () => navToWidget(const CreateFolderExample()),
           ),
+          if (Platform.isIOS || Platform.isMacOS)
+            ElevatedButton(
+              child: const Text('Darwin: cloudId / adjustments / parent paths'),
+              onPressed: () => navToWidget(const DarwinFeaturesPage()),
+            ),
           ElevatedButton(
             child: const Text('Test edit image'),
             onPressed: () => navToWidget(const EditAssetPage()),

--- a/example/lib/page/developer/ios/darwin_features_page.dart
+++ b/example/lib/page/developer/ios/darwin_features_page.dart
@@ -1,0 +1,231 @@
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+/// Demonstrates the Darwin (iOS/macOS) only reads exposed through the
+/// `AssetEntity.darwin` / `AssetPathEntity.darwin` namespaces:
+///
+///  * `asset.darwin.cloudIdentifier` and the batch
+///    `PhotoManager.plugin.getCloudIdentifiers`
+///  * `asset.darwin.hasAdjustments` + `asset.darwin.baseFile()`
+///  * `path.darwin.getParentPathList()`
+///
+/// This page is only meaningful on iOS/macOS; the entry point in
+/// `develop_index_page.dart` is already gated behind `Platform.isIOS ||
+/// Platform.isMacOS`, and the page guards again at runtime so it degrades
+/// gracefully if opened elsewhere.
+class DarwinFeaturesPage extends StatefulWidget {
+  const DarwinFeaturesPage({super.key});
+
+  @override
+  State<DarwinFeaturesPage> createState() => _DarwinFeaturesPageState();
+}
+
+class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
+  final List<String> _logs = <String>[];
+  AssetEntity? _asset;
+  bool _busy = false;
+
+  bool get _supported => Platform.isIOS || Platform.isMacOS;
+
+  void _log(String message) {
+    if (!mounted) {
+      return;
+    }
+    setState(() => _logs.insert(0, message));
+  }
+
+  Future<bool> _ensurePermission() async {
+    final PermissionState ps = await PhotoManager.requestPermissionExtend();
+    if (!ps.hasAccess) {
+      _log('❌ No photo access granted ($ps).');
+      return false;
+    }
+    return true;
+  }
+
+  Future<AssetEntity?> _firstAsset() async {
+    if (_asset != null) {
+      return _asset;
+    }
+    final List<AssetPathEntity> paths =
+        await PhotoManager.getAssetPathList(onlyAll: true);
+    if (paths.isEmpty) {
+      _log('❌ No album found.');
+      return null;
+    }
+    final List<AssetEntity> assets =
+        await paths.first.getAssetListPaged(page: 0, size: 1);
+    if (assets.isEmpty) {
+      _log('❌ No asset found.');
+      return null;
+    }
+    _asset = assets.first;
+    _log('📌 Using asset ${_asset!.id}');
+    return _asset;
+  }
+
+  Future<void> _run(Future<void> Function() action) async {
+    if (!_supported) {
+      _log('⚠️ Darwin-only APIs are unavailable on this platform.');
+      return;
+    }
+    if (_busy) {
+      return;
+    }
+    setState(() => _busy = true);
+    try {
+      if (await _ensurePermission()) {
+        await action();
+      }
+    } catch (e) {
+      _log('❌ $e');
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  Future<void> _cloudIdentifierSingle() async {
+    final AssetEntity? asset = await _firstAsset();
+    if (asset == null) {
+      return;
+    }
+    final String? cloudId = await asset.darwin.cloudIdentifier;
+    _log('☁️ cloudIdentifier: ${cloudId ?? '<null>'}');
+  }
+
+  Future<void> _cloudIdentifierBatch() async {
+    final List<AssetPathEntity> paths =
+        await PhotoManager.getAssetPathList(onlyAll: true);
+    if (paths.isEmpty) {
+      _log('❌ No album found.');
+      return;
+    }
+    final List<AssetEntity> assets =
+        await paths.first.getAssetListPaged(page: 0, size: 10);
+    if (assets.isEmpty) {
+      _log('❌ No asset found.');
+      return;
+    }
+    final List<String> ids = assets.map((AssetEntity e) => e.id).toList();
+    final Map<String, String?> mapping =
+        await PhotoManager.plugin.getCloudIdentifiers(ids);
+    _log(
+      '☁️ Batch getCloudIdentifiers over ${ids.length} assets:\n'
+      '${mapping.entries.map((e) => '  ${e.key} -> ${e.value ?? '<null>'}').join('\n')}',
+    );
+  }
+
+  Future<void> _hasAdjustmentsAndBaseFile() async {
+    final AssetEntity? asset = await _firstAsset();
+    if (asset == null) {
+      return;
+    }
+    final bool hasAdjustments = await asset.darwin.hasAdjustments;
+    _log('✏️ hasAdjustments: $hasAdjustments');
+    final File? base = await asset.darwin.baseFile();
+    if (base == null) {
+      _log('📄 baseFile: <null>');
+      return;
+    }
+    final int length = await base.length();
+    _log('📄 baseFile: ${base.path} ($length bytes)');
+  }
+
+  Future<void> _parentPaths() async {
+    final List<AssetPathEntity> albums = await PhotoManager.getAssetPathList(
+      type: RequestType.common,
+    );
+    if (albums.isEmpty) {
+      _log('❌ No album found.');
+      return;
+    }
+    final StringBuffer buffer = StringBuffer('🗂 Parent folders per album:');
+    // Probe up to 10 albums to keep the output readable.
+    for (final AssetPathEntity album in albums.take(10)) {
+      final List<AssetPathEntity> parents =
+          await album.darwin.getParentPathList();
+      final String parentNames = parents.isEmpty
+          ? '(no parent)'
+          : parents.map((AssetPathEntity p) => p.name).join(' / ');
+      buffer.write('\n  ${album.name} -> $parentNames');
+    }
+    _log(buffer.toString());
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: AppBar(title: const Text('Darwin-only features')),
+      body: !_supported
+          ? const Center(
+              child: Padding(
+                padding: EdgeInsets.all(24),
+                child: Text(
+                  'These APIs (cloudIdentifier / hasAdjustments / baseFile / '
+                  'getParentPathList) are only available on iOS and macOS.',
+                  textAlign: TextAlign.center,
+                ),
+              ),
+            )
+          : Column(
+              children: <Widget>[
+                Padding(
+                  padding: const EdgeInsets.all(8),
+                  child: Wrap(
+                    spacing: 8,
+                    runSpacing: 8,
+                    children: <Widget>[
+                      ElevatedButton(
+                        onPressed:
+                            _busy ? null : () => _run(_cloudIdentifierSingle),
+                        child: const Text('cloudIdentifier (single)'),
+                      ),
+                      ElevatedButton(
+                        onPressed:
+                            _busy ? null : () => _run(_cloudIdentifierBatch),
+                        child: const Text('getCloudIdentifiers (batch)'),
+                      ),
+                      ElevatedButton(
+                        onPressed: _busy
+                            ? null
+                            : () => _run(_hasAdjustmentsAndBaseFile),
+                        child: const Text('hasAdjustments + baseFile'),
+                      ),
+                      ElevatedButton(
+                        onPressed: _busy ? null : () => _run(_parentPaths),
+                        child: const Text('getParentPathList'),
+                      ),
+                      OutlinedButton(
+                        onPressed: _busy
+                            ? null
+                            : () => setState(() {
+                                  _logs.clear();
+                                  _asset = null;
+                                }),
+                        child: const Text('Reset'),
+                      ),
+                    ],
+                  ),
+                ),
+                if (_busy) const LinearProgressIndicator(),
+                const Divider(height: 1),
+                Expanded(
+                  child: ListView.separated(
+                    padding: const EdgeInsets.all(12),
+                    itemCount: _logs.length,
+                    separatorBuilder: (_, __) => const Divider(height: 8),
+                    itemBuilder: (_, int index) => Text(
+                      _logs[index],
+                      style: const TextStyle(fontFamily: 'monospace'),
+                    ),
+                  ),
+                ),
+              ],
+            ),
+    );
+  }
+}

--- a/lib/photo_manager.dart
+++ b/lib/photo_manager.dart
@@ -26,6 +26,7 @@ export 'src/managers/notify_manager.dart';
 export 'src/managers/photo_manager.dart';
 
 export 'src/types/cancel_token.dart';
+export 'src/types/darwin.dart';
 export 'src/types/entity.dart';
 export 'src/types/thumbnail.dart';
 export 'src/types/types.dart';

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -64,6 +64,12 @@ class PMConstants {
   static const String mMoveAssetsToPath = 'moveAssetsToPath';
   static const String mColumnNames = 'getColumnNames';
 
+  /// Darwin (iOS/macOS) only methods.
+  static const String mGetCloudIdentifiers = 'getCloudIdentifiers';
+  static const String mHasAdjustments = 'hasAdjustments';
+  static const String mGetBaseAdjustmentFile = 'getBaseAdjustmentFile';
+  static const String mGetParentPath = 'getParentPath';
+
   static const String mGetAssetCount = 'getAssetCount';
   static const String mGetAssetsByRange = 'getAssetsByRange';
 

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -29,6 +29,24 @@ mixin BasePlugin {
   final Map<String, dynamic> onlyAddPermission = <String, dynamic>{
     'onlyAddPermission': true,
   };
+
+  void _injectProgressHandlerParams(
+    Map<String, dynamic> params,
+    PMProgressHandler? progressHandler,
+  ) {
+    if (progressHandler != null) {
+      params['progressHandler'] = progressHandler.channelIndex;
+    }
+  }
+
+  void _setCancelToken(
+    Map<String, dynamic> params,
+    PMCancelToken? cancelToken,
+  ) {
+    if (cancelToken != null) {
+      params[PMConstants.cancelTokenKey] = cancelToken.key;
+    }
+  }
 }
 
 class PMMethodChannel extends MethodChannel {
@@ -255,24 +273,6 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
       },
     );
     return ConvertUtils.convertToAssetList(map.cast());
-  }
-
-  void _injectProgressHandlerParams(
-    Map<String, dynamic> params,
-    PMProgressHandler? progressHandler,
-  ) {
-    if (progressHandler != null) {
-      params['progressHandler'] = progressHandler.channelIndex;
-    }
-  }
-
-  void _setCancelToken(
-    Map<String, dynamic> params,
-    PMCancelToken? cancelToken,
-  ) {
-    if (cancelToken != null) {
-      params[PMConstants.cancelTokenKey] = cancelToken.key;
-    }
   }
 
   /// Get thumbnail of asset id.
@@ -951,6 +951,85 @@ mixin IosPlugin on BasePlugin {
       },
     );
     return result['errorMsg'] == null;
+  }
+
+  /// Resolve the stable cloud identifiers for the given [ids] (localIdentifiers).
+  ///
+  /// Returns a map keyed by the input localIdentifier. A value is `null` when
+  /// the asset has no cloud identifier. Returns an empty map on unsupported
+  /// platforms (non-Darwin, iOS < 15, macOS < 12).
+  ///
+  /// Backed by `PHPhotoLibrary.cloudIdentifierMappingsForLocalIdentifiers`.
+  Future<Map<String, String?>> getCloudIdentifiers(List<String> ids) async {
+    if (!(Platform.isIOS || Platform.isMacOS)) {
+      return <String, String?>{};
+    }
+    final Map result = await _channel.invokeMethod(
+      PMConstants.mGetCloudIdentifiers,
+      <String, dynamic>{'ids': ids},
+    );
+    return result.map(
+      (key, value) => MapEntry(key as String, value as String?),
+    );
+  }
+
+  /// Whether the asset with [id] contains adjustment (edit) data.
+  ///
+  /// Backed by `PHAsset.hasAdjustments` (iOS/macOS 15+) with a resource-based
+  /// fallback on older systems.
+  Future<bool> hasAdjustments(String id) async {
+    assert(Platform.isIOS || Platform.isMacOS);
+    final bool? result = await _channel.invokeMethod<bool>(
+      PMConstants.mHasAdjustments,
+      <String, dynamic>{'id': id},
+    );
+    return result ?? false;
+  }
+
+  /// Export the base (unedited) file of the asset with [id].
+  ///
+  /// Mirrors [getFullFile] but targets the base adjustment resource.
+  Future<String?> getBaseAdjustmentFile(
+    String id, {
+    bool isOrigin = true,
+    PMProgressHandler? progressHandler,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+    assert(Platform.isIOS || Platform.isMacOS);
+    final params = <String, dynamic>{
+      'id': id,
+      'isOrigin': isOrigin,
+      'darwinFileType': darwinFileType?.value ?? 0,
+    };
+    _injectProgressHandlerParams(params, progressHandler);
+    _setCancelToken(params, cancelToken);
+    return _channel.invokeMethod(PMConstants.mGetBaseAdjustmentFile, params);
+  }
+
+  /// Request the parent folders containing [pathEntity].
+  ///
+  /// Mirrors [getSubPathEntities] but walks up the hierarchy. Backed by
+  /// `PHCollectionList.fetchCollectionListsContainingCollection:`.
+  Future<List<AssetPathEntity>> getParentPathEntities(
+    AssetPathEntity pathEntity,
+  ) async {
+    assert(Platform.isIOS || Platform.isMacOS);
+    final Map result = await _channel.invokeMethod(
+      PMConstants.mGetParentPath,
+      <String, dynamic>{
+        'id': pathEntity.id,
+        'type': pathEntity.type.value,
+        'albumType': pathEntity.albumType,
+        'option': pathEntity.filterOption?.toMap(),
+      },
+    );
+    final items = result['list'] as Map;
+    return ConvertUtils.convertToPathList(
+      items.cast(),
+      type: pathEntity.type,
+      filterOption: pathEntity.filterOption,
+    );
   }
 }
 

--- a/lib/src/types/darwin.dart
+++ b/lib/src/types/darwin.dart
@@ -1,0 +1,130 @@
+// Copyright 2018 The FlutterCandies author. All rights reserved.
+// Use of this source code is governed by an Apache license that can be found
+// in the LICENSE file.
+
+import 'dart:io';
+
+import '../internal/enums.dart';
+import '../internal/plugin.dart';
+import '../internal/progress_handler.dart';
+import 'cancel_token.dart';
+import 'entity.dart';
+
+/// A Darwin (iOS/macOS) only view over an [AssetEntity].
+///
+/// Obtain it through [AssetEntity.darwin]. It groups PhotoKit-specific reads
+/// that only make sense on Apple platforms, so that [AssetEntity] itself stays
+/// lean instead of accumulating platform-specific members.
+///
+/// {@template photo_manager.DarwinView.migration}
+/// Migration note: this wrapper deliberately keeps no state beyond the wrapped
+/// entity and every member simply forwards to the platform channel. Once the
+/// package's Dart SDK floor reaches 3.3, it can be replaced by a zero-cost
+/// `extension type` over the same representation type without touching any call
+/// site — `asset.darwin.xxx` stays byte-for-byte identical:
+///
+/// ```dart
+/// extension type DarwinAsset(AssetEntity _asset) { ... }
+/// ```
+/// {@endtemplate}
+class DarwinAsset {
+  /// Creates a Darwin view over the given [_asset].
+  ///
+  /// Prefer [AssetEntity.darwin] which performs the platform check for you.
+  const DarwinAsset(this._asset);
+
+  final AssetEntity _asset;
+
+  /// The stable cloud identifier of the asset, shared across devices that use
+  /// the same iCloud Photo Library.
+  ///
+  /// Unlike [AssetEntity.id] (the `localIdentifier`), which differs on every
+  /// device, the cloud identifier lets you match the same photo across devices.
+  ///
+  /// Returns `null` when the asset has no cloud identifier, when iCloud Photos
+  /// is disabled, or when the platform is below iOS 15 / macOS 12.
+  ///
+  /// See also:
+  ///  * `PhotoManager.plugin.getCloudIdentifiers` to resolve many assets in one
+  ///    call, which is far more efficient than calling this getter in a loop.
+  Future<String?> get cloudIdentifier async {
+    final Map<String, String?> mapping = await plugin.getCloudIdentifiers(
+      <String>[_asset.id],
+    );
+    return mapping[_asset.id];
+  }
+
+  /// Whether the asset contains adjustment (edit) data, e.g. filters or crops
+  /// applied in the Photos app.
+  ///
+  /// Backed by `PHAsset.hasAdjustments`. On iOS/macOS below 15.0 a slower
+  /// fallback based on asset resources is used, so avoid calling it in tight
+  /// loops on older systems.
+  ///
+  /// See also:
+  ///  * [baseFile] to obtain the unedited version when this returns `true`.
+  Future<bool> get hasAdjustments => plugin.hasAdjustments(_asset.id);
+
+  /// Obtain the base (unedited) file of the asset, before any adjustments were
+  /// applied in the Photos app.
+  ///
+  /// When the asset has no adjustments this resolves to the same content as
+  /// [AssetEntity.originFile]. Returns `null` if the base resource cannot be
+  /// exported.
+  ///
+  ///  * [isOrigin] requests the original, full-resolution base resource.
+  ///  * [progressHandler] observes the (possibly network-bound) export progress.
+  ///  * [darwinFileType] tries to define the export format, e.g. exporting a
+  ///    MOV file to MP4.
+  ///  * [cancelToken] cancels the export.
+  ///
+  /// See also:
+  ///  * [hasAdjustments] to check whether a distinct base version exists.
+  Future<File?> baseFile({
+    bool isOrigin = true,
+    PMProgressHandler? progressHandler,
+    PMDarwinAVFileType? darwinFileType,
+    PMCancelToken? cancelToken,
+  }) async {
+    final String? path = await plugin.getBaseAdjustmentFile(
+      _asset.id,
+      isOrigin: isOrigin,
+      progressHandler: progressHandler,
+      darwinFileType: darwinFileType,
+      cancelToken: cancelToken,
+    );
+    if (path == null) {
+      return null;
+    }
+    return File(path);
+  }
+}
+
+/// A Darwin (iOS/macOS) only view over an [AssetPathEntity].
+///
+/// Obtain it through [AssetPathEntity.darwin]. Mirrors [DarwinAsset] for
+/// album/folder hierarchy reads that only exist on Apple platforms.
+///
+/// {@macro photo_manager.DarwinView.migration}
+class DarwinAssetPath {
+  /// Creates a Darwin view over the given [_path].
+  ///
+  /// Prefer [AssetPathEntity.darwin] which performs the platform check for you.
+  const DarwinAssetPath(this._path);
+
+  final AssetPathEntity _path;
+
+  /// Request the parent folders that contain this album or folder.
+  ///
+  /// Useful for breadcrumb navigation and walking up nested folder structures.
+  /// Backed by `PHCollectionList.fetchCollectionListsContainingCollection:`.
+  ///
+  /// Returns an empty list for the root, system albums (e.g. Recent, All
+  /// Photos), or collections that are not contained by any folder.
+  ///
+  /// See also:
+  ///  * [AssetPathEntity.getSubPathList] to walk down the hierarchy instead.
+  Future<List<AssetPathEntity>> getParentPathList() {
+    return plugin.getParentPathEntities(_path);
+  }
+}

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -18,6 +18,7 @@ import '../internal/plugin.dart';
 import '../internal/progress_handler.dart';
 import '../utils/convert_utils.dart';
 import 'cancel_token.dart';
+import 'darwin.dart';
 import 'thumbnail.dart';
 import 'types.dart';
 
@@ -191,6 +192,20 @@ class AssetPathEntity {
       albumType: albumType,
       type: type,
       optionGroup: filterOption,
+    );
+  }
+
+  /// A Darwin (iOS/macOS) only namespace of PhotoKit reads for this path.
+  ///
+  /// Groups Apple-specific hierarchy reads (e.g. [DarwinAssetPath.getParentPathList])
+  /// so that [AssetPathEntity] itself stays lean. Throws an [OSError] when
+  /// accessed on a non-Darwin platform, so guard with [Platform] if needed.
+  DarwinAssetPath get darwin {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return DarwinAssetPath(this);
+    }
+    throw const OSError(
+      'AssetPathEntity.darwin is only available on iOS or macOS.',
     );
   }
 
@@ -522,6 +537,21 @@ class AssetEntity {
   ///  * https://developer.android.com/reference/android/provider/MediaStore.Images.ImageColumns#LATITUDE
   ///  * https://developer.apple.com/documentation/corelocation/cllocation?language=objc#declaration
   double? get longitude => _latLng?.longitude;
+
+  /// A Darwin (iOS/macOS) only namespace of PhotoKit reads for this asset.
+  ///
+  /// Groups Apple-specific reads such as [DarwinAsset.cloudIdentifier],
+  /// [DarwinAsset.hasAdjustments] and [DarwinAsset.baseFile], so that
+  /// [AssetEntity] itself stays lean. Throws an [OSError] when accessed on a
+  /// non-Darwin platform, so guard with [Platform] if needed.
+  DarwinAsset get darwin {
+    if (Platform.isIOS || Platform.isMacOS) {
+      return DarwinAsset(this);
+    }
+    throw const OSError(
+      'AssetEntity.darwin is only available on iOS or macOS.',
+    );
+  }
 
   /// Whether this asset is locally available.
   ///  * Android: Always true.


### PR DESCRIPTION
## Summary
- Group iOS/macOS-only PhotoKit reads under `AssetEntity.darwin` / `AssetPathEntity.darwin` so the shared entity classes don't accumulate platform-specific members.
- Add `asset.darwin.cloudIdentifier` and the batch `PhotoManager.plugin.getCloudIdentifiers` for stable cross-device identifiers (iOS 15+/macOS 12+).
- Add `asset.darwin.hasAdjustments` and `asset.darwin.baseFile()` to detect edits and export the unedited base file.
- Add `path.darwin.getParentPathList()` for upward folder navigation.
- Native reuses the existing resource export / path conversion routines; `getParentPath` mirrors `getSubPath`.
- Add a gated example page (iOS/macOS only) demonstrating all three.

The `darwin` accessors keep no state beyond the wrapped entity and only forward to the channel, so they can later be swapped to a zero-cost `extension type` without touching call sites once the SDK floor reaches Dart 3.3.

This supersedes and implements #1333, #1336 and #1339.