### PR TITLE
🐛 Fix Darwin saveLivePhoto returning PHPhotosErrorDomain -1 by injecting pairing metadata

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Fix Darwin `PhotoManager.editor.darwin.saveLivePhoto` returning `PHPhotosErrorDomain (-1)` when the caller-supplied image and video lacked the shared Live Photo pairing identifier `PHAssetCreationRequest` requires.
 - Fix iOS 18+ raising `Unsupported fetch for asset collections with type 2 and subtype 2` when navigating into the primary album, caused by an invalid `SmartAlbum` + `AlbumRegular` combination in the recent-collection check.
 - Fix Darwin `AssetEntity.loadFile` / `originFile` sporadically failing with `PHPhotosErrorDomain (-1)` for edited assets and Live Photos by walking multiple `PHAssetResource` candidates and falling back to `PHImageManager` for plain videos/images when `writeDataForAssetResource` exhausts them.
 - Reduce built-in Kotlin migration warnings for supported project configurations while preserving legacy Flutter compatibility.

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -14,6 +14,9 @@
 #import "PMRequestTypeUtils.h"
 #import "PMResultHandler.h"
 
+#import <AVFoundation/AVFoundation.h>
+#import <ImageIO/ImageIO.h>
+
 static NSString *PMResourceTypeName(PHAssetResourceType type) {
     // Adjustment-base types have newer availability than the plugin's iOS 9
     // deployment target, so guard the comparisons behind `@available` before
@@ -1993,40 +1996,361 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }];
 }
 
