### PR TITLE
🐛 Fix iOS 18 raising "Unsupported fetch for asset collections" opening the primary album

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Fix iOS 18+ raising `Unsupported fetch for asset collections with type 2 and subtype 2` when navigating into the primary album, caused by an invalid `SmartAlbum` + `AlbumRegular` combination in the recent-collection check.
 - Reduce built-in Kotlin migration warnings for supported project configurations while preserving legacy Flutter compatibility.
 - Fix Darwin crashes when querying assets by local identifier by catching PhotoKit exceptions and returning safe fallback results instead of aborting the process.
 - Fix the `AssetEntity.duration` API docs to clarify that audio and video durations are returned in seconds across supported platforms, preserving the existing API behavior.

--- a/darwin/photo_manager/Sources/photo_manager/core/PMFolderUtils.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMFolderUtils.m
@@ -20,19 +20,24 @@
 }
 
 + (BOOL)isRecentCollection:(NSString *)id {
+    // iOS 18 tightened `fetchAssetCollectionsWithType:subtype:` to raise
+    // "Unsupported fetch for asset collections with type 2 and subtype 2"
+    // for the (SmartAlbum, AlbumRegular) combination that older releases
+    // silently tolerated. AlbumRegular is a subtype of the Album *type*,
+    // never SmartAlbum, so the previous call was already meaningless — we
+    // just want the user's primary library, which is exactly what
+    // `SmartAlbumUserLibrary` targets.
     PHFetchResult<PHAssetCollection *> *result = [PHAssetCollection
                                                   fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum
-                                                  subtype:PHAssetCollectionSubtypeAlbumRegular
+                                                  subtype:PHAssetCollectionSubtypeSmartAlbumUserLibrary
                                                   options:nil];
-    
-    if (result && result.count) {
-        for (PHAssetCollection *collection in result) {
-            if (collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary) {
-                return [id isEqualToString:collection.localIdentifier];
-            }
+
+    for (PHAssetCollection *collection in result) {
+        if (collection.assetCollectionSubtype == PHAssetCollectionSubtypeSmartAlbumUserLibrary) {
+            return [id isEqualToString:collection.localIdentifier];
         }
     }
-    
+
     return NO;
 }
 


### PR DESCRIPTION
## Summary

- `PMFolderUtils isRecentCollection:` calls `fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAlbumRegular options:nil`. That combination has always been meaningless — `.AlbumRegular` (=2) is a subtype of the `Album` type, not `SmartAlbum` (=2) — but PhotoKit on iOS ≤17 silently tolerated it. iOS 18 tightened the API and raises `Unsupported fetch for asset collections with type 2 and subtype 2`, which surfaces to Flutter as the primary album ("主库" / Recents) failing to open, because `getSubPathWithId:` calls this predicate first.

- The intent of the check was to identify the User Library collection. `PHAssetCollectionSubtypeSmartAlbumUserLibrary` is the correct subtype to pair with `PHAssetCollectionTypeSmartAlbum` for that, so the fetch subtype is switched accordingly. The iteration guard against a different `assetCollectionSubtype` value stays as-is for safety.

- Same iOS 18 regression reported and fixed the same way in ZLPhotoBrowser [#936](https://github.com/longitachi/ZLPhotoBrowser/issues/936) / [#990](https://github.com/longitachi/ZLPhotoBrowser/issues/990) / [#993](https://github.com/longitachi/ZLPhotoBrowser/issues/993) / [#1001](https://github.com/longitachi/ZLPhotoBrowser/issues/1001).

- The `fetchAssetCollectionsWithType:PHAssetCollectionTypeSmartAlbum subtype:PHAssetCollectionSubtypeAny` and the sibling `.Album/.Any` calls in `PMManager.m` are not affected — `.Any` is always valid.

Verified: iOS example build compiles clean; hit and fixed on a real device (iOS 18) while testing the sibling loadFile branch (#1414).