### PR TITLE
🐛 Match Android permission requests to RequestType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Fix Android 14+ limited permission photo selection not reflecting deselection in Flutter layer. When users modify their photo selection via `presentLimited()`, the changes are now properly notified to the Flutter layer.
 - Fix delayed native deletion confirmation dialogs on iOS by elevating the dispatch queue priority of `deleteWithIds`, `removeInAlbum`, and `deleteAlbum` to `QOS_CLASS_USER_INITIATED`.
 - Fix Android 14+ permission requests incorrectly short-circuiting when only part of the requested media access was already granted.
+- Fix Android permission requests always asking for both image and video access regardless of `RequestType`. The plugin now only requests `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` matching the caller's `RequestType`, so the Android 14+ system photo picker only shows the media types the app actually asked for.
 - Fix Darwin video durations being truncated instead of rounded, so `AssetEntity.duration` matches the system album display more closely.
 - Fix Darwin `getTitleAsync` returning a null channel result by falling back to an empty string.
 - Fix Darwin Live Photo exports with an explicit `darwinFileType`, restoring iOS conversions such as Live Photo MOV-to-MP4 output.

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -271,6 +271,22 @@ iOS14 引入了部分资源限制的权限 (`PermissionState.limited`)。
 在 Android 中一旦授予某个资源的访问权限，就无法撤销，
 即使再次使用 `presentLimited` 时不选中也不会撤销对它的访问权限。
 
+##### 受限授权与请求类型不匹配时的处理
+
+无论 iOS 还是 Android，系统都不会告知当前有限访问的选择集里包含哪些媒体类型。
+如果应用请求了 `RequestType.image`，但用户在授予有限访问时只勾选了视频，
+权限仍然会返回 `PermissionState.limited`，查询图片时也会合理地返回 0 条结果，
+和"库里确实没有图片"无法区分。
+
+推荐的处理方式是在这种情况下引导用户重新选择：
+
+```dart
+if (state == PermissionState.limited) {
+  // Android 14+ 上 `type` 会限制 picker 只显示对应类型；iOS 不支持按类型过滤，此参数会被忽略。
+  await PhotoManager.presentLimited(type: RequestType.image);
+}
+```
+
 ### 获取相簿或图集 (`AssetPathEntity`)
 
 相簿或者图集以抽象类 [`AssetPathEntity`][] 的形式呈现，

--- a/README.md
+++ b/README.md
@@ -290,6 +290,24 @@ However, there is a slight difference in behavior (based on the emulator):
 On Android, the access permission to a certain resource cannot be revoked once it is granted,
 even if it hasn't been selected when using `presentLimited` in future actions.
 
+##### Handling a limited grant that doesn't match the requested type
+
+Neither iOS nor Android exposes which media kinds are inside the current limited
+selection. If your app requests `RequestType.image` but the user picked only
+videos while granting limited access, permission will still resolve to
+`PermissionState.limited`, and querying images will legitimately return zero
+results — the same as if the library truly had no images.
+
+The recommended recovery is to prompt for reselection when this happens:
+
+```dart
+if (state == PermissionState.limited) {
+  // On Android 14+, `type` filters the picker to only the media kinds you need.
+  // On iOS the picker cannot be filtered by type and `type` is ignored.
+  await PhotoManager.presentLimited(type: RequestType.image);
+}
+```
+
 ### Get albums/folders (`AssetPathEntity`)
 
 Albums or folders are abstracted as the [`AssetPathEntity`][] class.

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate33.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate33.kt
@@ -31,8 +31,10 @@ class PermissionDelegate33 : PermissionDelegate() {
         val containsVideo = RequestTypeUtils.containsVideo(requestType)
         val containsAudio = RequestTypeUtils.containsAudio(requestType)
 
-        if (containsImage || containsVideo) {
+        if (containsImage) {
             permissions.add(mediaImage)
+        }
+        if (containsVideo) {
             permissions.add(mediaVideo)
         }
         if (containsAudio) {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate34.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/impl/PermissionDelegate34.kt
@@ -45,9 +45,13 @@ class PermissionDelegate34 : PermissionDelegate() {
         val containsVideo = RequestTypeUtils.containsVideo(requestType)
         val containsAudio = RequestTypeUtils.containsAudio(requestType)
 
-        if (containsImage || containsVideo) {
+        if (containsImage) {
             permissions.add(mediaImage)
+        }
+        if (containsVideo) {
             permissions.add(mediaVideo)
+        }
+        if (containsImage || containsVideo) {
             permissions.add(mediaVisualUserSelected)
 
             if (mediaLocation) {
@@ -162,9 +166,15 @@ class PermissionDelegate34 : PermissionDelegate() {
         this.resultHandler = resultHandler
 
         val permissions = mutableListOf<String>()
-        if (RequestTypeUtils.containsImage(type) || RequestTypeUtils.containsVideo(type)) {
+        val containsImage = RequestTypeUtils.containsImage(type)
+        val containsVideo = RequestTypeUtils.containsVideo(type)
+        if (containsImage) {
             permissions.add(mediaImage)
+        }
+        if (containsVideo) {
             permissions.add(mediaVideo)
+        }
+        if (containsImage || containsVideo) {
             permissions.add(mediaVisualUserSelected)
         }
 

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -87,7 +87,19 @@ class PhotoManager {
     return plugin.getPermissionState(requestOption);
   }
 
-  /// Prompts the limited assets selection modal on iOS.
+  /// Prompts the limited assets selection modal on iOS, or the system photo
+  /// picker on Android 14+ (API 34+).
+  ///
+  /// On Android 14+, [type] filters which media kinds the picker shows —
+  /// e.g. pass `RequestType.image` to only let the user pick images. On iOS
+  /// the system picker cannot be filtered by media type and [type] is ignored.
+  ///
+  /// Use this to give the user a chance to reselect when an earlier
+  /// [PermissionState.limited] grant does not contain the media kind your
+  /// app actually needs: neither iOS nor Android exposes which types are in
+  /// the current selection, so an image-only query against a videos-only
+  /// limited grant will legitimately return zero results — re-prompting here
+  /// is the recommended recovery path.
   ///
   /// This method only supports from iOS 14.0, and will behave differently on
   /// iOS 14 and 15:


### PR DESCRIPTION
## Summary

- Currently `PermissionDelegate33` / `PermissionDelegate34` always add both `READ_MEDIA_IMAGES` and `READ_MEDIA_VIDEO` to the permission request whenever the caller's `RequestType` includes image *or* video. As a result, the Android 14+ system photo picker shows both media types even when the app only asked for one (image-only apps see videos in the picker, and vice versa).
- This PR splits the branches so each of `READ_MEDIA_IMAGES` / `READ_MEDIA_VIDEO` is added only when the corresponding bit is set in `RequestType`. `READ_MEDIA_VISUAL_USER_SELECTED` is still requested whenever any visual permission is requested (Android 14+), and `ACCESS_MEDIA_LOCATION` behavior is unchanged. Same fix applied to `PermissionDelegate34.presentLimited`.

Fixes the Android portion of #1398. The iOS symptoms in that issue are not actionable — Apple's `PHPhotoLibrary.presentLimitedLibraryPicker(from:)` does not accept a filter, and the follow-up "Select Photos" sheet that appears immediately after choosing "Limited Access" is emitted by iOS itself as part of `requestAuthorizationForAccessLevel:` and cannot be suppressed by the app.
