### PR TITLE
🐛 Fix latitude/longitude 0.0 being dropped as "no location"

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Fix Darwin Live Photo exports with an explicit `darwinFileType`, restoring iOS conversions such as Live Photo MOV-to-MP4 output.
 - Fix Darwin image `loadFile(isOrigin: false)` blocking the iOS UI thread by making the request asynchronous and moving JPEG file conversion off the main thread, allowing `PMProgressHandler` updates to arrive while loading.
 - Fix `presentLimited()` on iOS resolving the presenting view controller through the deprecated `UIApplication.keyWindow`, which can return the wrong window (or none) once an app adopts the UIScene life cycle. The plugin now prefers the `FlutterViewController` attached to its own engine and falls back to scanning the foreground-active `UIWindowScene` for the key window.
+- Fix `latitude`/`longitude`/`latLng` being dropped whenever a coordinate component was exactly `0.0` (e.g. assets near the equator or prime meridian). Dart, Android, and iOS/macOS all used `0.0` as a "no location" sentinel; `0.0` is now treated as a valid coordinate, and the native platforms report the absence of location data as an explicit `null` instead.
 
 ## 3.9.0
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -245,10 +245,10 @@ class PhotoManager(private val context: Context) {
         resultHandler.reply(exists)
     }
 
-    fun getLocation(id: String): Map<String, Double> {
+    fun getLocation(id: String): Map<String, Double?> {
         val latLong = dbUtils.getLatLong(context, id)
         return if (latLong == null) {
-            mapOf("lat" to 0.0, "lng" to 0.0)
+            mapOf("lat" to null, "lng" to null)
         } else {
             mapOf("lat" to latLong[0], "lng" to latLong[1])
         }

--- a/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMAssetPathEntity.h
@@ -29,8 +29,8 @@
 @property(nonatomic, assign) int type;
 @property(nonatomic, strong) PHAsset *phAsset;
 @property(nonatomic, assign) long modifiedDt;
-@property(nonatomic, assign) double lat;
-@property(nonatomic, assign) double lng;
+@property(nonatomic, strong, nullable) NSNumber *lat;
+@property(nonatomic, strong, nullable) NSNumber *lng;
 @property(nonatomic, copy) NSString *title;
 @property(nonatomic, assign) NSUInteger subtype;
 @property(nonatomic, assign) BOOL favorite;

--- a/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMConvertUtils.m
@@ -95,8 +95,8 @@
         @"duration": @(duration),
         @"type": @(typeInt),
         @"modifiedDt": @(modifiedDt),
-        @"lng": @(asset.location.coordinate.longitude),
-        @"lat": @(asset.location.coordinate.latitude),
+        @"lng": asset.location != nil ? @(asset.location.coordinate.longitude) : [NSNull null],
+        @"lat": asset.location != nil ? @(asset.location.coordinate.latitude) : [NSNull null],
         @"title": needTitle ? [asset title] : @"",
         @"subtype": @(asset.mediaSubtypes),
     };
@@ -113,8 +113,8 @@
         @"favorite": @(asset.favorite),
         @"type": @(asset.type),
         @"modifiedDt": @(asset.modifiedDt),
-        @"lng": @(asset.lng),
-        @"lat": @(asset.lat),
+        @"lng": asset.lng ?: [NSNull null],
+        @"lat": asset.lat ?: [NSNull null],
         @"title": needTitle ? asset.title : @"",
         @"subtype": @(asset.subtype),
     };

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -429,8 +429,13 @@
                                                     type:type];
     entity.phAsset = asset;
     entity.modifiedDt = modifiedTimeStamp;
