### PR TITLE
🐛 Fix Darwin loadFile PHPhotosErrorDomain -1 for edited assets and Live Photos

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ To know more about breaking changes, see the [Migration Guide][].
 **Fixes**
 
 - Fix iOS 18+ raising `Unsupported fetch for asset collections with type 2 and subtype 2` when navigating into the primary album, caused by an invalid `SmartAlbum` + `AlbumRegular` combination in the recent-collection check.
+- Fix Darwin `AssetEntity.loadFile` / `originFile` sporadically failing with `PHPhotosErrorDomain (-1)` for edited assets and Live Photos by walking multiple `PHAssetResource` candidates and falling back to `PHImageManager` for plain videos/images when `writeDataForAssetResource` exhausts them.
 - Reduce built-in Kotlin migration warnings for supported project configurations while preserving legacy Flutter compatibility.
 - Fix Darwin crashes when querying assets by local identifier by catching PhotoKit exceptions and returning safe fallback results instead of aborting the process.
 - Fix the `AssetEntity.duration` API docs to clarify that audio and video durations are returned in seconds across supported platforms, preserving the existing API behavior.

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -53,9 +53,11 @@ NS_ASSUME_NONNULL_BEGIN
 /// materialized that specific resource. Callers walk this list, retrying with
 /// the next candidate on failure until one succeeds or the list is exhausted.
 ///
-/// Order is `rendered/current → primary → adjustment base`, so an edited asset
-/// exports what the Photos app shows first, matching the plugin's historical
-/// behavior on both `isOrigin: true` and `isOrigin: false`.
+/// Order is `rendered/current → primary → adjustment base → alternate`
+/// (alternate = the RAW/JPEG paired resource, only present for images that
+/// were captured as a RAW+JPEG pair). Rendered-first exports what the Photos
+/// app shows for an edited asset, matching the plugin's historical behavior
+/// on both `isOrigin: true` and `isOrigin: false`.
 ///
 /// @param isOrigin  Reserved for future opt-in ordering control; ignored for
 ///                  the resource order today.

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -53,11 +53,12 @@ NS_ASSUME_NONNULL_BEGIN
 /// materialized that specific resource. Callers walk this list, retrying with
 /// the next candidate on failure until one succeeds or the list is exhausted.
 ///
-/// @param isOrigin  When `YES`, the caller wants the original (unedited) bytes;
-///                  the returned order prefers the original resource type,
-///                  then adjustment base, then the rendered/full-size variant.
-///                  When `NO`, the caller wants the current rendered version
-///                  and the order is reversed.
+/// Order is `rendered/current → primary → adjustment base`, so an edited asset
+/// exports what the Photos app shows first, matching the plugin's historical
+/// behavior on both `isOrigin: true` and `isOrigin: false`.
+///
+/// @param isOrigin  Reserved for future opt-in ordering control; ignored for
+///                  the resource order today.
 /// @param livePhoto When `YES`, resources for the Live Photo's paired video
 ///                  are returned instead of the primary photo/video resources.
 - (NSArray<PHAssetResource *> *)candidateResourcesForFetch:(BOOL)isOrigin

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.h
@@ -45,6 +45,24 @@ NS_ASSUME_NONNULL_BEGIN
 
 - (PHAssetResource *)getLivePhotosResource;
 
+/// Ordered list of `PHAssetResource`s to try when exporting an asset's file.
+///
+/// PhotoKit exposes several resources per asset (original, adjusted, rendered,
+/// paired video, ...) and any one of them can fail `writeDataForAssetResource`
+/// with a generic `PHPhotosErrorInternalError` when iCloud has not fully
+/// materialized that specific resource. Callers walk this list, retrying with
+/// the next candidate on failure until one succeeds or the list is exhausted.
+///
+/// @param isOrigin  When `YES`, the caller wants the original (unedited) bytes;
+///                  the returned order prefers the original resource type,
+///                  then adjustment base, then the rendered/full-size variant.
+///                  When `NO`, the caller wants the current rendered version
+///                  and the order is reversed.
+/// @param livePhoto When `YES`, resources for the Live Photo's paired video
+///                  are returned instead of the primary photo/video resources.
+- (NSArray<PHAssetResource *> *)candidateResourcesForFetch:(BOOL)isOrigin
+                                                 livePhoto:(BOOL)livePhoto;
+
 @end
 
 NS_ASSUME_NONNULL_END

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -355,14 +355,16 @@
     }
 
     NSMutableArray<PHAssetResource *> *ordered = [NSMutableArray arrayWithCapacity:4];