+#pragma mark - Live Photo Metadata Helpers
+
+// Live Photos require the still image and paired video to share a
+// `com.apple.quicktime.content.identifier` UUID. When callers hand us plain
+// HEIC/JPEG + MOV/MP4 the Photos framework rejects the resource pair with
+// PHPhotosErrorDomain -1. These helpers inject the identifier into both files
+// (image via `kCGImagePropertyMakerAppleDictionary["17"]`, video via a
+// QuickTime metadata item + a still-image-time metadata track) before we
+// submit the creation request. Reference: https://github.com/LimitPoint/LivePhoto
+//
+// `sourceType` (out) receives the source image's UTI so the caller can set
+// `PHAssetResourceCreationOptions.uniformTypeIdentifier` accurately.
+- (NSURL *)addLivePhotoAssetIdentifier:(NSString *)assetIdentifier
+                                  desc:(NSString *)desc
+                          toImageAtURL:(NSURL *)imageURL
+                             outputURL:(NSURL *)outputURL
+                            sourceUTI:(NSString **)sourceUTIOut {
+    CGImageSourceRef imageSource = CGImageSourceCreateWithURL((__bridge CFURLRef)imageURL, nil);
+    if (!imageSource) {
+        [PMLogUtils.sharedInstance info:@"[LivePhoto][Meta] Failed to create image source"];
+        return nil;
+    }
+    CFStringRef sourceType = CGImageSourceGetType(imageSource);
+    if (!sourceType) {
+        CFRelease(imageSource);
+        [PMLogUtils.sharedInstance info:@"[LivePhoto][Meta] Failed to determine source image type"];
+        return nil;
+    }
+    if (sourceUTIOut) {
+        // Copy the string — CGImageSourceGetType returns a CFStringRef whose
+        // lifetime is tied to the source, which we release below.
+        *sourceUTIOut = [NSString stringWithString:(__bridge NSString *)sourceType];
+    }
+    CGImageDestinationRef imageDestination = CGImageDestinationCreateWithURL(
+        (__bridge CFURLRef)outputURL, sourceType, 1, nil);
+    if (!imageDestination) {
+        CFRelease(imageSource);
+        [PMLogUtils.sharedInstance info:@"[LivePhoto][Meta] Failed to create image destination"];
+        return nil;
+    }
+    NSDictionary *srcProps = (__bridge_transfer NSDictionary *)
+        CGImageSourceCopyPropertiesAtIndex(imageSource, 0, nil);
+    NSMutableDictionary *props = srcProps ? [srcProps mutableCopy]
+                                          : [NSMutableDictionary dictionary];
+    props[(__bridge NSString *)kCGImagePropertyMakerAppleDictionary] =
+        @{ @"17" : assetIdentifier };
+    if (![desc isNilOrNull] && desc.length > 0) {
+        NSString *tiffKey = (__bridge NSString *)kCGImagePropertyTIFFDictionary;
+        NSString *tiffDescKey = (__bridge NSString *)kCGImagePropertyTIFFImageDescription;
+        NSMutableDictionary *tiff = props[tiffKey] ? [props[tiffKey] mutableCopy]
+                                                   : [NSMutableDictionary dictionary];
+        tiff[tiffDescKey] = desc;
+        props[tiffKey] = tiff;
+    }
+    // Streams encoded bytes through — no CG decode/re-encode.
+    CGImageDestinationAddImageFromSource(imageDestination, imageSource, 0,
+                                         (__bridge CFDictionaryRef)props);
+    BOOL ok = CGImageDestinationFinalize(imageDestination);
+    CFRelease(imageSource);
+    CFRelease(imageDestination);
+    if (!ok) {
+        [PMLogUtils.sharedInstance info:@"[LivePhoto][Meta] CGImageDestinationFinalize failed"];
+        return nil;
+    }
+    return outputURL;
+}
+
+- (void)addLivePhotoAssetIdentifier:(NSString *)assetIdentifier
+                       toVideoAtURL:(NSURL *)videoURL
+                          outputURL:(NSURL *)outputURL
+                         completion:(void (^)(NSURL *resultURL, NSError *error))completion {
+    AVURLAsset *videoAsset = [AVURLAsset URLAssetWithURL:videoURL options:nil];
+    NSArray<AVAssetTrack *> *videoTracks = [videoAsset tracksWithMediaType:AVMediaTypeVideo];
+    if (videoTracks.count == 0) {
+        completion(nil, [NSError errorWithDomain:@"PMManager" code:-1
+                                       userInfo:@{NSLocalizedDescriptionKey: @"No video track found in source file"}]);
+        return;
+    }
+    AVAssetTrack *videoTrack = videoTracks.firstObject;
+
+    NSError *error = nil;
+    AVAssetWriter *assetWriter = [AVAssetWriter assetWriterWithURL:outputURL
+                                                         fileType:AVFileTypeQuickTimeMovie
+                                                            error:&error];
+    if (error || !assetWriter) {
+        completion(nil, error);
+        return;
+    }
+
+    AVAssetReader *videoReader = [[AVAssetReader alloc] initWithAsset:videoAsset error:&error];
+    if (error || !videoReader) {
+        completion(nil, error);
+        return;
+    }
+    AVAssetReaderTrackOutput *videoReaderOutput =
+        [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:videoTrack
+                                                  outputSettings:nil];
+    [videoReader addOutput:videoReaderOutput];
+
+    CMFormatDescriptionRef videoFmt =
+        (__bridge CMFormatDescriptionRef)videoTrack.formatDescriptions.firstObject;
+    AVAssetWriterInput *videoWriterInput =
+        [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeVideo
+                                          outputSettings:nil
+                                        sourceFormatHint:videoFmt];
+    videoWriterInput.transform = videoTrack.preferredTransform;
+    videoWriterInput.expectsMediaDataInRealTime = NO;
+    [assetWriter addInput:videoWriterInput];
+
+    AVAssetReader *audioReader = nil;
+    AVAssetReaderTrackOutput *audioReaderOutput = nil;
+    AVAssetWriterInput *audioWriterInput = nil;
+    NSArray<AVAssetTrack *> *audioTracks = [videoAsset tracksWithMediaType:AVMediaTypeAudio];
+    if (audioTracks.count > 0) {
+        AVAssetTrack *audioTrack = audioTracks.firstObject;
+        audioReader = [[AVAssetReader alloc] initWithAsset:videoAsset error:&error];
+        if (!error && audioReader) {
+            audioReaderOutput =
+                [AVAssetReaderTrackOutput assetReaderTrackOutputWithTrack:audioTrack
+                                                         outputSettings:nil];
+            [audioReader addOutput:audioReaderOutput];
+            audioWriterInput =
+                [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeAudio
+                                                  outputSettings:nil];
+            audioWriterInput.expectsMediaDataInRealTime = NO;
+            [assetWriter addInput:audioWriterInput];
+        }
+    }
+
+    AVMutableMetadataItem *identifierItem = [AVMutableMetadataItem metadataItem];
+    identifierItem.key = @"com.apple.quicktime.content.identifier";
+    identifierItem.keySpace = AVMetadataKeySpaceQuickTimeMetadata;
+    identifierItem.value = assetIdentifier;
+    identifierItem.dataType = @"com.apple.metadata.datatype.UTF-8";
+    assetWriter.metadata = @[identifierItem];
+
+    NSString *keyStillImageTime = @"com.apple.quicktime.still-image-time";
+    NSDictionary *spec = @{
+        (__bridge NSString *)kCMMetadataFormatDescriptionMetadataSpecificationKey_Identifier :
+            [NSString stringWithFormat:@"mdta/%@", keyStillImageTime],
+        (__bridge NSString *)kCMMetadataFormatDescriptionMetadataSpecificationKey_DataType :
+            @"com.apple.metadata.datatype.int8"
+    };
+    CMFormatDescriptionRef metaFmtDesc = NULL;
+    CMMetadataFormatDescriptionCreateWithMetadataSpecifications(
+        kCFAllocatorDefault, kCMMetadataFormatType_Boxed,
+        (__bridge CFArrayRef)@[spec], &metaFmtDesc);
+    AVAssetWriterInput *metadataWriterInput =
+        [AVAssetWriterInput assetWriterInputWithMediaType:AVMediaTypeMetadata
+                                          outputSettings:nil
+                                        sourceFormatHint:metaFmtDesc];
+    AVAssetWriterInputMetadataAdaptor *metadataAdaptor =
+        [AVAssetWriterInputMetadataAdaptor
+            assetWriterInputMetadataAdaptorWithAssetWriterInput:metadataWriterInput];
+    [assetWriter addInput:metadataWriterInput];
+    if (metaFmtDesc) {
+        CFRelease(metaFmtDesc);
+    }
+
+    [assetWriter startWriting];
+    [assetWriter startSessionAtSourceTime:kCMTimeZero];
+
+    AVMutableMetadataItem *stillItem = [AVMutableMetadataItem metadataItem];
+    stillItem.key = keyStillImageTime;
+    stillItem.keySpace = AVMetadataKeySpaceQuickTimeMetadata;
+    stillItem.value = @0;
+    stillItem.dataType = @"com.apple.metadata.datatype.int8";
+    CMTime duration = videoAsset.duration;
+    CMTime midPoint = CMTimeMake(duration.value / 2, duration.timescale);
+    Float64 fps = videoTrack.nominalFrameRate;
+    // Round up so fractional fps (time-lapse, slow-mo variants) doesn't
+    // truncate to zero and crash the CMTimeMake divide below.
+    int32_t fpsInt = fps >= 1.0 ? (int32_t)ceil(fps) : 30;
+    CMTime frameDur = CMTimeMake(duration.timescale / fpsInt, duration.timescale);
+    CMTimeRange stillRange = CMTimeRangeMake(midPoint, frameDur);
+    AVTimedMetadataGroup *metaGroup =
+        [[AVTimedMetadataGroup alloc] initWithItems:@[stillItem] timeRange:stillRange];
+    if (![metadataAdaptor appendTimedMetadataGroup:metaGroup]) {
+        [PMLogUtils.sharedInstance info:@"[LivePhoto][Meta] Failed to append still-image-time metadata group"];
+    }
+    [metadataWriterInput markAsFinished];
+
+    dispatch_group_t doneGroup = dispatch_group_create();
+    dispatch_queue_t videoQueue = dispatch_queue_create("com.fluttercandies.pm.livePhotoVideoQueue", NULL);
+    dispatch_queue_t audioQueue = dispatch_queue_create("com.fluttercandies.pm.livePhotoAudioQueue", NULL);
+
+    dispatch_group_enter(doneGroup);
+    if ([videoReader startReading]) {
+        [videoWriterInput requestMediaDataWhenReadyOnQueue:videoQueue usingBlock:^{
+            // Keep videoReader alive until the block finishes — the output
+            // holds only an unowned reference back to its reader, so if the
+            // outer function's strong ref goes out of scope before the block
+            // runs, copyNextSampleBuffer will throw
+            // "output not added to a reader".
+            (void)videoReader;
+            while (videoWriterInput.readyForMoreMediaData) {
+                CMSampleBufferRef buf = [videoReaderOutput copyNextSampleBuffer];
+                if (buf) {
+                    [videoWriterInput appendSampleBuffer:buf];
+                    CFRelease(buf);
+                } else {
+                    [videoWriterInput markAsFinished];
+                    dispatch_group_leave(doneGroup);
+                    return;
+                }
+            }
+        }];
+    } else {
+        [videoWriterInput markAsFinished];
+        dispatch_group_leave(doneGroup);
+    }
+
+    if (audioWriterInput && audioReader) {
+        dispatch_group_enter(doneGroup);
+        if ([audioReader startReading]) {
+            [audioWriterInput requestMediaDataWhenReadyOnQueue:audioQueue usingBlock:^{
+                (void)audioReader;
+                while (audioWriterInput.readyForMoreMediaData) {
+                    CMSampleBufferRef buf = [audioReaderOutput copyNextSampleBuffer];
+                    if (buf) {
+                        [audioWriterInput appendSampleBuffer:buf];
+                        CFRelease(buf);
+                    } else {
+                        [audioWriterInput markAsFinished];
+                        dispatch_group_leave(doneGroup);
+                        return;
+                    }
+                }
+            }];
+        } else {
+            [audioWriterInput markAsFinished];
+            dispatch_group_leave(doneGroup);
+        }
+    }
+
+    dispatch_group_notify(doneGroup, dispatch_get_main_queue(), ^{
+        [assetWriter finishWritingWithCompletionHandler:^{
+            if (assetWriter.status == AVAssetWriterStatusCompleted) {
+                completion(outputURL, nil);
+            } else {
+                completion(nil, assetWriter.error);
+            }
+        }];
+    });
+}
+
 - (void)saveLivePhoto:(NSString *)imagePath
             videoPath:(NSString *)videoPath
                 title:(NSString *)title
                  desc:(NSString *)desc
                 block:(AssetBlockResult)block {
     [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Saving Live Photo with imagePath: %@, videoPath: %@, filename: %@, desc: %@", imagePath, videoPath, title, desc]];
-    NSURL *imageURL = [NSURL fileURLWithPath:imagePath];
-    NSURL *videoURL = [NSURL fileURLWithPath:videoPath];
 
-    __block NSString *assetId = nil;
-    __weak typeof(self) weakSelf = self;
-    [[PHPhotoLibrary sharedPhotoLibrary]
-     performChanges:^{
-        PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
-        PHAssetResourceCreationOptions *imageOptions = [PHAssetResourceCreationOptions new];
-        [imageOptions setOriginalFilename:title];
-        [request addResourceWithType:PHAssetResourceTypePhoto fileURL:imageURL options:imageOptions];
-        PHAssetResourceCreationOptions *videoOptions = [PHAssetResourceCreationOptions new];
-        [videoOptions setOriginalFilename:title];
-        [request addResourceWithType:PHAssetResourceTypePairedVideo fileURL:videoURL options:videoOptions];
-        assetId = request.placeholderForCreatedAsset.localIdentifier;
+    NSFileManager *fm = NSFileManager.defaultManager;
+    if (![fm fileExistsAtPath:imagePath]) {
+        block(nil, [NSError errorWithDomain:@"PMManager" code:-1 userInfo:@{
+            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Image file does not exist at path: %@", imagePath]
+        }]);
+        return;
     }
-     completionHandler:^(BOOL success, NSError *error) {
+    if (![fm fileExistsAtPath:videoPath]) {
+        block(nil, [NSError errorWithDomain:@"PMManager" code:-1 userInfo:@{
+            NSLocalizedDescriptionKey: [NSString stringWithFormat:@"Video file does not exist at path: %@", videoPath]
+        }]);
+        return;
+    }
+
+    NSString *assetIdentifier = [[NSUUID UUID] UUIDString];
+    NSString *tmpDir = [NSTemporaryDirectory() stringByAppendingPathComponent:@"pm_livephoto"];
+    [fm createDirectoryAtPath:tmpDir withIntermediateDirectories:YES attributes:nil error:nil];
+
+    NSString *imageExt = imagePath.pathExtension.length > 0 ? imagePath.pathExtension : @"jpg";
+    // Paired Live Photo video is always QuickTime .mov — Photos rejects
+    // other containers even if the source was MP4/HEVC.
+    NSString *videoExt = @"mov";
+    NSURL *srcImageURL = [NSURL fileURLWithPath:imagePath];
+    NSURL *srcVideoURL = [NSURL fileURLWithPath:videoPath];
+    NSURL *tmpImageURL = [NSURL fileURLWithPath:
+        [[tmpDir stringByAppendingPathComponent:assetIdentifier] stringByAppendingPathExtension:imageExt]];
+    NSURL *tmpVideoURL = [NSURL fileURLWithPath:
+        [[tmpDir stringByAppendingPathComponent:assetIdentifier] stringByAppendingPathExtension:videoExt]];
+    [fm removeItemAtURL:tmpImageURL error:nil];
+    [fm removeItemAtURL:tmpVideoURL error:nil];
+
+    NSString *imageUTI = nil;
+    NSURL *enrichedImageURL = [self addLivePhotoAssetIdentifier:assetIdentifier
+                                                           desc:desc
+                                                  toImageAtURL:srcImageURL
+                                                     outputURL:tmpImageURL
+                                                     sourceUTI:&imageUTI];
+    if (!enrichedImageURL) {
+        block(nil, [NSError errorWithDomain:@"PMManager" code:-1 userInfo:@{
+            NSLocalizedDescriptionKey: @"Failed to write Live Photo metadata to image file"
+        }]);
+        return;
+    }
+
+    __weak typeof(self) weakSelf = self;
+    [self addLivePhotoAssetIdentifier:assetIdentifier
+                         toVideoAtURL:srcVideoURL
+                            outputURL:tmpVideoURL
+                           completion:^(NSURL *enrichedVideoURL, NSError *videoError) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) {
+        if (!strongSelf) { return; }
+        if (!enrichedVideoURL) {
+            [fm removeItemAtURL:tmpImageURL error:nil];
+            // AVAssetWriter may have written a partial file before failing.
+            [fm removeItemAtURL:tmpVideoURL error:nil];
+            block(nil, videoError ?: [NSError errorWithDomain:@"PMManager" code:-1 userInfo:@{
+                NSLocalizedDescriptionKey: @"Failed to write Live Photo metadata to video file"
+            }]);
             return;
         }
-        if (success) {
-            [PMLogUtils.sharedInstance info: [NSString stringWithFormat:@"Created Live Photo asset = %@", assetId]];
-            block([strongSelf getAssetEntity:assetId], nil);
-        } else {
-            [PMLogUtils.sharedInstance info: [NSString stringWithFormat:@"Create Live Photo asset failed = %@, %@", assetId, error]];
-            block(nil, error);
+
+        PHAssetResourceCreationOptions *imageOptions = [PHAssetResourceCreationOptions new];
+        PHAssetResourceCreationOptions *videoOptions = [PHAssetResourceCreationOptions new];
+        if (imageUTI.length > 0) {
+            imageOptions.uniformTypeIdentifier = imageUTI;
         }
+        videoOptions.uniformTypeIdentifier = AVFileTypeQuickTimeMovie;
+        if (![title isNilOrNull] && title.length > 0) {
+            NSString *baseTitle = title.stringByDeletingPathExtension;
+            [imageOptions setOriginalFilename:[baseTitle stringByAppendingPathExtension:imageExt]];
+            [videoOptions setOriginalFilename:[baseTitle stringByAppendingPathExtension:videoExt]];
+        }
+
+        __block NSString *assetId = nil;
+        [[PHPhotoLibrary sharedPhotoLibrary]
+         performChanges:^{
+            PHAssetCreationRequest *request = [PHAssetCreationRequest creationRequestForAsset];
+            [request addResourceWithType:PHAssetResourceTypePhoto fileURL:enrichedImageURL options:imageOptions];
+            [request addResourceWithType:PHAssetResourceTypePairedVideo fileURL:enrichedVideoURL options:videoOptions];
+            assetId = request.placeholderForCreatedAsset.localIdentifier;
+        }
+         completionHandler:^(BOOL success, NSError *saveError) {
+            [fm removeItemAtURL:tmpImageURL error:nil];
+            [fm removeItemAtURL:tmpVideoURL error:nil];
+            if (success) {
+                [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Created Live Photo asset = %@", assetId]];
+                // Warn (don't fail) if Photos accepted the pair but didn't
+                // classify it as a Live Photo — indicates the metadata was
+                // ignored and the pair was flattened to a still + video.
+                PHFetchResult *r = [PHAsset fetchAssetsWithLocalIdentifiers:@[assetId] options:nil];
+                PHAsset *created = r.firstObject;
+                if (created && (created.mediaSubtypes & PHAssetMediaSubtypePhotoLive) == 0) {
+                    [PMLogUtils.sharedInstance info:[NSString stringWithFormat:
+                        @"[LivePhoto] WARNING: saved asset %@ was NOT recognized as Live Photo (mediaSubtypes=%lu)",
+                        assetId, (unsigned long)created.mediaSubtypes]];
+                }
+                block([strongSelf getAssetEntity:assetId], nil);
+            } else {
+                [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Create Live Photo asset failed = %@, %@", assetId, saveError]];
+                block(nil, saveError);
+            }
+        }];
     }];
 }
 


### PR DESCRIPTION
## Summary

- `PhotoManager.editor.darwin.saveLivePhoto` handed the caller-supplied image and video straight to `PHAssetCreationRequest addResourceWithType:`, but PhotoKit only pairs the two resources into a Live Photo when they share a matching content-identifier UUID: the image needs `kCGImagePropertyMakerAppleDictionary["17"] = <UUID>`, and the video needs the same UUID in a QuickTime `com.apple.quicktime.content.identifier` metadata item plus a `com.apple.quicktime.still-image-time` timed-metadata track. When the caller's inputs lack this pairing (arbitrary HEIC/JPEG + MOV/MP4 that isn't already a stitched Live Photo pair), PhotoKit falls through to the catch-all `PHPhotosErrorInternalError (-1)` — the same opaque error that #1414 fixed on the read side. That's what #1258 has been chasing.

- The pairing recipe is the same one used by [LimitPoint/LivePhoto](https://github.com/LimitPoint/LivePhoto): reverse-engineered but stable since at least iOS 9.1 (the AVFoundation constant `AVMetadataQuickTimeMetadataKeyContentIdentifier` corroborates the video side, and the MakerApple `17` key is community-verified). This PR wires the recipe into the plugin's save path.

- Both files are re-authored into `NSTemporaryDirectory()/pm_livephoto/<UUID>.<ext>` before the creation request, then cleaned up unconditionally in the completion handler and in every failure branch:
  1. **Image**: `CGImageDestinationAddImageFromSource` streams the encoded bytes into a new destination without a `CGImage` decode/re-encode step, preserving HEIC/JPEG/PNG format (via `CGImageSourceGetType`) and full EXIF/GPS. The rewritten properties merge the original `srcProps` with the injected `MakerApple["17"]` UUID and (when non-empty) an EXIF `TIFFImageDescription` for `desc`. The source UTI is copied out of the CGImageSource before it's released — `CGImageSourceGetType` follows the CF Get Rule, so the returned `CFStringRef` doesn't outlive its source and needs `[NSString stringWithString:]` before crossing into async callbacks.
  2. **Video**: `AVAssetWriter` passthrough re-mux (`outputSettings:nil + sourceFormatHint:`) into a QuickTime `.mov` container. Reader is sample-by-sample (`copyNextSampleBuffer` → `appendSampleBuffer:`), so memory stays bounded regardless of source length; H.264 and HEVC pass through unchanged. Live Photo companion video **must** be in a QuickTime container per Photos' resource contract, so even MP4 inputs are re-muxed rather than kept as-is — the paired-video temp file extension is forced to `.mov` and `PHAssetResourceCreationOptions.uniformTypeIdentifier` is set to `AVFileTypeQuickTimeMovie` so PhotoKit doesn't guess by filename.
  - Native iPhone Live Photos are already HEIC + HEVC/`.mov` (High Efficiency mode is the default since iOS 11 and remains so through iOS 26/27), so the common "round-trip an existing Live Photo pair" case is a MOV → MOV passthrough with a metadata overlay — no encoding cost. Cross-source inputs (JPEG + MP4, HEIC + MP4/HEVC) are the ones that pay the re-mux.

- Robustness fixes surfaced by adversarial review of the LimitPoint recipe as ported:
  - `title` and `desc` are guarded with the plugin's existing `-isNilOrNull` category before any `-length` message. The Flutter method channel materializes Dart `null` as `NSNull`, so `desc.length > 0` sent a selector `NSNull` doesn't respond to and crashed with `NSInvalidArgumentException` on the first save call from a Dart caller that omitted either optional. The sibling `saveImage` / `saveVideo` methods already use this pattern.
  - `videoReader` and `audioReader` are strong-referenced from within their sample-pump blocks (`(void)videoReader;`, `(void)audioReader;`). `AVAssetReaderTrackOutput` holds only an unowned back-pointer to its reader, so once the enclosing function returned, ARC released the readers before the async block ran and `copyNextSampleBuffer` raised `NSInternalInconsistencyException: cannot copy next sample buffer before adding this output to an instance of AVAssetReader`. Symbol references inside each block keep the readers alive for the duration of the pump.
  - Guard the fps → frame-duration divide against fractional / sub-1 fps inputs. The prior expression `(int32_t)fps` truncated 0.5 fps time-lapse assets to `0`, then `CMTimeMake(duration.timescale / 0, …)` divided by zero and raised `SIGFPE`. Now `ceil(fps)` with a `>= 1.0` guard falls back to 30 for the degenerate cases.
  - Call `[metadataWriterInput markAsFinished]` after appending the still-image-time group and check `appendTimedMetadataGroup:`'s BOOL return — the metadata track was previously left in an open state, relying on `finishWritingWithCompletionHandler`'s implicit finalization, which is documented as best-effort.
  - Clean up both `tmpImageURL` and `tmpVideoURL` in the video-enrichment failure branch. `AVAssetWriter` may have written a partial `.mov` before failing.

- Post-save the plugin re-fetches the created `PHAsset` and logs a warning if `mediaSubtypes & PHAssetMediaSubtypePhotoLive == 0`. That's a footgun path — PhotoKit accepts the pair but flattens it into a still + a plain video, and the caller can't tell locally. Not surfaced as an error yet (the asset does exist, so the return value is honest), but the log line is enough to diagnose from the field.

- Sibling relationship with #1414: that PR was `-1` on **reads** (`writeDataForAssetResource:`); this one is `-1` on **writes** (`PHAssetCreationRequest`). Both are `PHPhotosErrorInternalError` with no `NSLocalizedFailureReasonErrorKey`, and both were called out as separate root causes in the #1414 discussion.

## Verified

- `flutter build ios --debug --no-codesign` clean on both simulator and device; `PMManager.o` rebuilt for arm64 + x86_64.
- Static syntax/type check via `clang -fsyntax-only -fmodules` clean.
- Approach independently reality-checked against Apple docs (`AVAssetWriterInput.h` passthrough contract, `CGImageDestinationAddImageFromSource` byte-preserving guarantee, `CGImageSourceGetType` Get Rule, `AVFileTypeQuickTimeMovie` UTI, `PHAssetResourceCreationOptions.uniformTypeIdentifier` availability floor at iOS 9.0 / macOS 10.15 — matches the plugin's deployment targets, no new gating needed) and against the LimitPoint reference for the metadata key/value/timing conventions.
- Verified on a real iOS device with a **JPEG + H.264/MP4** input pair (3840×2160 @ 25fps, 5s clip re-muxed to `.mov` for the paired video, JPEG rewritten with the MakerApple `17` UUID). `PhotoManager.editor.darwin.saveLivePhoto` returned an `AssetEntity` with `isLivePhoto=true` and `subtype=8` (`PHAssetMediaSubtypePhotoLive`), and the created asset played back as a Live Photo in Photos.app with the Live badge visible. The `NSNull` crash on optional `desc`/`title` and the `AVAssetReader` lifetime crash were both first surfaced by this real-device run and are addressed in the same commit; the eventual pass covers those regressions. HEIC + HEVC/MOV (native round-trip) and HEIC + MP4/HEVC (cross-tool) not exercised on device yet — the JPEG + H.264/MP4 case is the higher-risk cross-source path, so passing it is the best signal available short of exhaustive matrix testing.

Fixes #1258.