-    entity.lat = asset.location.coordinate.latitude;
-    entity.lng = asset.location.coordinate.longitude;
+    if (asset.location != nil) {
+        entity.lat = @(asset.location.coordinate.latitude);
+        entity.lng = @(asset.location.coordinate.longitude);
+    } else {
+        entity.lat = nil;
+        entity.lng = nil;
+    }
     entity.title = needTitle ? [asset title] : @"";
     entity.favorite = asset.isFavorite;
     entity.subtype = asset.mediaSubtypes;

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -1005,13 +1005,10 @@ class LatLng {
   const LatLng({
     required this.latitude,
     required this.longitude,
-  }) : assert(latitude != 0.0 && longitude != 0.0);
+  });
 
   static LatLng? fromValues({double? latitude, double? longitude}) {
-    if (latitude == null ||
-        latitude == 0.0 ||
-        longitude == null ||
-        longitude == 0.0) {
+    if (latitude == null || longitude == null) {
       return null;
     }
     return LatLng(latitude: latitude, longitude: longitude);
@@ -1025,7 +1022,7 @@ class LatLng {
 
   @override
   bool operator ==(Object other) {
-    if (other is! AssetEntity) {
+    if (other is! LatLng) {
       return false;
     }
     return latitude == other.latitude && longitude == other.longitude;

--- a/lib/src/utils/convert_utils.dart
+++ b/lib/src/utils/convert_utils.dart
@@ -110,9 +110,9 @@ class ConvertUtils {
     String? title,
   }) {
     final rawLat = data['lat'];
-    final lat = rawLat is num && rawLat != 0 ? rawLat.toDouble() : null;
+    final lat = rawLat is num ? rawLat.toDouble() : null;
     final rawLng = data['lng'];
-    final lng = rawLng is num && rawLng != 0 ? rawLng.toDouble() : null;
+    final lng = rawLng is num ? rawLng.toDouble() : null;
 
     final AssetEntity result = AssetEntity(
       id: data['id'] as String,

--- a/test/photo_manager_test.dart
+++ b/test/photo_manager_test.dart
@@ -8,6 +8,7 @@ import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:photo_manager/photo_manager.dart';
 import 'package:photo_manager/src/internal/constants.dart';
+import 'package:photo_manager/src/utils/convert_utils.dart';
 
 class _TestPlugin extends PhotoManagerPlugin {
   @override
@@ -64,5 +65,31 @@ void main() {
     await expectLater(entity.fileSize, completion(12345));
     expect(capturedCall?.method, PMConstants.mGetFileSize);
     expect(capturedCall?.arguments['id'], 'asset-id');
+  });
+
+  test('LatLng.fromValues keeps real zero coordinates', () {
+    expect(LatLng.fromValues(latitude: 0.0, longitude: 45.0), isNotNull);
+    expect(LatLng.fromValues(latitude: 45.0, longitude: 0.0), isNotNull);
+    expect(
+      LatLng.fromValues(latitude: 0.0, longitude: 0.0),
+      equals(const LatLng(latitude: 0.0, longitude: 0.0)),
+    );
+    expect(LatLng.fromValues(latitude: null, longitude: 0.0), isNull);
+    expect(LatLng.fromValues(latitude: 0.0, longitude: null), isNull);
+  });
+
+  test('convertMapToAsset keeps real zero lat/lng from the platform', () {
+    final entity = ConvertUtils.convertMapToAsset(<String, dynamic>{
+      'id': 'asset-id',
+      'type': AssetType.image.index,
+      'width': 1,
+      'height': 1,
+      'lat': 0.0,
+      'lng': 45.0,
+    });
+
+    expect(entity.latitude, equals(0.0));
+    expect(entity.longitude, equals(45.0));
+    expect(entity.latLng, isNotNull);
   });
 }


### PR DESCRIPTION
## Summary

- Assets whose GPS coordinate had a latitude or longitude of exactly `0.0` (e.g. near the equator or prime meridian) had their location silently dropped and reported as `null` instead of the real coordinate. Several layers used `0.0` as a sentinel for "no location" rather than a proper nullable representation.
- Dart: `ConvertUtils.convertMapToAsset` only accepted `lat`/`lng` from the platform channel when the raw value was `!= 0`, and `LatLng`'s constructor/`fromValues` treated `0.0` as invalid, asserting against it and returning `null`. Both now only check for `null`/type, not zero.
- Android: `PhotoManager.getLocation` returned `{lat: 0.0, lng: 0.0}` whenever `getLatLong` found no location, indistinguishable from a real `(0, 0)` fix. It now returns `null` for both fields in that case.
- iOS/macOS: `PMAssetEntity.lat`/`.lng` were primitive `double`s populated from `asset.location.coordinate`, but messaging `.coordinate` on a `nil` `location` returns a zeroed struct in Objective-C — the same ambiguity. The properties are now nullable `NSNumber *`, only populated when `asset.location != nil`, and serialized as `NSNull` otherwise.
- Also fixed a latent typo in `LatLng.operator==` (`other is! AssetEntity` instead of `other is! LatLng`), found while adding a test for the fix above — it made `LatLng` equality never succeed.
- Added Dart tests asserting `LatLng.fromValues` keeps a real `(0.0, X)`/`(0.0, 0.0)` coordinate instead of returning `null`, and that `ConvertUtils.convertMapToAsset` preserves a `lat: 0.0` value from the platform channel.

Fixes #1400.