-    // Always prefer the rendered ("current") resource first, matching what the
-    // Photos app shows the user, and matching the plugin's historical behavior
-    // for both `loadFile(isOrigin: true)` and `loadFile(isOrigin: false)`.
-    // Fall back to the raw primary resource, then the adjustment base, when
-    // the preferred one is missing from iCloud or otherwise unreadable. The
-    // `isOrigin` parameter is kept in the signature for future opt-in ordering
-    // control but does not reshuffle the list today, so upgrading callers do
-    // not silently switch between edited and unedited exports.
+    // Order: rendered ("fullSize") → primary → adjustment base → alternate.
+    // The fullSize resource is the one Photos shows the user for an edited
+    // asset, so preferring it first keeps the file exports "what you see is
+    // what you get". For unedited assets it is absent, so the primary
+    // resource is selected in practice. Note this is not a byte-for-byte
+    // reproduction of `getCurrentResource` on `main`, which used the private
+    // `isCurrent` KVC key as an additional tiebreaker; edge cases where
+    // `isCurrent` sits on the primary instead of the fullSize will see
+    // different first-choice bytes here, though the walker's later
+    // candidates cover the same set.
     if (fullSize) [ordered addObject:fullSize];
     if (primary) [ordered addObject:primary];
     if (adjustmentBase) [ordered addObject:adjustmentBase];

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -267,26 +267,110 @@
 }
 
 - (PHAssetResource *)getLivePhotosResource {
+    NSArray<PHAssetResource *> *candidates = [self candidateResourcesForFetch:NO livePhoto:YES];
+    return candidates.firstObject;
+}
+
+- (NSArray<PHAssetResource *> *)candidateResourcesForFetch:(BOOL)isOrigin
+                                                 livePhoto:(BOOL)livePhoto {
     NSArray<PHAssetResource *> *resources = [PHAssetResource assetResourcesForAsset:self];
     if (resources.count == 0) {
-        return nil;
+        return @[];
     }
-    if (@available(iOS 9.1, *)) {
-        PHAssetResource *paired;
-        PHAssetResource *fullSizePaired;
+
+    // Collect the resources matching each interesting type. There can be at
+    // most one of each type per asset in practice, but if PhotoKit ever
+    // exposes more than one we keep the first (`isCurrent` in a later pass
+    // would be the tiebreaker, but PhotoKit does not surface it here).
+    PHAssetResource *primary;         // .photo / .video / .pairedVideo
+    PHAssetResource *fullSize;        // .fullSizePhoto / .fullSizeVideo / .fullSizePairedVideo
+    PHAssetResource *adjustmentBase;  // .adjustmentBasePhoto / .adjustmentBaseVideo / .adjustmentBasePairedVideo
+    PHAssetResource *alternate;       // .alternatePhoto (RAW+JPEG pair)
+
+    if (livePhoto) {
         for (PHAssetResource *r in resources) {
-            if (r.type == PHAssetResourceTypePairedVideo && !paired) {
-                paired = r;
-                continue;
-            }
-            if (r.type == PHAssetResourceTypeFullSizePairedVideo && !fullSizePaired) {
-                fullSizePaired = r;
-                continue;
+            if (!r.isValid) continue;
+            switch (r.type) {
+                case PHAssetResourceTypePairedVideo:
+                    if (!primary) primary = r;
+                    break;
+                case PHAssetResourceTypeFullSizePairedVideo:
+                    if (!fullSize) fullSize = r;
+                    break;
+                default:
+                    if (@available(iOS 10.0, macOS 10.15, *)) {
+                        if (r.type == PHAssetResourceTypeAdjustmentBasePairedVideo && !adjustmentBase) {
+                            adjustmentBase = r;
+                        }
+                    }
+                    break;
             }
         }
-        return fullSizePaired ?: paired;
+    } else if (self.isImage) {
+        for (PHAssetResource *r in resources) {
+            if (!r.isValid) continue;
+            switch (r.type) {
+                case PHAssetResourceTypePhoto:
+                    if (!primary) primary = r;
+                    break;
+                case PHAssetResourceTypeFullSizePhoto:
+                    if (!fullSize) fullSize = r;
+                    break;
+                case PHAssetResourceTypeAdjustmentBasePhoto:
+                    if (!adjustmentBase) adjustmentBase = r;
+                    break;
+                case PHAssetResourceTypeAlternatePhoto:
+                    if (!alternate) alternate = r;
+                    break;
+                default:
+                    break;
+            }
+        }
+    } else if (self.isVideo) {
+        for (PHAssetResource *r in resources) {
+            if (!r.isValid) continue;
+            switch (r.type) {
+                case PHAssetResourceTypeVideo:
+                    if (!primary) primary = r;
+                    break;
+                case PHAssetResourceTypeFullSizeVideo:
+                    if (!fullSize) fullSize = r;
+                    break;
+                default:
+                    if (@available(iOS 13.0, macOS 10.15, *)) {
+                        if (r.type == PHAssetResourceTypeAdjustmentBaseVideo && !adjustmentBase) {
+                            adjustmentBase = r;
+                        }
+                    }
+                    break;
+            }
+        }
+    } else if (self.isAudio) {
+        for (PHAssetResource *r in resources) {
+            if (!r.isValid) continue;
+            if (r.type == PHAssetResourceTypeAudio && !primary) {
+                primary = r;
+            }
+        }
     }
-    return nil;
+
+    NSMutableArray<PHAssetResource *> *ordered = [NSMutableArray arrayWithCapacity:4];
+    if (isOrigin) {
+        // Try the untouched original first, then the adjustment base (which is
+        // the "before" copy Photos keeps around when the user has edits), then
+        // the rendered current version as a last resort.
+        if (primary) [ordered addObject:primary];
+        if (adjustmentBase) [ordered addObject:adjustmentBase];
+        if (fullSize) [ordered addObject:fullSize];
+    } else {
+        // Prefer the rendered current version; fall back to the original bytes
+        // if the render is missing from iCloud, then to the adjustment base.
+        if (fullSize) [ordered addObject:fullSize];
+        if (primary) [ordered addObject:primary];
+        if (adjustmentBase) [ordered addObject:adjustmentBase];
+    }
+    if (alternate) [ordered addObject:alternate];
+    return ordered;
 }
 
 @end

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -355,20 +355,17 @@
     }
 
     NSMutableArray<PHAssetResource *> *ordered = [NSMutableArray arrayWithCapacity:4];
-    if (isOrigin) {
-        // Try the untouched original first, then the adjustment base (which is
-        // the "before" copy Photos keeps around when the user has edits), then
-        // the rendered current version as a last resort.
-        if (primary) [ordered addObject:primary];
-        if (adjustmentBase) [ordered addObject:adjustmentBase];
-        if (fullSize) [ordered addObject:fullSize];
-    } else {
-        // Prefer the rendered current version; fall back to the original bytes
-        // if the render is missing from iCloud, then to the adjustment base.
-        if (fullSize) [ordered addObject:fullSize];
-        if (primary) [ordered addObject:primary];
-        if (adjustmentBase) [ordered addObject:adjustmentBase];
-    }
+    // Always prefer the rendered ("current") resource first, matching what the
+    // Photos app shows the user, and matching the plugin's historical behavior
+    // for both `loadFile(isOrigin: true)` and `loadFile(isOrigin: false)`.
+    // Fall back to the raw primary resource, then the adjustment base, when
+    // the preferred one is missing from iCloud or otherwise unreadable. The
+    // `isOrigin` parameter is kept in the signature for future opt-in ordering
+    // control but does not reshuffle the list today, so upgrading callers do
+    // not silently switch between edited and unedited exports.
+    if (fullSize) [ordered addObject:fullSize];
+    if (primary) [ordered addObject:primary];
+    if (adjustmentBase) [ordered addObject:adjustmentBase];
     if (alternate) [ordered addObject:alternate];
     return ordered;
 }

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAssetResource+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAssetResource+PM_COMMON.m
@@ -15,7 +15,7 @@
 }
 
 - (bool)isVideo {
-    BOOL predicate = [self type] == PHAssetResourceTypeVideo || PHAssetResourceTypeFullSizeVideo;
+    BOOL predicate = [self type] == PHAssetResourceTypeVideo || [self type] == PHAssetResourceTypeFullSizeVideo;
     if (@available(iOS 9.1, *)) {
         predicate = (predicate || [self type] == PHAssetResourceTypePairedVideo);
     }

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -634,6 +634,15 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have a Live-Photo resource.", asset.localIdentifier]];
         return;
     }
+    NSString *cached = [self cachedPathForAsset:asset
+                                     candidates:candidates
+                                       isOrigin:YES
+                                       fileType:fileType
+                            includeFallbackPath:NO];
+    if (cached) {
+        [handler reply:withScheme ? [NSURL fileURLWithPath:cached].absoluteString : cached];
+        return;
+    }
     [self fetchVideoFileWithCandidates:candidates
                                  asset:asset
                        progressHandler:progressHandler
@@ -644,6 +653,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         if (path) {
             [handler reply:path];
         } else {
+            [self notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
             [handler replyError:error];
         }
     }];
@@ -656,6 +666,15 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     NSArray<PHAssetResource *> *candidates = [asset candidateResourcesForFetch:YES livePhoto:NO];
     if (candidates.count == 0) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have available resources.", asset.localIdentifier]];
