### PR TITLE
✨ Add `AssetEntity.darwin.getAdjustmentData()` to export AAE edit data on iOS/macOS

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Add Darwin (iOS/macOS) only namespaced accessors `AssetEntity.darwin` and `AssetPathEntity.darwin` that group PhotoKit-specific reads without bloating the shared entity classes:
   - `asset.darwin.cloudIdentifier` and the batch `PhotoManager.plugin.getCloudIdentifiers` resolve stable cross-device cloud identifiers (iOS 15+/macOS 12+).
   - `asset.darwin.hasAdjustments` reports whether an asset has edits, and `asset.darwin.baseFile()` exports the unedited base file.
+  - `asset.darwin.adjustmentData()` exports the raw AAE adjustment (edit-history) data backing an asset's edits, so callers can access the original resource, the edit metadata, and the rendered result separately (non-destructive editing).
   - `path.darwin.getParentPathList()` returns the parent folders containing an album or folder.
 - Add `updateCreationDate` to `PhotoManager.editor.darwin` and `PhotoManager.editor.android` for modifying an asset's creation date after it has been saved.
   - On iOS/macOS: updates the `PHAsset.creationDate` property.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,8 +13,8 @@ To know more about breaking changes, see the [Migration Guide][].
 - Add an optional `type` parameter to `AssetPathEntity.getAssetListPaged` and `AssetPathEntity.getAssetListRange` so callers can filter to a specific `RequestType` within a single album (e.g. read videos out of a `common` album) without constructing a new `AssetPathEntity`. Defaults to the album's own `type` when omitted.
 - Add Darwin (iOS/macOS) only namespaced accessors `AssetEntity.darwin` and `AssetPathEntity.darwin` that group PhotoKit-specific reads without bloating the shared entity classes:
   - `asset.darwin.cloudIdentifier` and the batch `PhotoManager.plugin.getCloudIdentifiers` resolve stable cross-device cloud identifiers (iOS 15+/macOS 12+).
-  - `asset.darwin.hasAdjustments` reports whether an asset has edits, and `asset.darwin.baseFile()` exports the unedited base file.
-  - `asset.darwin.adjustmentData()` exports the raw AAE adjustment (edit-history) data backing an asset's edits, so callers can access the original resource, the edit metadata, and the rendered result separately (non-destructive editing).
+  - `asset.darwin.hasAdjustments` reports whether an asset has edits, and `asset.darwin.getBaseFile()` exports the unedited base file.
+  - `asset.darwin.getAdjustmentData()` exports the raw AAE adjustment (edit-history) data backing an asset's edits, so callers can access the original resource, the edit metadata, and the rendered result separately (non-destructive editing).
   - `path.darwin.getParentPathList()` returns the parent folders containing an album or folder.
 - Add `updateCreationDate` to `PhotoManager.editor.darwin` and `PhotoManager.editor.android` for modifying an asset's creation date after it has been saved.
   - On iOS/macOS: updates the `PHAsset.creationDate` property.

--- a/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
+++ b/darwin/photo_manager/Sources/photo_manager/PMPlugin.m
@@ -405,6 +405,7 @@
         [method isEqualToString:@"getAssetListRange"] ||
         [method isEqualToString:@"getFullFile"] ||
         [method isEqualToString:@"getBaseAdjustmentFile"] ||
+        [method isEqualToString:@"getAdjustmentData"] ||
         [method isEqualToString:@"getFileSize"] ||
         [method isEqualToString:@"getMediaUrl"] ||
         [method isEqualToString:@"fetchEntityProperties"] ||
@@ -706,6 +707,12 @@
                                     fileType:fileType
                                resultHandler:handler
                              progressHandler:progressHandler];
+    } else if ([@"getAdjustmentData" isEqualToString:call.method]) {
+        NSString *assetId = call.arguments[@"id"];
+        PMProgressHandler *progressHandler = [self getProgressHandlerFromDict:call.arguments];
+        [manager getAdjustmentDataWithId:assetId
+                           resultHandler:handler
+                         progressHandler:progressHandler];
     } else if ([@"getParentPath" isEqualToString:call.method]) {
         NSString *galleryId = call.arguments[@"id"];
         int type = [call.arguments[@"type"] intValue];

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -35,6 +35,14 @@ NS_ASSUME_NONNULL_BEGIN
 /// `getCurrentResource` when no distinct original resource exists.
 - (PHAssetResource *)getOriginalResource;
 
+/// The AAE adjustment-data resource (`PHAssetResourceTypeAdjustmentData`) that
+/// stores the edit history applied in the Photos app, or `nil` when the asset
+/// has no adjustments.
+///
+/// @note This resource is deliberately excluded by `getCurrentResource` /
+/// `getOriginalResource`, so it must be fetched through this dedicated accessor.
+- (nullable PHAssetResource *)getAdjustmentDataResource;
+
 - (PHAssetResource *)getLivePhotosResource;
 
 @end

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -230,6 +230,16 @@
     return [self getCurrentResource];
 }
 
