### PR TITLE
✨ Allow overriding album type in getAssetListPaged/Range

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Features**
 
+- Add an optional `type` parameter to `AssetPathEntity.getAssetListPaged` and `AssetPathEntity.getAssetListRange` so callers can filter to a specific `RequestType` within a single album (e.g. read videos out of a `common` album) without constructing a new `AssetPathEntity`. Defaults to the album's own `type` when omitted.
 - Add Darwin (iOS/macOS) only namespaced accessors `AssetEntity.darwin` and `AssetPathEntity.darwin` that group PhotoKit-specific reads without bloating the shared entity classes:
   - `asset.darwin.cloudIdentifier` and the batch `PhotoManager.plugin.getCloudIdentifiers` resolve stable cross-device cloud identifiers (iOS 15+/macOS 12+).
   - `asset.darwin.hasAdjustments` reports whether an asset has edits, and `asset.darwin.baseFile()` exports the unedited base file.

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -213,12 +213,16 @@ class AssetPathEntity {
   ///
   /// [page] should starts with and greater than 0.
   /// [size] is item count of current [page].
+  /// [type] overrides the album's own [RequestType] for this call only, so a
+  /// caller can e.g. read only videos out of a `common` album. Defaults to the
+  /// album's [type] when omitted.
   ///
   /// The length of returned assets might be less than requested.
   /// Not existing assets will be excluded from the result.
   Future<List<AssetEntity>> getAssetListPaged({
     required int page,
     required int size,
+    RequestType? type,
   }) {
     assert(albumType == 1, 'Only album can request for assets.');
     assert(size > 0, 'Page size must be greater than 0.');
@@ -226,7 +230,7 @@ class AssetPathEntity {
       id,
       page: page,
       size: size,
-      type: type,
+      type: type ?? this.type,
       optionGroup: filterOption,
     );
   }
@@ -236,12 +240,16 @@ class AssetPathEntity {
   /// The [start] and [end] are similar to [String.substring], but it'll return
   /// the maximum assets if the total count of assets is fewer than the range,
   /// instead of throwing a [RangeError] like [String.substring].
+  /// [type] overrides the album's own [RequestType] for this call only, so a
+  /// caller can e.g. read only videos out of a `common` album. Defaults to the
+  /// album's [type] when omitted.
   ///
   /// The length of returned assets might be less than requested.
   /// Not existing assets will be excluded from the result.
   Future<List<AssetEntity>> getAssetListRange({
     required int start,
     required int end,
+    RequestType? type,
   }) async {
     assert(albumType == 1, 'Only album can request for assets.');
     assert(start >= 0, 'The start must be greater than 0.');
@@ -253,7 +261,7 @@ class AssetPathEntity {
     }
     return plugin.getAssetListRange(
       id,
-      type: type,
+      type: type ?? this.type,
       start: start,
       end: end,
       optionGroup: filterOption,


### PR DESCRIPTION
## Summary

- Adds optional `RequestType? type` to `AssetPathEntity.getAssetListPaged` and `AssetPathEntity.getAssetListRange`, defaulting to the album's own `type`, so callers can filter to a specific media type within a single album without constructing a new entity.
- Dart-only change — the native pipeline already applies the mediaType predicate (`PMRequestTypeUtils getFetchOptionsByType:` / `PMFilterOption getFetchOptions:type:` on Darwin, and the equivalent on Android), so no platform code moves.

Implements #1257. Supersedes #1305 (rebased on latest `main` with review feedback applied; original authorship preserved).