+        return;
+    }
+    NSString *cached = [self cachedPathForAsset:asset
+                                     candidates:candidates
+                                       isOrigin:YES
+                                       fileType:fileType
+                            includeFallbackPath:YES];
+    if (cached) {
+        [handler reply:cached];
         return;
     }
     __weak typeof(self) weakSelf = self;
@@ -683,13 +702,50 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                                            block:^(NSString *fbPath, NSObject *fbError) {
             if (fbPath) {
                 [handler reply:fbPath];
-            } else {
-                // Prefer the walker's error over the fallback's since it
-                // carries the list of resource types we tried.
-                [handler replyError:walkerError ?: fbError];
+                return;
             }
+            [strongSelf notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+            // Prefer the walker's error over the fallback's since it
+            // carries the list of resource types we tried.
+            [handler replyError:walkerError ?: fbError];
         }];
     }];
+}
+
+// Returns the first candidate resource whose cache file already exists, or
+// (when `includeFallbackPath` is YES) the AVAsset/image-data fallback cache
+// path if present. Used before walking candidates so that assets that
+// previously succeeded on a non-first candidate don't pay for a fresh
+// PhotoKit round-trip against the first candidate on every subsequent call.
+- (NSString *)cachedPathForAsset:(PHAsset *)asset
+                      candidates:(NSArray<PHAssetResource *> *)candidates
+                        isOrigin:(BOOL)isOrigin
+                        fileType:(AVFileType)fileType
+             includeFallbackPath:(BOOL)includeFallbackPath {
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    for (PHAssetResource *candidate in candidates) {
+        NSString *path = [self makeAssetOutputPath:asset
+                                          resource:candidate
+                                          isOrigin:isOrigin
+                                          fileType:fileType
+                                           manager:fileManager];
+        if ([fileManager fileExistsAtPath:path]) {
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
+            return path;
+        }
+    }
+    if (includeFallbackPath) {
+        NSString *fallbackPath = [self makeAssetOutputPath:asset
+                                                  resource:nil
+                                                  isOrigin:isOrigin
+                                                  fileType:fileType
+                                                   manager:fileManager];
+        if ([fileManager fileExistsAtPath:fallbackPath]) {
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", fallbackPath]];
+            return fallbackPath;
+        }
+    }
+    return nil;
 }
 
 // Compose the terminal error surfaced after every candidate resource fails.
@@ -981,7 +1037,9 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             return;
         }
         if (error) {
-            [strongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
+            // Don't emit Failed here — the walker may retry with another
+            // candidate and only the terminal outcome should surface as a
+            // failure state to progress observers.
             block(nil, error);
             return;
         }
@@ -1312,6 +1370,15 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have available resources.", asset.localIdentifier]];
         return;
     }
+    NSString *cached = [self cachedPathForAsset:asset
+                                     candidates:candidates
+                                       isOrigin:YES
+                                       fileType:nil
+                            includeFallbackPath:YES];
+    if (cached) {
+        [handler reply:cached];
+        return;
+    }
     __weak typeof(self) weakSelf = self;
     [self fetchImageFileFromCandidates:candidates
                                atIndex:0
@@ -1335,9 +1402,10 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                                         block:^(NSString *fbPath, NSObject *fbError) {
             if (fbPath) {
                 [handler reply:fbPath];
-            } else {
-                [handler replyError:walkerError ?: fbError];
+                return;
             }
+            [strongSelf notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+            [handler replyError:walkerError ?: fbError];
         }];
     }];
 }