+- (PHAssetResource *)getAdjustmentDataResource {
+    NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:self];
+    for (PHAssetResource *res in resources) {
+        if (res.type == PHAssetResourceTypeAdjustmentData) {
+            return res;
+        }
+    }
+    return nil;
+}
+
 - (void)requestCurrentResourceData:(void (^)(NSData *_Nullable))block {
     PHAssetResource *res = [self getCurrentResource];
     

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
@@ -131,6 +131,12 @@ typedef void (^AssetBlockResult)(PMAssetEntity *, NSObject *);
                       resultHandler:(PMResultHandler *)handler
                     progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;
 
+/// Export the raw AAE adjustment-data bytes of the asset with [assetId].
+/// Replies with `nil` when the asset has no adjustment data.
+- (void)getAdjustmentDataWithId:(NSString *)assetId
+                  resultHandler:(PMResultHandler *)handler
+                progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler;
+
 /// The parent folders containing the album/folder with [id].
 - (NSArray<PMAssetPathEntity *> *)getParentPathWithId:(NSString *)id type:(int)type albumType:(int)albumType option:(NSObject<PMBaseFilter> *)option;
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1808,14 +1808,72 @@
     }];
 }
 
+- (void)getAdjustmentDataWithId:(NSString *)assetId
+                  resultHandler:(PMResultHandler *)handler
+                progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler {
+    PMAssetEntity *entity = [self getAssetEntity:assetId];
+    if (!entity || !entity.phAsset) {
+        [handler replyError:[NSString stringWithFormat:@"Asset %@ file cannot be obtained.", assetId]];
+        return;
+    }
+    PHAssetResource *resource = [entity.phAsset getAdjustmentDataResource];
+    if (!resource) {
+        // The asset has no adjustment data; reply with null so the Dart side
+        // resolves to `null` rather than an error.
+        [self notifySuccess:progressHandler];
+        [handler reply:nil];
+        return;
+    }
+
+    PHAssetResourceRequestOptions *options = [PHAssetResourceRequestOptions new];
+    [options setNetworkAccessAllowed:YES];
+
+    __block double lastProgress = 0.0;
+    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
+    __weak typeof(self) weakSelf = self;
+    [options setProgressHandler:^(double progress) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        lastProgress = progress;
+        if (progress != 1) {
+            [strongSelf notifyProgress:progressHandler progress:progress state:PMProgressStateLoading];
+        }
+    }];
+
+    // Adjustment data can be delivered across multiple callbacks, so accumulate.
+    NSMutableData *buffer = [NSMutableData data];
+    PHAssetResourceManager *resourceManager = PHAssetResourceManager.defaultManager;
+    [resourceManager requestDataForAssetResource:resource
+                                         options:options
+                             dataReceivedHandler:^(NSData *_Nonnull data) {
+        [buffer appendData:data];
+    }
+                               completionHandler:^(NSError *_Nullable error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) {
+            return;
+        }
+        if (error) {
+            [strongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
+            [handler replyError:error.localizedDescription];
+        } else {
+            id result = [strongSelf.converter convertData:buffer];
+            [handler reply:result];
+            [strongSelf notifySuccess:progressHandler];
+        }
+    }];
+}
+
 - (NSArray<PMAssetPathEntity *> *)convertPHCollectionToPMAssetPathArray:(NSArray<PHCollection *> *)phArray
                                                                  option:(PHFetchOptions *)option {
     NSMutableArray<PMAssetPathEntity *> *result = [NSMutableArray new];
-    
+
     for (PHCollection *collection in phArray) {
         [result addObject:[self convertPHCollectionToPMPath:collection option:option]];
     }
-    
+
     return result;
 }
 

--- a/example/lib/page/developer/ios/darwin_features_page.dart
+++ b/example/lib/page/developer/ios/darwin_features_page.dart
@@ -1,4 +1,5 @@
 import 'dart:io';
+import 'dart:typed_data';
 
 import 'package:flutter/material.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -8,7 +9,8 @@ import 'package:photo_manager/photo_manager.dart';
 ///
 ///  * `asset.darwin.cloudIdentifier` and the batch
 ///    `PhotoManager.plugin.getCloudIdentifiers`
