### PR TITLE
🐛 Fix iOS presentLimited() using deprecated UIApplication.keyWindow

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Fix Darwin `getTitleAsync` returning a null channel result by falling back to an empty string.
 - Fix Darwin Live Photo exports with an explicit `darwinFileType`, restoring iOS conversions such as Live Photo MOV-to-MP4 output.
 - Fix Darwin image `loadFile(isOrigin: false)` blocking the iOS UI thread by making the request asynchronous and moving JPEG file conversion off the main thread, allowing `PMProgressHandler` updates to arrive while loading.
+- Fix `presentLimited()` on iOS resolving the presenting view controller through the deprecated `UIApplication.keyWindow`, which can return the wrong window (or none) once an app adopts the UIScene life cycle. The plugin now prefers the `FlutterViewController` attached to its own engine and falls back to scanning the foreground-active `UIWindowScene` for the key window.
 
 ## 3.9.0
 

--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -201,8 +201,57 @@
 #if TARGET_OS_IOS
 #if __IPHONE_14_0
 
+// `UIApplication.keyWindow` doesn't reflect the right window once an app adopts
+// (or is forced onto, per TN3187) the UIScene life cycle, and it's the only window
+// picking API compatible back to the plugin's iOS 9 deployment target.
+- (nullable UIWindow *)pm_keyWindow {
+    if (@available(iOS 13.0, *)) {
+        for (UIScene *scene in UIApplication.sharedApplication.connectedScenes) {
+            if (![scene isKindOfClass:UIWindowScene.class]) {
+                continue;
+            }
+            UIWindowScene *windowScene = (UIWindowScene *)scene;
+            if (windowScene.activationState != UISceneActivationStateForegroundActive) {
+                continue;
+            }
+            for (UIWindow *window in windowScene.windows) {
+                if (window.isKeyWindow) {
+                    return window;
+                }
+            }
+        }
+    }
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Wdeprecated-declarations"
+    return UIApplication.sharedApplication.keyWindow;
+#pragma clang diagnostic pop
+}
+
 - (UIViewController *)getCurrentViewController {
-    UIViewController *controller = UIApplication.sharedApplication.keyWindow.rootViewController;
+    UIViewController *controller = nil;
+
+    // `registrar.viewController` (Flutter 3.38+) is scoped to the FlutterEngine that owns
+    // this plugin instance, so it's the correct pick in multi-engine/add-to-app hosts where
+    // several engines/windows can be alive at once. Dispatched dynamically so the plugin
+    // keeps compiling against older Flutter.framework headers that don't declare it.
+    // Fall back whenever it's unavailable, nil, or stale (a FlutterViewController pushed off
+    // a native nav stack stays attached to its engine, and thus non-nil, until it's
+    // deallocated -- long after its view has left the window).
+    id registrar = privateRegistrar;
+    if ([registrar respondsToSelector:@selector(viewController)]) {
+#pragma clang diagnostic push
+#pragma clang diagnostic ignored "-Warc-performSelector-leaks"
+        UIViewController *registrarController = [registrar performSelector:@selector(viewController)];
+#pragma clang diagnostic pop
+        if (registrarController.isViewLoaded && registrarController.view.window != nil) {
+            controller = registrarController;
+        }
+    }
+
+    if (!controller) {
+        controller = [self pm_keyWindow].rootViewController;
+    }
+
     if (controller) {
         UIViewController *result = controller;
         while (1) {


### PR DESCRIPTION
## Summary

- `getCurrentViewController` (used by `presentLimited()`) resolved the presenting view controller via `UIApplication.sharedApplication.keyWindow.rootViewController`, which is deprecated since iOS 13 and can return the wrong window — or none — once an app adopts the UIScene life cycle. Per Apple's TN3187, iOS 27 makes the UIScene life cycle mandatory for apps built with the latest SDK, so this needed to stop depending on `keyWindow`.
- The plugin doesn't otherwise need UIScene adoption: it only implements `applicationWillTerminate:` via `addApplicationDelegate:`, which is an app-level (not scene-level) callback that Apple's docs confirm keeps firing regardless of UIScene adoption. No `addSceneDelegate:` registration is needed.
- New resolution order in `getCurrentViewController`:
  1. `registrar.viewController` (Flutter 3.38+), dispatched dynamically so the plugin keeps compiling against older `Flutter.framework` headers that don't declare it. Verified against the Flutter engine source (`FlutterEngine.mm`) that this is scoped per-`FlutterEngine`, making it the correct pick in multi-engine/add-to-app hosts. Only trusted when the returned controller's view is actually attached to a window (`isViewLoaded && view.window != nil`), since a `FlutterViewController` pushed off a native nav stack stays attached to its engine — and thus non-nil — until it's deallocated, well after its view has left the window.
  2. Falls back to scanning `UIApplication.sharedApplication.connectedScenes` for the foreground-active `UIWindowScene`'s key window (iOS 13+, pure UIKit — no Flutter engine version dependency).
  3. Falls back further to the deprecated `keyWindow` for pre-iOS 13 (below the effective iOS 14 gate on this code path) or scene-less apps.
- Unrelated to this: issue #1410's iOS 27 beta crash in `getAssetPathList()` is a separate `PHAssetCollection` fetch issue, not a window/UIScene problem (the reporter's environment shows an app built with Xcode 16, so it isn't even subject to the UIScene-mandatory launch failure). No logs have been provided for that one yet.

Fixes #1377.