@@ -1423,7 +1491,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             return;
         }
         if (error) {
-            [strongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
+            // Walker retries with the next candidate; don't emit Failed here.
             block(nil, error);
         } else {
             [strongSelf notifySuccess:progressHandler];

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -14,6 +14,25 @@
 #import "PMRequestTypeUtils.h"
 #import "PMResultHandler.h"
 
+static NSString *PMResourceTypeName(PHAssetResourceType type) {
+    switch (type) {
+        case PHAssetResourceTypePhoto:                       return @"photo";
+        case PHAssetResourceTypeVideo:                       return @"video";
+        case PHAssetResourceTypeAudio:                       return @"audio";
+        case PHAssetResourceTypeAlternatePhoto:              return @"alternatePhoto";
+        case PHAssetResourceTypeFullSizePhoto:               return @"fullSizePhoto";
+        case PHAssetResourceTypeFullSizeVideo:               return @"fullSizeVideo";
+        case PHAssetResourceTypeAdjustmentData:              return @"adjustmentData";
+        case PHAssetResourceTypeAdjustmentBasePhoto:         return @"adjustmentBasePhoto";
+        case PHAssetResourceTypePairedVideo:                 return @"pairedVideo";
+        case PHAssetResourceTypeFullSizePairedVideo:         return @"fullSizePairedVideo";
+        case PHAssetResourceTypeAdjustmentBasePairedVideo:   return @"adjustmentBasePairedVideo";
+        case PHAssetResourceTypeAdjustmentBaseVideo:         return @"adjustmentBaseVideo";
+        default:
+            return [NSString stringWithFormat:@"unknown(%ld)", (long)type];
+    }
+}
+
 @implementation PMManager {
     PMCacheContainer *cacheContainer;
     
@@ -610,19 +629,18 @@
             progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
                  withScheme:(BOOL)withScheme
                    fileType:(AVFileType)fileType {
-    PHAssetResource *resource = [asset getLivePhotosResource];
-    if (!resource) {
+    NSArray<PHAssetResource *> *candidates = [asset candidateResourcesForFetch:YES livePhoto:YES];
+    if (candidates.count == 0) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have a Live-Photo resource.", asset.localIdentifier]];
         return;
     }
-    
-    [self fetchVideoResourceToFile:asset
-                          resource:resource
-                   progressHandler:progressHandler
-                        withScheme:withScheme
-                          isOrigin:YES
-                          fileType:fileType
-                             block:^(NSString *path, NSObject *error) {
+    [self fetchVideoFileWithCandidates:candidates
+                                 asset:asset
+                       progressHandler:progressHandler
+                            withScheme:withScheme
+                              isOrigin:YES
+                              fileType:fileType
+                                 block:^(NSString *path, NSObject *error) {
         if (path) {
             [handler reply:path];
         } else {
@@ -635,23 +653,138 @@
                      handler:(PMResultHandler *)handler
              progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
                     fileType:(AVFileType)fileType {
-    PHAssetResource *resource = [asset getCurrentResource];
-    if (!resource) {
+    NSArray<PHAssetResource *> *candidates = [asset candidateResourcesForFetch:YES livePhoto:NO];
+    if (candidates.count == 0) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have available resources.", asset.localIdentifier]];
         return;
     }
+    __weak typeof(self) weakSelf = self;
+    [self fetchVideoFileWithCandidates:candidates
+                                 asset:asset
+                       progressHandler:progressHandler
+                            withScheme:NO
+                              isOrigin:YES
+                              fileType:fileType
+                                 block:^(NSString *path, NSObject *walkerError) {
+        if (path) {
+            [handler reply:path];
+            return;
+        }
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        // Every candidate resource failed (typical iCloud flake). Fall back to
+        // PHImageManager's requestAVAssetForVideo pipeline which frequently
+        // succeeds when the raw-resource pipeline can't materialize the file.
+        [strongSelf fallbackFetchVideoViaAVAsset:asset
+                                        isOrigin:YES
+                                      withScheme:NO
+                                        fileType:fileType
+                                 progressHandler:progressHandler
+                                           block:^(NSString *fbPath, NSObject *fbError) {
+            if (fbPath) {
+                [handler reply:fbPath];
+            } else {
+                // Prefer the walker's error over the fallback's since it
+                // carries the list of resource types we tried.
+                [handler replyError:walkerError ?: fbError];
+            }
+        }];
+    }];
+}
+
+// Compose the terminal error surfaced after every candidate resource fails.
+// Preserves the last underlying NSError's domain/code (so callers keep seeing
+// `PHPhotosErrorDomain (-1)` in their existing log matchers) while attaching
+// the list of resource types we tried into the failure-reason field. That
+// list is what surfaces as `PlatformException.details` on the Flutter side.
+- (NSObject *)composeFetchError:(NSObject *)lastError
+                          asset:(PHAsset *)asset
+                      attempted:(NSArray<NSString *> *)attempted {
+    NSString *attemptList = attempted.count > 0 ? [attempted componentsJoinedByString:@", "] : @"(none)";
+    NSString *description = [NSString stringWithFormat:
+                             @"Failed to export asset %@ after trying resources: [%@]",
+                             asset.localIdentifier, attemptList];
+    if ([lastError isKindOfClass:[NSError class]]) {
+        NSError *err = (NSError *)lastError;
+        NSMutableDictionary *userInfo = err.userInfo
+            ? [NSMutableDictionary dictionaryWithDictionary:err.userInfo]
+            : [NSMutableDictionary dictionary];
+        if (!userInfo[NSLocalizedDescriptionKey]) {
+            userInfo[NSLocalizedDescriptionKey] = description;
+        }
+        userInfo[NSLocalizedFailureReasonErrorKey] = description;
+        return [NSError errorWithDomain:err.domain code:err.code userInfo:userInfo];
+    }
+    if (lastError) {
+        return lastError;
+    }
+    return [NSError errorWithDomain:@"PMPhotoManager"
+                               code:-1
+                           userInfo:@{NSLocalizedDescriptionKey: description}];
+}
+
+- (void)fetchVideoFileWithCandidates:(NSArray<PHAssetResource *> *)candidates
+                               asset:(PHAsset *)asset
+                     progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                          withScheme:(BOOL)withScheme
+                            isOrigin:(BOOL)isOrigin
+                            fileType:(AVFileType)fileType
+                               block:(void (^)(NSString *path, NSObject *error))block {
+    [self fetchVideoFileFromCandidates:candidates
+                               atIndex:0
+                             attempted:[NSMutableArray arrayWithCapacity:candidates.count]
+                             lastError:nil
+                                 asset:asset
+                       progressHandler:progressHandler
+                            withScheme:withScheme
+                              isOrigin:isOrigin
+                              fileType:fileType
+                                 block:block];
+}
+
+- (void)fetchVideoFileFromCandidates:(NSArray<PHAssetResource *> *)candidates
+                             atIndex:(NSUInteger)index
+                           attempted:(NSMutableArray<NSString *> *)attempted
+                           lastError:(NSObject *)lastError
+                               asset:(PHAsset *)asset
+                     progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                          withScheme:(BOOL)withScheme
+                            isOrigin:(BOOL)isOrigin
+                            fileType:(AVFileType)fileType
+                               block:(void (^)(NSString *path, NSObject *error))block {
+    if (index >= candidates.count) {
+        block(nil, [self composeFetchError:lastError asset:asset attempted:attempted]);
+        return;
+    }
+    PHAssetResource *resource = candidates[index];
+    [attempted addObject:PMResourceTypeName(resource.type)];
+    __weak typeof(self) weakSelf = self;
     [self fetchVideoResourceToFile:asset
                           resource:resource
                    progressHandler:progressHandler
-                        withScheme:NO
-                          isOrigin:YES
+                        withScheme:withScheme
+                          isOrigin:isOrigin
                           fileType:fileType
                              block:^(NSString *path, NSObject *error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
         if (path) {
-            [handler reply:path];
-        } else {
-            [handler replyError:error];
+            block(path, nil);
+            return;
         }
+        [[PMLogUtils sharedInstance]
+         info:[NSString stringWithFormat:@"Resource %@ failed for asset %@, trying next candidate. Error: %@",
+               PMResourceTypeName(resource.type), asset.localIdentifier, error]];
+        [strongSelf fetchVideoFileFromCandidates:candidates
+                                         atIndex:index + 1
+                                       attempted:attempted
+                                       lastError:error
+                                           asset:asset
+                                 progressHandler:progressHandler
+                                      withScheme:withScheme
+                                        isOrigin:isOrigin
+                                        fileType:fileType
+                                           block:block];
     }];
 }
 
@@ -672,6 +805,94 @@
             [handler replyError:error];
         }
     }];
+}
+
+// Fallback video fetch used when `writeDataForAssetResource` fails across every
+// candidate resource. Goes through PHImageManager's requestAVAssetForVideo,
+// which uses a different iCloud pipeline internally and often succeeds on
+// assets the resource-level API refuses. Not usable for Live Photo paired
+// videos (asset.mediaType is image), so only wire this into the plain-video
+// entry point.
+- (void)fallbackFetchVideoViaAVAsset:(PHAsset *)asset
+                            isOrigin:(BOOL)isOrigin
+                          withScheme:(BOOL)withScheme
+                            fileType:(AVFileType)fileType
+                     progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                               block:(void (^)(NSString *path, NSObject *error))block {
+    if (!asset.isVideo) {
+        // Live Photo (isImage=YES) and other non-video assets can't use this
+        // API; refuse to run rather than get an opaque PhotoKit rejection.
+        block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
+            NSLocalizedDescriptionKey: @"AVAsset fallback only applies to video assets."
+        }]);
+        return;
+    }
+
+    NSFileManager *manager = NSFileManager.defaultManager;
+    NSString *path = [self makeAssetOutputPath:asset resource:nil isOrigin:isOrigin fileType:fileType manager:manager];
+    if ([manager fileExistsAtPath:path]) {
+        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
+        block(withScheme ? [NSURL fileURLWithPath:path].absoluteString : path, nil);
+        return;
+    }
+
+    PHVideoRequestOptions *options = [PHVideoRequestOptions new];
+    [options setDeliveryMode:PHVideoRequestOptionsDeliveryModeHighQualityFormat];
+    [options setNetworkAccessAllowed:YES];
+    [options setVersion:isOrigin ? PHVideoRequestOptionsVersionOriginal : PHVideoRequestOptionsVersionCurrent];
+
+    __weak typeof(self) weakSelf = self;
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        [strongSelf.cachingManager
+         requestAVAssetForVideo:asset
+         options:options
+         resultHandler:^(AVAsset *_Nullable avAsset,
+                         AVAudioMix *_Nullable audioMix,
+                         NSDictionary *_Nullable info) {
+            __strong typeof(weakSelf) innerSelf = weakSelf;
+            if (!innerSelf) { return; }
+            NSObject *error = info[PHImageErrorKey];
+            if (error) {
+                block(nil, error);
+                return;
+            }
+            if (![PMManager isDownloadFinish:info]) {
+                return;
+            }
+            if ([avAsset isKindOfClass:[AVURLAsset class]]) {
+                AVURLAsset *urlAsset = (AVURLAsset *)avAsset;
+                NSURL *videoURL = urlAsset.URL;
+                NSURL *destination = [NSURL fileURLWithPath:path];
+                if ([videoURL.path isEqualToString:destination.path]) {
+                    block(withScheme ? videoURL.absoluteString : videoURL.path, nil);
+                    return;
+                }
+                NSError *copyError;
+                [manager copyItemAtURL:videoURL toURL:destination error:&copyError];
+                if (copyError) {
+                    block(nil, copyError);
+                    return;
+                }
+                block(withScheme ? destination.absoluteString : path, nil);
+                return;
+            }
+            // AVComposition (adjusted asset) — export session handles it.
+            [innerSelf exportAVAssetToFile:avAsset
+                              destination:path
+                          progressHandler:progressHandler
+                               withScheme:withScheme
+                                 fileType:fileType
+                                    block:^(NSString *exportedPath, NSObject *exportError) {
+                if (exportedPath) {
+                    block(withScheme ? [NSURL fileURLWithPath:exportedPath].absoluteString : exportedPath, nil);
+                } else {
+                    block(nil, exportError);
+                }
+            }];
+        }];
+    });
 }
 
 - (void)fetchVideoResourceToFile:(PHAsset *)asset