-///  * `asset.darwin.hasAdjustments` + `asset.darwin.baseFile()`
+///  * `asset.darwin.hasAdjustments` + `asset.darwin.baseFile()` +
+///    `asset.darwin.adjustmentData()`
 ///  * `path.darwin.getParentPathList()`
 ///
 /// This page is only meaningful on iOS/macOS; the entry point in
@@ -129,10 +131,16 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
     final File? base = await asset.darwin.baseFile();
     if (base == null) {
       _log('📄 baseFile: <null>');
-      return;
+    } else {
+      final int length = await base.length();
+      _log('📄 baseFile: ${base.path} ($length bytes)');
     }
-    final int length = await base.length();
-    _log('📄 baseFile: ${base.path} ($length bytes)');
+    final Uint8List? aae = await asset.darwin.adjustmentData();
+    _log(
+      aae == null
+          ? '🧬 adjustmentData: <null>'
+          : '🧬 adjustmentData: ${aae.length} bytes',
+    );
   }
 
   Future<void> _parentPaths() async {
@@ -166,7 +174,8 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
                 padding: EdgeInsets.all(24),
                 child: Text(
                   'These APIs (cloudIdentifier / hasAdjustments / baseFile / '
-                  'getParentPathList) are only available on iOS and macOS.',
+                  'adjustmentData / getParentPathList) are only available on '
+                  'iOS and macOS.',
                   textAlign: TextAlign.center,
                 ),
               ),
@@ -193,7 +202,7 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
                         onPressed: _busy
                             ? null
                             : () => _run(_hasAdjustmentsAndBaseFile),
-                        child: const Text('hasAdjustments + baseFile'),
+                        child: const Text('hasAdjustments + baseFile + aae'),
                       ),
                       ElevatedButton(
                         onPressed: _busy ? null : () => _run(_parentPaths),

--- a/example/lib/page/developer/ios/darwin_features_page.dart
+++ b/example/lib/page/developer/ios/darwin_features_page.dart
@@ -9,8 +9,8 @@ import 'package:photo_manager/photo_manager.dart';
 ///
 ///  * `asset.darwin.cloudIdentifier` and the batch
 ///    `PhotoManager.plugin.getCloudIdentifiers`
-///  * `asset.darwin.hasAdjustments` + `asset.darwin.baseFile()` +
-///    `asset.darwin.adjustmentData()`
+///  * `asset.darwin.hasAdjustments` + `asset.darwin.getBaseFile()` +
+///    `asset.darwin.getAdjustmentData()`
 ///  * `path.darwin.getParentPathList()`
 ///
 /// This page is only meaningful on iOS/macOS; the entry point in
@@ -128,18 +128,18 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
     }
     final bool hasAdjustments = await asset.darwin.hasAdjustments;
     _log('✏️ hasAdjustments: $hasAdjustments');
-    final File? base = await asset.darwin.baseFile();
+    final File? base = await asset.darwin.getBaseFile();
     if (base == null) {
-      _log('📄 baseFile: <null>');
+      _log('📄 getBaseFile: <null>');
     } else {
       final int length = await base.length();
-      _log('📄 baseFile: ${base.path} ($length bytes)');
+      _log('📄 getBaseFile: ${base.path} ($length bytes)');
     }
-    final Uint8List? aae = await asset.darwin.adjustmentData();
+    final Uint8List? aae = await asset.darwin.getAdjustmentData();
     _log(
       aae == null
-          ? '🧬 adjustmentData: <null>'
-          : '🧬 adjustmentData: ${aae.length} bytes',
+          ? '🧬 getAdjustmentData: <null>'
+          : '🧬 getAdjustmentData: ${aae.length} bytes',
     );
   }
 
@@ -173,8 +173,8 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
               child: Padding(
                 padding: EdgeInsets.all(24),
                 child: Text(
-                  'These APIs (cloudIdentifier / hasAdjustments / baseFile / '
-                  'adjustmentData / getParentPathList) are only available on '
+                  'These APIs (cloudIdentifier / hasAdjustments / getBaseFile / '
+                  'getAdjustmentData / getParentPathList) are only available on '
                   'iOS and macOS.',
                   textAlign: TextAlign.center,
                 ),
@@ -202,7 +202,7 @@ class _DarwinFeaturesPageState extends State<DarwinFeaturesPage> {
                         onPressed: _busy
                             ? null
                             : () => _run(_hasAdjustmentsAndBaseFile),
-                        child: const Text('hasAdjustments + baseFile + aae'),
+                        child: const Text('hasAdjustments + getBaseFile + aae'),
                       ),
                       ElevatedButton(
                         onPressed: _busy ? null : () => _run(_parentPaths),

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -69,6 +69,7 @@ class PMConstants {
   static const String mGetCloudIdentifiers = 'getCloudIdentifiers';
   static const String mHasAdjustments = 'hasAdjustments';
   static const String mGetBaseAdjustmentFile = 'getBaseAdjustmentFile';
+  static const String mGetAdjustmentData = 'getAdjustmentData';
   static const String mGetParentPath = 'getParentPath';
 
   static const String mGetAssetCount = 'getAssetCount';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -1018,6 +1018,16 @@ mixin IosPlugin on BasePlugin {
     return _channel.invokeMethod(PMConstants.mGetBaseAdjustmentFile, params);
   }
 
+  Future<typed_data.Uint8List?> getAdjustmentData(
+    String id, {
+    PMProgressHandler? progressHandler,
+  }) async {
+    assert(Platform.isIOS || Platform.isMacOS);
+    final params = <String, dynamic>{'id': id};
+    _injectProgressHandlerParams(params, progressHandler);
+    return _channel.invokeMethod(PMConstants.mGetAdjustmentData, params);
+  }
+
   /// Request the parent folders containing [pathEntity].
   ///
   /// Mirrors [getSubPathEntities] but walks up the hierarchy. Backed by

--- a/lib/src/types/darwin.dart
+++ b/lib/src/types/darwin.dart
@@ -3,6 +3,7 @@
 // in the LICENSE file.
 
 import 'dart:io';
+import 'dart:typed_data' as typed_data;
 
 import '../internal/enums.dart';
 import '../internal/plugin.dart';
@@ -97,6 +98,26 @@ class DarwinAsset {
       return null;
     }
     return File(path);
+  }
+
+  /// Export the raw AAE adjustment (edit-history) data for this asset, or
+  /// `null` when the asset has no adjustments.
+  ///
+  /// Backed by the `PHAssetResourceTypeAdjustmentData` resource. Combine it with
+  /// [baseFile] (the unedited base image) and [AssetEntity.file] (the rendered
+  /// result) to reconstruct a non-destructive editing pipeline.
+  ///
+  ///  * [progressHandler] observes the (possibly network-bound) export progress.
+  ///
+  /// See also:
+  ///  * [hasAdjustments] to cheaply check whether adjustment data exists.
+  Future<typed_data.Uint8List?> adjustmentData({
+    PMProgressHandler? progressHandler,
+  }) {
+    return plugin.getAdjustmentData(
+      _asset.id,
+      progressHandler: progressHandler,
+    );
   }
 }
 

--- a/lib/src/types/darwin.dart
+++ b/lib/src/types/darwin.dart
@@ -63,7 +63,7 @@ class DarwinAsset {
   /// loops on older systems.
   ///
   /// See also:
-  ///  * [baseFile] to obtain the unedited version when this returns `true`.
+  ///  * [getBaseFile] to obtain the unedited version when this returns `true`.
   Future<bool> get hasAdjustments => plugin.hasAdjustments(_asset.id);
 
   /// Obtain the base (unedited) file of the asset, before any adjustments were
@@ -81,7 +81,7 @@ class DarwinAsset {
   ///
   /// See also:
   ///  * [hasAdjustments] to check whether a distinct base version exists.
-  Future<File?> baseFile({
+  Future<File?> getBaseFile({
     bool isOrigin = true,
     PMProgressHandler? progressHandler,
     PMDarwinAVFileType? darwinFileType,
@@ -104,14 +104,14 @@ class DarwinAsset {
   /// `null` when the asset has no adjustments.
   ///
   /// Backed by the `PHAssetResourceTypeAdjustmentData` resource. Combine it with
-  /// [baseFile] (the unedited base image) and [AssetEntity.file] (the rendered
-  /// result) to reconstruct a non-destructive editing pipeline.
+  /// [getBaseFile] (the unedited base image) and [AssetEntity.file] (the
+  /// rendered result) to reconstruct a non-destructive editing pipeline.
   ///
   ///  * [progressHandler] observes the (possibly network-bound) export progress.
   ///
   /// See also:
   ///  * [hasAdjustments] to cheaply check whether adjustment data exists.
-  Future<typed_data.Uint8List?> adjustmentData({
+  Future<typed_data.Uint8List?> getAdjustmentData({
     PMProgressHandler? progressHandler,
   }) {
     return plugin.getAdjustmentData(

--- a/lib/src/types/entity.dart
+++ b/lib/src/types/entity.dart
@@ -549,7 +549,7 @@ class AssetEntity {
   /// A Darwin (iOS/macOS) only namespace of PhotoKit reads for this asset.
   ///
   /// Groups Apple-specific reads such as [DarwinAsset.cloudIdentifier],
-  /// [DarwinAsset.hasAdjustments] and [DarwinAsset.baseFile], so that
+  /// [DarwinAsset.hasAdjustments] and [DarwinAsset.getBaseFile], so that
   /// [AssetEntity] itself stays lean. Throws an [OSError] when accessed on a
   /// non-Darwin platform, so guard with [Platform] if needed.
   DarwinAsset get darwin {

--- a/test/photo_manager_test.dart
+++ b/test/photo_manager_test.dart
@@ -4,6 +4,8 @@
 
 // ignore_for_file: use_named_constants
 
+import 'dart:io';
+
 import 'package:flutter/services.dart';
 import 'package:flutter_test/flutter_test.dart';
 import 'package:photo_manager/photo_manager.dart';
@@ -92,4 +94,33 @@ void main() {
     expect(entity.longitude, equals(45.0));
     expect(entity.latLng, isNotNull);
   });
+
+  test(
+    'darwin.adjustmentData forwards to the getAdjustmentData channel method',
+    () async {
+      MethodCall? capturedCall;
+      final Uint8List payload = Uint8List.fromList(<int>[1, 2, 3, 4]);
+      TestDefaultBinaryMessengerBinding.instance.defaultBinaryMessenger
+          .setMockMethodCallHandler(
+        const MethodChannel(PMConstants.channelPrefix),
+        (MethodCall call) async {
+          capturedCall = call;
+          return payload;
+        },
+      );
+
+      final entity = AssetEntity(
+        id: 'asset-id',
+        typeInt: AssetType.image.index,
+        width: 1,
+        height: 1,
+      );
+
+      await expectLater(entity.darwin.adjustmentData(), completion(payload));
+      expect(capturedCall?.method, PMConstants.mGetAdjustmentData);
+      expect(capturedCall?.arguments['id'], 'asset-id');
+    },
+    // The Darwin view and its plugin call assert on iOS/macOS only.
+    skip: !(Platform.isIOS || Platform.isMacOS),
+  );
 }

--- a/test/photo_manager_test.dart
+++ b/test/photo_manager_test.dart
@@ -96,7 +96,7 @@ void main() {
   });
 
   test(
-    'darwin.adjustmentData forwards to the getAdjustmentData channel method',
+    'darwin.getAdjustmentData forwards to the getAdjustmentData channel method',
     () async {
       MethodCall? capturedCall;
       final Uint8List payload = Uint8List.fromList(<int>[1, 2, 3, 4]);
@@ -116,7 +116,7 @@ void main() {
         height: 1,
       );
 
-      await expectLater(entity.darwin.adjustmentData(), completion(payload));
+      await expectLater(entity.darwin.getAdjustmentData(), completion(payload));
       expect(capturedCall?.method, PMConstants.mGetAdjustmentData);
       expect(capturedCall?.arguments['id'], 'asset-id');
     },


### PR DESCRIPTION
## Summary
- Add `asset.darwin.getAdjustmentData()` returning `Future<Uint8List?>` that exports the raw AAE adjustment (edit-history) data backing an asset's edits, or `null` when the asset is unedited.
- Backed by the `PHAssetResourceTypeAdjustmentData` resource, read via `PHAssetResourceManager requestDataForAssetResource:` (accumulated across delivery callbacks) with iCloud network access and optional `PMProgressHandler`.
- Native adds `getAdjustmentDataResource` on `PHAsset (PM_COMMON)` — a dedicated accessor, since that resource is intentionally excluded by `getCurrentResource` / `getOriginalResource`.
- Sits alongside the existing `asset.darwin.hasAdjustments` and `asset.darwin.getBaseFile()`: combine the unedited base file, the edit metadata, and `AssetEntity.file` (rendered result) to reconstruct a non-destructive editing pipeline.
- Rename the non-getter Darwin request methods to the verb-prefixed convention used across `AssetEntity` (e.g. `getMediaUrl`): `baseFile()` → `getBaseFile()`, `adjustmentData()` → `getAdjustmentData()`. Both were unreleased, so no shipped API changes.
- Extend the gated Darwin-only example page and add a channel-forwarding unit test (skipped off iOS/macOS).

This completes the read side of #1070 (original + adjustment data + rendered), building on the Darwin namespace introduced in #1407.

## Notes
- Adjustment-data export is not cancellable: `requestDataForAssetResource:` returns no request id, so no `cancelToken` is exposed (unlike `getBaseFile()`).