@@ -1086,11 +1307,82 @@
 }
 
 - (void)fetchOriginImageFile:(PHAsset *)asset resultHandler:(PMResultHandler *)handler progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler {
-    PHAssetResource *imageResource = [asset getCurrentResource];
-    if (!imageResource) {
+    NSArray<PHAssetResource *> *candidates = [asset candidateResourcesForFetch:YES livePhoto:NO];
+    if (candidates.count == 0) {
         [handler replyError:[NSString stringWithFormat:@"Asset %@ does not have available resources.", asset.localIdentifier]];
         return;
     }
+    __weak typeof(self) weakSelf = self;
+    [self fetchImageFileFromCandidates:candidates
+                               atIndex:0
+                             attempted:[NSMutableArray arrayWithCapacity:candidates.count]
+                             lastError:nil
+                                 asset:asset
+                       progressHandler:progressHandler
+                                 block:^(NSString *path, NSObject *walkerError) {
+        if (path) {
+            [handler reply:path];
+            return;
+        }
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        // Every candidate resource failed. Fall back to PHImageManager's
+        // requestImageDataAndOrientation pipeline, which is a separate iCloud
+        // materialization path and preserves the original HEIC/RAW bytes.
+        [strongSelf fallbackFetchImageDataFor:asset
+                                     isOrigin:YES
+                              progressHandler:progressHandler
+                                        block:^(NSString *fbPath, NSObject *fbError) {
+            if (fbPath) {
+                [handler reply:fbPath];
+            } else {
+                [handler replyError:walkerError ?: fbError];
+            }
+        }];
+    }];
+}
+
+- (void)fetchImageFileFromCandidates:(NSArray<PHAssetResource *> *)candidates
+                             atIndex:(NSUInteger)index
+                           attempted:(NSMutableArray<NSString *> *)attempted
+                           lastError:(NSObject *)lastError
+                               asset:(PHAsset *)asset
+                     progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                               block:(void (^)(NSString *path, NSObject *error))block {
+    if (index >= candidates.count) {
+        block(nil, [self composeFetchError:lastError asset:asset attempted:attempted]);
+        return;
+    }
+    PHAssetResource *resource = candidates[index];
+    [attempted addObject:PMResourceTypeName(resource.type)];
+    __weak typeof(self) weakSelf = self;
+    [self writeImageResourceToFile:resource
+                             asset:asset
+                   progressHandler:progressHandler
+                             block:^(NSString *path, NSObject *error) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (path) {
+            block(path, nil);
+            return;
+        }
+        [[PMLogUtils sharedInstance]
+         info:[NSString stringWithFormat:@"Resource %@ failed for asset %@, trying next candidate. Error: %@",
+               PMResourceTypeName(resource.type), asset.localIdentifier, error]];
+        [strongSelf fetchImageFileFromCandidates:candidates
+                                         atIndex:index + 1
+                                       attempted:attempted
+                                       lastError:error
+                                           asset:asset
+                                 progressHandler:progressHandler
+                                           block:block];
+    }];
+}
+
+- (void)writeImageResourceToFile:(PHAssetResource *)imageResource
+                           asset:(PHAsset *)asset
+                 progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                           block:(void (^)(NSString *path, NSObject *error))block {
     NSFileManager *fileManager = NSFileManager.defaultManager;
     NSString *path = [self makeAssetOutputPath:asset
                                       resource:imageResource
@@ -1099,13 +1391,13 @@
                                        manager:fileManager];
     if ([fileManager fileExistsAtPath:path]) {
         [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
-        [handler reply:path];
+        block(path, nil);
         return;
     }
-    
+
     PHAssetResourceRequestOptions *options = [PHAssetResourceRequestOptions new];
     [options setNetworkAccessAllowed:YES];
-    
+
     __block double lastProgress = 0.0;
     [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     __weak typeof(self) weakSelf = self;
@@ -1119,7 +1411,7 @@
             [strongSelf notifyProgress:progressHandler progress:progress state:PMProgressStateLoading];
         }
     }];
-    
+
     PHAssetResourceManager *resourceManager = PHAssetResourceManager.defaultManager;
     NSURL *fileUrl = [NSURL fileURLWithPath:path];
     [resourceManager writeDataForAssetResource:imageResource
@@ -1132,12 +1424,99 @@
         }
         if (error) {
             [strongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
-            [handler replyError:error];
+            block(nil, error);
         } else {
-            [handler reply:path];
             [strongSelf notifySuccess:progressHandler];
+            block(path, nil);
         }
     }];
+}
+
+// Fallback image fetch used when `writeDataForAssetResource` fails across
+// every candidate resource. Uses PHImageManager's data pipeline, which is a
+// separate iCloud-materialization path and returns the raw image bytes so we
+// can write them verbatim without a JPEG recompression.
+- (void)fallbackFetchImageDataFor:(PHAsset *)asset
+                         isOrigin:(BOOL)isOrigin
+                  progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                            block:(void (^)(NSString *path, NSObject *error))block {
+    NSFileManager *manager = NSFileManager.defaultManager;
+    NSString *path = [self makeAssetOutputPath:asset resource:nil isOrigin:isOrigin fileType:nil manager:manager];
+    if ([manager fileExistsAtPath:path]) {
+        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
+        block(path, nil);
+        return;
+    }
+
+    PHImageRequestOptions *options = [PHImageRequestOptions new];
+    [options setDeliveryMode:PHImageRequestOptionsDeliveryModeHighQualityFormat];
+    [options setNetworkAccessAllowed:YES];
+    [options setSynchronous:NO];
+    [options setVersion:isOrigin ? PHImageRequestOptionsVersionOriginal : PHImageRequestOptionsVersionCurrent];
+
+    __weak typeof(self) weakSelf = self;
+    [options setProgressHandler:^(double progress, NSError *progressError, BOOL *stop, NSDictionary *info) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (progressError) { return; }
+        if (progress != 1) {
+            [strongSelf notifyProgress:progressHandler progress:progress state:PMProgressStateLoading];
+        }
+    }];
+
+    void (^dataHandler)(NSData *_Nullable, NSDictionary *_Nullable) = ^(NSData *_Nullable imageData, NSDictionary *_Nullable info) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        NSObject *error = info[PHImageErrorKey];
+        if (error) {
+            block(nil, error);
+            return;
+        }
+        if (!imageData) {
+            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
+                NSLocalizedDescriptionKey: @"PHImageManager returned no image data."
+            }]);
+            return;
+        }
+        NSError *writeError;
+        [imageData writeToFile:path options:NSDataWritingAtomic error:&writeError];
+        if (writeError) {
+            block(nil, writeError);
+            return;
+        }
+        [strongSelf notifySuccess:progressHandler];
+        block(path, nil);
+    };
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (@available(iOS 13.0, macOS 10.15, *)) {
+            [strongSelf.cachingManager requestImageDataAndOrientationForAsset:asset
+                                                                     options:options
+                                                               resultHandler:^(NSData *_Nullable imageData,
+                                                                               NSString *_Nullable dataUTI,
+                                                                               CGImagePropertyOrientation orientation,
+                                                                               NSDictionary *_Nullable info) {
+                dataHandler(imageData, info);
+            }];
+        } else {
+#if TARGET_OS_IOS
+            [strongSelf.cachingManager requestImageDataForAsset:asset
+                                                        options:options
+                                                  resultHandler:^(NSData *_Nullable imageData,
+                                                                  NSString *_Nullable dataUTI,
+                                                                  UIImageOrientation orientation,
+                                                                  NSDictionary *_Nullable info) {
+                dataHandler(imageData, info);
+            }];
+#else
+            dataHandler(nil, @{PHImageErrorKey: [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
+                NSLocalizedDescriptionKey: @"requestImageDataForAsset unavailable on this platform version."
+            }]});
+#endif
+        }
+    });
 }
 
 - (void)fetchFullSizeImageFile:(PHAsset *)asset

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -784,12 +784,17 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         userInfo[NSLocalizedFailureReasonErrorKey] = description;
         return [NSError errorWithDomain:err.domain code:err.code userInfo:userInfo];
     }
+    // Non-NSError underlying values (strings/exceptions from helper blocks)
+    // or the no-error path (empty candidate list): always return an NSError
+    // carrying the attempted-resource list, and stash the original value in
+    // userInfo so Xcode logs can still surface whatever the helper produced.
+    NSMutableDictionary *userInfo = [NSMutableDictionary dictionary];
+    userInfo[NSLocalizedDescriptionKey] = description;
+    userInfo[NSLocalizedFailureReasonErrorKey] = description;
     if (lastError) {
-        return lastError;
+        userInfo[@"underlyingValue"] = [lastError description] ?: @"<non-NSError value>";
     }
-    return [NSError errorWithDomain:@"PMPhotoManager"
-                               code:-1
-                           userInfo:@{NSLocalizedDescriptionKey: description}];
+    return [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:userInfo];
 }
 
 - (void)fetchVideoFileWithCandidates:(NSArray<PHAssetResource *> *)candidates
@@ -901,6 +906,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     NSString *path = [self makeAssetOutputPath:asset resource:nil isOrigin:isOrigin fileType:fileType manager:manager];
     if ([manager fileExistsAtPath:path]) {
         [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
+        [self notifySuccess:progressHandler];
         block(withScheme ? [NSURL fileURLWithPath:path].absoluteString : path, nil);
         return;
     }
@@ -942,6 +948,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 NSURL *videoURL = urlAsset.URL;
                 NSURL *destination = [NSURL fileURLWithPath:path];
                 if ([videoURL.path isEqualToString:destination.path]) {
+                    [innerSelf notifySuccess:progressHandler];
                     block(withScheme ? videoURL.absoluteString : videoURL.path, nil);
                     return;
                 }
@@ -949,6 +956,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 // when the destination already has a stub from a prior aborted
                 // fetch. Match the guard `exportAssetToFile` uses on iOS 18.
                 if ([manager fileExistsAtPath:destination.path]) {
+                    [innerSelf notifySuccess:progressHandler];
                     block(withScheme ? destination.absoluteString : path, nil);
                     return;
                 }
@@ -958,6 +966,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     block(nil, copyError);
                     return;
                 }
+                [innerSelf notifySuccess:progressHandler];
                 block(withScheme ? destination.absoluteString : path, nil);
                 return;
             }
@@ -1542,6 +1551,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     NSString *path = [self makeAssetOutputPath:asset resource:nil isOrigin:isOrigin fileType:nil manager:manager];
     if ([manager fileExistsAtPath:path]) {
         [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"read cache from %@", path]];
+        [self notifySuccess:progressHandler];
         block(path, nil);
         return;
     }

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -15,19 +15,28 @@
 #import "PMResultHandler.h"
 
 static NSString *PMResourceTypeName(PHAssetResourceType type) {
+    // Adjustment-base types have newer availability than the plugin's iOS 9
+    // deployment target, so guard the comparisons behind `@available` before
+    // touching the enum values.
+    if (@available(iOS 13.0, macOS 10.15, *)) {
+        if (type == PHAssetResourceTypeAdjustmentBaseVideo) return @"adjustmentBaseVideo";
+    }
+    if (@available(iOS 10.0, macOS 10.15, *)) {
+        if (type == PHAssetResourceTypeFullSizePairedVideo) return @"fullSizePairedVideo";
+        if (type == PHAssetResourceTypeAdjustmentBasePairedVideo) return @"adjustmentBasePairedVideo";
+    }
+    if (@available(iOS 9.1, macOS 10.15, *)) {
+        if (type == PHAssetResourceTypePairedVideo) return @"pairedVideo";
+    }
     switch (type) {
-        case PHAssetResourceTypePhoto:                       return @"photo";
-        case PHAssetResourceTypeVideo:                       return @"video";
-        case PHAssetResourceTypeAudio:                       return @"audio";
-        case PHAssetResourceTypeAlternatePhoto:              return @"alternatePhoto";
-        case PHAssetResourceTypeFullSizePhoto:               return @"fullSizePhoto";
-        case PHAssetResourceTypeFullSizeVideo:               return @"fullSizeVideo";
-        case PHAssetResourceTypeAdjustmentData:              return @"adjustmentData";
-        case PHAssetResourceTypeAdjustmentBasePhoto:         return @"adjustmentBasePhoto";
-        case PHAssetResourceTypePairedVideo:                 return @"pairedVideo";
-        case PHAssetResourceTypeFullSizePairedVideo:         return @"fullSizePairedVideo";
-        case PHAssetResourceTypeAdjustmentBasePairedVideo:   return @"adjustmentBasePairedVideo";
-        case PHAssetResourceTypeAdjustmentBaseVideo:         return @"adjustmentBaseVideo";
+        case PHAssetResourceTypePhoto:                return @"photo";
+        case PHAssetResourceTypeVideo:                return @"video";
+        case PHAssetResourceTypeAudio:                return @"audio";
+        case PHAssetResourceTypeAlternatePhoto:       return @"alternatePhoto";
+        case PHAssetResourceTypeFullSizePhoto:        return @"fullSizePhoto";
+        case PHAssetResourceTypeFullSizeVideo:        return @"fullSizeVideo";
+        case PHAssetResourceTypeAdjustmentData:       return @"adjustmentData";
+        case PHAssetResourceTypeAdjustmentBasePhoto:  return @"adjustmentBasePhoto";
         default:
             return [NSString stringWithFormat:@"unknown(%ld)", (long)type];
     }
@@ -640,9 +649,11 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                                        fileType:fileType
                             includeFallbackPath:NO];
     if (cached) {
+        [self notifySuccess:progressHandler];
         [handler reply:withScheme ? [NSURL fileURLWithPath:cached].absoluteString : cached];
         return;
     }
+    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     [self fetchVideoFileWithCandidates:candidates
                                  asset:asset
                        progressHandler:progressHandler
@@ -674,9 +685,11 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                                        fileType:fileType
                             includeFallbackPath:YES];
     if (cached) {
+        [self notifySuccess:progressHandler];
         [handler reply:cached];
         return;
     }
+    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     __weak typeof(self) weakSelf = self;
     [self fetchVideoFileWithCandidates:candidates
                                  asset:asset
@@ -895,7 +908,14 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     PHVideoRequestOptions *options = [PHVideoRequestOptions new];
     [options setDeliveryMode:PHVideoRequestOptionsDeliveryModeHighQualityFormat];
     [options setNetworkAccessAllowed:YES];
-    [options setVersion:isOrigin ? PHVideoRequestOptionsVersionOriginal : PHVideoRequestOptionsVersionCurrent];
+    // Match the walker's rendered-first preference: if the caller asked for
+    // the current version, the walker prefers the rendered/`fullSize`
+    // resource, and this fallback should hit the same conceptual bytes.
+    // `PHVideoRequestOptionsVersionCurrent` returns the edited AVComposition
+    // for adjusted assets and the original file for unedited ones, so we
+    // use it unconditionally. `isOrigin` is kept in the signature for
+    // future opt-in ordering control but does not switch versions today.
+    [options setVersion:PHVideoRequestOptionsVersionCurrent];
 
     __weak typeof(self) weakSelf = self;
     dispatch_async(dispatch_get_main_queue(), ^{
@@ -925,6 +945,13 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     block(withScheme ? videoURL.absoluteString : videoURL.path, nil);
                     return;
                 }
+                // `copyItemAtURL:toURL:` fails with NSFileWriteFileExistsError
+                // when the destination already has a stub from a prior aborted
+                // fetch. Match the guard `exportAssetToFile` uses on iOS 18.
+                if ([manager fileExistsAtPath:destination.path]) {
+                    block(withScheme ? destination.absoluteString : path, nil);
+                    return;
+                }
                 NSError *copyError;
                 [manager copyItemAtURL:videoURL toURL:destination error:&copyError];
                 if (copyError) {
@@ -935,17 +962,16 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 return;
             }
             // AVComposition (adjusted asset) — export session handles it.
+            // Note: `exportAVAssetToFile` already applies the withScheme
+            // wrap when writing back, so we return its `exportedPath`
+            // verbatim to avoid a `file:///file:///…` double-wrap.
             [innerSelf exportAVAssetToFile:avAsset
                               destination:path
                           progressHandler:progressHandler
                                withScheme:withScheme
                                  fileType:fileType
                                     block:^(NSString *exportedPath, NSObject *exportError) {
-                if (exportedPath) {
-                    block(withScheme ? [NSURL fileURLWithPath:exportedPath].absoluteString : exportedPath, nil);
-                } else {
-                    block(nil, exportError);
-                }
+                block(exportedPath, exportedPath ? nil : exportError);
             }];
         }];
     });
@@ -1013,7 +1039,8 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     [options setNetworkAccessAllowed:YES];
     
     __block double lastProgress = 0.0;
-    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
+    // `Prepare` is emitted once from the caller so multi-candidate walks don't
+    // bounce progress observers back to 0 between attempts.
     __weak typeof(self) weakSelf = self;
     [options setProgressHandler:^(double progress) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -1376,9 +1403,11 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                                        fileType:nil
                             includeFallbackPath:YES];
     if (cached) {
+        [self notifySuccess:progressHandler];
         [handler reply:cached];
         return;
     }
+    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     __weak typeof(self) weakSelf = self;
     [self fetchImageFileFromCandidates:candidates
                                atIndex:0
@@ -1467,7 +1496,8 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     [options setNetworkAccessAllowed:YES];
 
     __block double lastProgress = 0.0;
-    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
+    // `Prepare` is emitted once from the caller so multi-candidate walks don't
+    // bounce progress observers back to 0 between attempts.
     __weak typeof(self) weakSelf = self;
     [options setProgressHandler:^(double progress) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -1520,7 +1550,9 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     [options setDeliveryMode:PHImageRequestOptionsDeliveryModeHighQualityFormat];
     [options setNetworkAccessAllowed:YES];
     [options setSynchronous:NO];
-    [options setVersion:isOrigin ? PHImageRequestOptionsVersionOriginal : PHImageRequestOptionsVersionCurrent];
+    // Match the walker's rendered-first preference (see the equivalent note
+    // on `fallbackFetchVideoViaAVAsset`).
+    [options setVersion:PHImageRequestOptionsVersionCurrent];
 
     __weak typeof(self) weakSelf = self;
     [options setProgressHandler:^(double progress, NSError *progressError, BOOL *stop, NSDictionary *info) {
@@ -2240,6 +2272,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     // `fetchVideoResourceToFile:` writes an arbitrary resource's bytes to disk
     // (and only performs AV conversion when a fileType is supplied), so it works
     // for images too.
+    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     [self fetchVideoResourceToFile:asset
                           resource:resource
                    progressHandler:progressHandler
@@ -2276,7 +2309,8 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     [options setNetworkAccessAllowed:YES];
 
     __block double lastProgress = 0.0;
-    [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
+    // `Prepare` is emitted once from the caller so multi-candidate walks don't
+    // bounce progress observers back to 0 between attempts.
     __weak typeof(self) weakSelf = self;
     [options setProgressHandler:^(double progress) {
         __strong typeof(weakSelf) strongSelf = weakSelf;


### PR DESCRIPTION
## Summary

- `AssetEntity.loadFile` / `originFile` on iOS/macOS was surfacing an opaque `PlatformException(PHPhotosErrorDomain (-1), ..., No failure reason provided, null)` sporadically online (#1245, #1368). `-1` is `PHPhotosErrorInternalError`, PhotoKit's catch-all when a resource read fails — Apple never fills in `NSLocalizedFailureReasonErrorKey` for this code, which is why every report looked identical and no one could pin it down. The two consistent triggers are (a) iCloud not fully materializing the requested resource and (b) the resource picked from the asset needing a derivative (rendered current version, adjustment base) that isn't locally available. Both surface through `PHAssetResourceManager writeDataForAssetResource:` as the same `-1`.

- The fix is three layers, each addressing a different failure mode:
  1. **Candidate-based resource picking.** New `-[PHAsset candidateResourcesForFetch:livePhoto:]` returns an ordered list of `PHAssetResource`s to try. `fetchLivePhotosFile`, `fetchOriginVideoFile`, and `fetchOriginImageFile` walk that list, moving to the next candidate on `writeDataForAssetResource` failure instead of returning on the first `-1`. Order is `rendered/fullSize → primary → adjustment base`, unconditional on `isOrigin`, so `loadFile(isOrigin: true)` on an edited Live Photo keeps returning the rendered/edited paired video the Photos app shows the user (matching pre-PR behavior — "what you see is what you get"). `isOrigin` stays on the signature for future opt-in ordering control but does not reshuffle the list today. This is the only lever available for Live Photo paired videos, since `requestAVAssetForVideo` doesn't apply to a Live Photo (`mediaType == image`) and `requestLivePhotoForAsset` returns an opaque `PHLivePhoto` with no file access.
  2. **Plain-video AVAsset fallback.** When every candidate fails on `fetchOriginVideoFile`, fall back to `PHImageManager requestAVAssetForVideo` with `PHVideoRequestOptionsVersionCurrent` (matching the walker's rendered-first preference). If the result is an `AVURLAsset`, `copyItemAtURL:` the file into our own sandbox — same copy pattern `exportAssetToFile` uses on iOS 18 for non-origin video, so we know it works without depending on the KVC `privateFileURL` that iOS 18 blocked in 3.6.0 / #1213. `NSFileWriteFileExistsError` from a prior partial copy is guarded by a `fileExistsAtPath:` check. If the result is an `AVComposition`, route through the existing `exportAVAssetToFile:` export session (whose return value is used verbatim to avoid double-URL-wrapping when `withScheme:YES` is ever wired in). Strictly gated on `asset.isVideo` so Live Photos never enter this path.
  3. **Origin-image data fallback.** When every candidate fails on `fetchOriginImageFile`, fall back to `PHImageManager requestImageDataAndOrientationForAsset:` with `PHImageRequestOptionsVersionCurrent` (iOS 13+ / macOS 10.15+, with `requestImageDataForAsset:` behind `TARGET_OS_IOS` for older iOS). Get the original `NSData` and write it verbatim — unlike `fetchFullSizeImageFile`, no JPEG recompression, so HEIC and RAW bytes are preserved.

- Terminal error is composed by a new `composeFetchError:asset:attempted:` helper: preserves the last underlying `NSError`'s `domain` and `code` so callers matching `PHPhotosErrorDomain (-1)` in existing logs aren't affected, and attaches the ordered list of resource types actually attempted into `NSLocalizedFailureReasonErrorKey` — which surfaces as `PlatformException.details` on the Flutter side. When the walker fails and the fallback also fails, the walker's composed error wins so the resource-candidate history isn't lost.

- Cache scan across candidates. With multiple candidates in play, first-call success may be on candidate #2. On subsequent calls the walker used to re-check candidate #1's cache path (empty) and re-request it from PhotoKit (fail) before ever getting to candidate #2's cache (hit). Every "success on non-first" asset paid one full failed PhotoKit round-trip on every access, turning a sporadic problem into a stable perf regression. New `cachedPathForAsset:candidates:isOrigin:fileType:includeFallbackPath:` scans every candidate's cache path (and the AVAsset/image-data fallback path where applicable) up front and short-circuits before the walker enters. Only `fetchOriginVideoFile` / `fetchOriginImageFile` ask for the fallback path scan since only they use the fallback; `fetchLivePhotosFile` does not.

- Progress state hygiene. `fetchVideoResourceToFile` and `writeImageResourceToFile` used to emit `PMProgressStateFailed` on their own error, so an observer watching the progress stream saw `Prepare → Loading → Failed → Prepare → Loading → Success` when the walker recovered on candidate #2. `Failed` is a terminal state in most consumer implementations, so this looked like a real error even though the fetch succeeded. `PMProgressStatePrepare` was also emitted per candidate, bouncing progress observers back to 0 between attempts. Both are now emitted exactly once from the caller: `Prepare(0)` at each entry point after the cache-miss check, and `Failed` only in the terminal branch after both walker and (where applicable) fallback refuse. Pre-scan cache hits emit `PMProgressStateSuccess` before replying.

- Fixed a pre-existing `PHAssetResource.isVideo` typo (`|| PHAssetResourceTypeFullSizeVideo` compared against enum truthiness) as a separate commit — visible symptom is audio resources landing in the video cache subdirectory via `makeAssetOutputPath:`.

- Not addressed here: #1258 (saveLivePhoto returning the same `-1`) is a separate root cause — the paired image/video the caller supplies lacks the `com.apple.quicktime.content.identifier` / MakerApple `17` metadata that `PHAssetCreationRequest` requires. That'll want a different fix that injects the pairing identifier before submitting.

Verified on a real iOS 18 device against the example app:

- Edited Live Photo `originFile` — walker picks `.fullSizePairedVideo` first (rendered/edited paired video), preserves pre-PR behavior.
- Edited Live Photo `file` (isOrigin=false, default) — same walker, different Dart entry point.
- Edited plain video (both `originFile` and default `file`) — walker cycles `.fullSizeVideo → .video → .adjustmentBaseVideo`.
- Edited plain image (both `originFile` and default `file`) — walker cycles `.fullSizePhoto → .photo → .adjustmentBasePhoto`; on failure, `fallbackFetchImageDataFor` picks up via `requestImageDataAndOrientation`.
- iCloud not-yet-downloaded video, plain image, and Live Photo — walker + AVAsset / image-data fallbacks exercised across both `originFile` and default `file` entry points.
- iCloud not-yet-downloaded × edited combined — walker cycles candidates and the fallback (where applicable) recovers.
- Progress observer stream — `Prepare (0) → Loading (0.00 → 1.00) → Success (2)`, no intermediate `Failed` events during walker retries.

Fixes #1245.
Fixes #1368.