### PR TITLE
🐛 Fix iOS iCloud + Optimize Storage delivering downsampled originFile bytes

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -27,6 +27,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Fix Darwin `AssetEntity.originFile` returning the locally-downsampled proxy for iCloud + "Optimize iPhone Storage"-affected photos by preferring `PHImageManager` with `HighQualityFormat` over `writeDataForAssetResource` on unedited raster primaries.
 - Fix Darwin `PhotoManager.editor.darwin.saveLivePhoto` returning `PHPhotosErrorDomain (-1)` when the caller-supplied image and video lacked the shared Live Photo pairing identifier `PHAssetCreationRequest` requires.
 - Fix iOS 18+ raising `Unsupported fetch for asset collections with type 2 and subtype 2` when navigating into the primary album, caused by an invalid `SmartAlbum` + `AlbumRegular` combination in the recent-collection check.
 - Fix Darwin `AssetEntity.loadFile` / `originFile` sporadically failing with `PHPhotosErrorDomain (-1)` for edited assets and Live Photos by walking multiple `PHAssetResource` candidates and falling back to `PHImageManager` for plain videos/images when `writeDataForAssetResource` exhausts them.

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1479,11 +1479,26 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             }
             __strong typeof(weakSelf) inner = weakSelf;
             if (!inner) { return; }
+            void (^tryOfflineProxy)(NSObject *finalError) = ^(NSObject *finalError) {
+                // Every network-touching path has failed. Try one last request
+                // with networkAccessAllowed=NO to surface the local proxy
+                // Photos keeps under Optimize Storage — better a small image
+                // than an opaque -1009.
+                [inner fetchOfflineImageProxyFor:asset
+                                progressHandler:progressHandler
+                                          block:^(NSString *proxyPath, NSObject *proxyError) {
+                    if (proxyPath) {
+                        [handler reply:proxyPath];
+                        return;
+                    }
+                    [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+                    [handler replyError:finalError ?: proxyError];
+                }];
+            };
             if (seedError) {
                 // PHImageManager already ran and failed — walker was the
-                // fallback. Nothing else to try.
-                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
-                [handler replyError:walkerError ?: seedError];
+                // fallback. Try offline proxy as last resort.
+                tryOfflineProxy(walkerError ?: seedError);
                 return;
             }
             // Walker ran as the primary path (RAW / exotic UTI) and every
@@ -1497,8 +1512,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     [handler reply:fbPath];
                     return;
                 }
-                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
-                [handler replyError:walkerError ?: fbError];
+                tryOfflineProxy(walkerError ?: fbError);
             }];
         }];
     };
@@ -1677,6 +1691,8 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         }
         NSObject *error = info[PHImageErrorKey];
         if (error) {
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] PHImageManager error: %@", error]];
             block(nil, error);
             return;
         }
@@ -1706,6 +1722,125 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 (unsigned long)dataLength, path]];
             [innerSelf notifySuccess:progressHandler];
             block(path, nil);
+        });
+    };
+
+    dispatch_async(dispatch_get_main_queue(), ^{
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (@available(iOS 13.0, macOS 10.15, *)) {
+            [strongSelf.cachingManager requestImageDataAndOrientationForAsset:asset
+                                                                     options:options
+                                                               resultHandler:^(NSData *_Nullable imageData,
+                                                                               NSString *_Nullable dataUTI,
+                                                                               CGImagePropertyOrientation orientation,
+                                                                               NSDictionary *_Nullable info) {
+                dataHandler(imageData, info);
+            }];
+        } else {
+#if TARGET_OS_IOS
+            [strongSelf.cachingManager requestImageDataForAsset:asset
+                                                        options:options
+                                                  resultHandler:^(NSData *_Nullable imageData,
+                                                                  NSString *_Nullable dataUTI,
+                                                                  UIImageOrientation orientation,
+                                                                  NSDictionary *_Nullable info) {
+                dataHandler(imageData, info);
+            }];
+#else
+            dataHandler(nil, @{PHImageErrorKey: [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
+                NSLocalizedDescriptionKey: @"requestImageDataForAsset unavailable on this platform version."
+            }]});
+#endif
+        }
+    });
+}
+
+// Tail fallback used when both the PHImageManager (HighQualityFormat +
+// networkAccessAllowed=YES) primary and the PHAssetResource walker have
+// failed — typically because the device is offline and the requested
+// resource is only present as an iCloud stub. Requests one more time with
+// deliveryMode=Opportunistic + networkAccessAllowed=NO and *accepts the
+// degraded result*, so the caller receives the local downsampled proxy
+// (the "small image" Photos.app itself falls back to offline) instead of
+// an opaque network error. The proxy is cached at a distinct
+// `proxy_`-prefixed filename so a subsequent online call still traverses
+// the primary path and materialises the iCloud original — no cross-mode
+// pollution.
+- (void)fetchOfflineImageProxyFor:(PHAsset *)asset
+                  progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
+                            block:(void (^)(NSString *path, NSObject *error))block {
+    NSFileManager *manager = NSFileManager.defaultManager;
+    NSString *base = [self makeAssetOutputPath:asset resource:nil isOrigin:YES fileType:nil manager:manager];
+    NSString *dir = [base stringByDeletingLastPathComponent];
+    NSString *proxyPath = [dir stringByAppendingPathComponent:
+                           [@"proxy_" stringByAppendingString:[base lastPathComponent]]];
+    if ([manager fileExistsAtPath:proxyPath]) {
+        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+            @"[#1118] local proxy cache hit → %@", proxyPath]];
+        [self notifySuccess:progressHandler];
+        block(proxyPath, nil);
+        return;
+    }
+
+    PHImageRequestOptions *options = [PHImageRequestOptions new];
+    [options setDeliveryMode:PHImageRequestOptionsDeliveryModeOpportunistic];
+    [options setNetworkAccessAllowed:NO];
+    [options setSynchronous:NO];
+    [options setVersion:PHImageRequestOptionsVersionCurrent];
+
+    __weak typeof(self) weakSelf = self;
+    // Opportunistic mode can fire the result handler more than once in
+    // principle. With networkAccessAllowed=NO a second callback is unlikely
+    // (no iCloud round trip is scheduled), but guard against double-reply
+    // regardless — the wrapping PMResultHandler treats a second reply as a
+    // programmer error.
+    __block BOOL replied = NO;
+    void (^dataHandler)(NSData *_Nullable, NSDictionary *_Nullable) = ^(NSData *_Nullable imageData, NSDictionary *_Nullable info) {
+        __strong typeof(weakSelf) strongSelf = weakSelf;
+        if (!strongSelf) { return; }
+        if (replied) { return; }
+        if ([info[PHImageCancelledKey] boolValue]) {
+            replied = YES;
+            [[PMLogUtils sharedInstance] info:@"[#1118] local-proxy PHImageManager cancelled"];
+            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-2 userInfo:@{
+                NSLocalizedDescriptionKey: @"PHImageManager request was cancelled."
+            }]);
+            return;
+        }
+        NSObject *error = info[PHImageErrorKey];
+        if (error) {
+            replied = YES;
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] local-proxy PHImageManager error: %@", error]];
+            block(nil, error);
+            return;
+        }
+        if (!imageData) {
+            replied = YES;
+            [[PMLogUtils sharedInstance] info:@"[#1118] local-proxy no data available"];
+            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
+                NSLocalizedDescriptionKey: @"No local proxy available for asset."
+            }]);
+            return;
+        }
+        replied = YES;
+        NSUInteger dataLength = imageData.length;
+        BOOL degraded = [info[PHImageResultIsDegradedKey] boolValue];
+        dispatch_async(strongSelf->_imageFileProcessingQueue, ^{
+            __strong typeof(weakSelf) innerSelf = weakSelf;
+            if (!innerSelf) { return; }
+            NSError *writeError;
+            [imageData writeToFile:proxyPath options:NSDataWritingAtomic error:&writeError];
+            if (writeError) {
+                block(nil, writeError);
+                return;
+            }
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] local proxy delivered %lu bytes%@ → %@",
+                (unsigned long)dataLength, degraded ? @" (degraded)" : @"", proxyPath]];
+            [innerSelf notifySuccess:progressHandler];
+            block(proxyPath, nil);
         });
     };
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1403,6 +1403,28 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     return resource.type == PHAssetResourceTypePhoto || resource.type == PHAssetResourceTypeFullSizePhoto;
 }
 
+// Common raster formats that PHImageManager reliably returns byte-identical
+// via its data pipeline. RAW/exotic formats are excluded — for those we walk
+// the PHAssetResource candidates instead so users still receive the raw
+// underlying resource bytes (e.g. a .dng file) rather than a JPEG rendition.
+- (BOOL)canFetchOriginViaImageManager:(PHAssetResource *)primary {
+    // Only substitute PHImageManager for the unedited primary photo resource.
+    // A `.fullSizePhoto` candidate (present only for edited assets) is the
+    // rendered edit that Photos shows the user; the walker returns those
+    // exact bytes, whereas PHImageManager may re-encode HEIC→JPEG for edits,
+    // silently changing the returned format.
+    if (primary.type != PHAssetResourceTypePhoto) {
+        return NO;
+    }
+    NSString *uti = primary.uniformTypeIdentifier ?: @"";
+    return [uti isEqualToString:@"public.jpeg"]
+        || [uti isEqualToString:@"public.heic"]
+        || [uti isEqualToString:@"public.heif"]
+        || [uti isEqualToString:@"public.heic-sequence"]
+        || [uti isEqualToString:@"public.heif-sequence"]
+        || [uti isEqualToString:@"public.png"];
+}
+
 - (void)fetchOriginImageFile:(PHAsset *)asset resultHandler:(PMResultHandler *)handler progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler {
     NSArray<PHAssetResource *> *candidates = [asset candidateResourcesForFetch:YES livePhoto:NO];
     if (candidates.count == 0) {
@@ -1421,33 +1443,72 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }
     [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
     __weak typeof(self) weakSelf = self;
-    [self fetchImageFileFromCandidates:candidates
-                               atIndex:0
-                             attempted:[NSMutableArray arrayWithCapacity:candidates.count]
-                             lastError:nil
-                                 asset:asset
-                       progressHandler:progressHandler
-                                 block:^(NSString *path, NSObject *walkerError) {
-        if (path) {
-            [handler reply:path];
-            return;
-        }
+    // Prefer PHImageManager.requestImageDataAndOrientation with
+    // deliveryMode=HighQualityFormat first: PHAssetResourceRequestOptions has
+    // no deliveryMode control, so writeDataForAssetResource can deliver the
+    // locally downsampled bytes when the user has "Optimize iPhone Storage"
+    // enabled and iCloud has replaced the local file with a low-quality
+    // proxy (#1118). PHImageManager's HighQualityFormat guarantees the full
+    // iCloud original is materialized when networkAccessAllowed=YES. Fall
+    // back to the PHAssetResource walker if PHImageManager cannot deliver —
+    // that path still covers cases like adjustment-base / RAW alternate
+    // resources that PHImageManager doesn't expose.
+    //
+    // For non-raster / RAW primaries we walk resources first: PHImageManager
+    // would return a JPEG rendition instead of the underlying RAW/DNG bytes.
+    void (^runWalker)(NSObject *seedError) = ^(NSObject *seedError) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
-        // Every candidate resource failed. Fall back to PHImageManager's
-        // requestImageDataAndOrientation pipeline, which is a separate iCloud
-        // materialization path and preserves the original HEIC/RAW bytes.
-        [strongSelf fallbackFetchImageDataFor:asset
-                                     isOrigin:YES
-                              progressHandler:progressHandler
-                                        block:^(NSString *fbPath, NSObject *fbError) {
-            if (fbPath) {
-                [handler reply:fbPath];
+        [strongSelf fetchImageFileFromCandidates:candidates
+                                         atIndex:0
+                                       attempted:[NSMutableArray arrayWithCapacity:candidates.count]
+                                       lastError:seedError
+                                           asset:asset
+                                 progressHandler:progressHandler
+                                           block:^(NSString *walkerPath, NSObject *walkerError) {
+            if (walkerPath) {
+                [handler reply:walkerPath];
                 return;
             }
-            [strongSelf notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
-            [handler replyError:walkerError ?: fbError];
+            __strong typeof(weakSelf) inner = weakSelf;
+            if (!inner) { return; }
+            if (seedError) {
+                // PHImageManager already ran and failed — walker was the
+                // fallback. Nothing else to try.
+                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+                [handler replyError:walkerError ?: seedError];
+                return;
+            }
+            // Walker ran as the primary path (RAW / exotic UTI) and every
+            // candidate failed. Fall back to PHImageManager for one more
+            // attempt — matches historical behaviour for non-raster assets.
+            [inner fallbackFetchImageDataFor:asset
+                                    isOrigin:YES
+                             progressHandler:progressHandler
+                                       block:^(NSString *fbPath, NSObject *fbError) {
+                if (fbPath) {
+                    [handler reply:fbPath];
+                    return;
+                }
+                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+                [handler replyError:walkerError ?: fbError];
+            }];
         }];
+    };
+
+    if (![self canFetchOriginViaImageManager:candidates.firstObject]) {
+        runWalker(nil);
+        return;
+    }
+    [self fallbackFetchImageDataFor:asset
+                            isOrigin:YES
+                     progressHandler:progressHandler
+                               block:^(NSString *primaryPath, NSObject *primaryError) {
+        if (primaryPath) {
+            [handler reply:primaryPath];
+            return;
+        }
+        runWalker(primaryError);
     }];
 }
 
@@ -1542,10 +1603,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }];
 }
 
-// Fallback image fetch used when `writeDataForAssetResource` fails across
-// every candidate resource. Uses PHImageManager's data pipeline, which is a
-// separate iCloud-materialization path and returns the raw image bytes so we
-// can write them verbatim without a JPEG recompression.
+// Fetches image bytes via PHImageManager's data pipeline. Used as the
+// primary path for `fetchOriginImageFile` (so we can request
+// HighQualityFormat delivery, which PHAssetResourceRequestOptions does not
+// expose — see #1118), and as the last-resort path for other flows that
+// walk PHAssetResource candidates via `writeDataForAssetResource`. Writes
+// the raw image bytes verbatim, so there is no JPEG recompression.
 - (void)fallbackFetchImageDataFor:(PHAsset *)asset
                          isOrigin:(BOOL)isOrigin
                   progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
@@ -1580,6 +1643,15 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     void (^dataHandler)(NSData *_Nullable, NSDictionary *_Nullable) = ^(NSData *_Nullable imageData, NSDictionary *_Nullable info) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
         if (!strongSelf) { return; }
+        // With deliveryMode=HighQualityFormat + synchronous=NO, PhotoKit is
+        // documented to deliver a single non-degraded callback, but historical
+        // reports (and the equivalent guard elsewhere in this file) show that
+        // a degraded interim result can slip through on some iOS versions.
+        // Ignore it and wait for the definitive callback — writing degraded
+        // bytes to disk would reproduce the very symptom of #1118.
+        if ([info[PHImageResultIsDegradedKey] boolValue]) {
+            return;
+        }
         NSObject *error = info[PHImageErrorKey];
         if (error) {
             block(nil, error);

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1479,26 +1479,17 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             }
             __strong typeof(weakSelf) inner = weakSelf;
             if (!inner) { return; }
-            void (^tryOfflineProxy)(NSObject *finalError) = ^(NSObject *finalError) {
-                // Every network-touching path has failed. Try one last request
-                // with networkAccessAllowed=NO to surface the local proxy
-                // Photos keeps under Optimize Storage — better a small image
-                // than an opaque -1009.
-                [inner fetchOfflineImageProxyFor:asset
-                                progressHandler:progressHandler
-                                          block:^(NSString *proxyPath, NSObject *proxyError) {
-                    if (proxyPath) {
-                        [handler reply:proxyPath];
-                        return;
-                    }
-                    [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
-                    [handler replyError:finalError ?: proxyError];
-                }];
-            };
             if (seedError) {
                 // PHImageManager already ran and failed — walker was the
-                // fallback. Try offline proxy as last resort.
-                tryOfflineProxy(walkerError ?: seedError);
+                // fallback. Both paths need network to materialise the iCloud
+                // original; if that's why they failed the caller can't get
+                // bytes offline (PhotoKit's data APIs refuse iCloud-only
+                // assets with PHPhotosErrorNetworkAccessRequired even with
+                // networkAccessAllowed=NO). Surface the underlying error so
+                // callers can distinguish "network needed" from other
+                // failures and route to the thumbnail API if appropriate.
+                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+                [handler replyError:walkerError ?: seedError];
                 return;
             }
             // Walker ran as the primary path (RAW / exotic UTI) and every
@@ -1512,7 +1503,8 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     [handler reply:fbPath];
                     return;
                 }
-                tryOfflineProxy(walkerError ?: fbError);
+                [inner notifyProgress:progressHandler progress:0 state:PMProgressStateFailed];
+                [handler replyError:walkerError ?: fbError];
             }];
         }];
     };
@@ -1722,125 +1714,6 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 (unsigned long)dataLength, path]];
             [innerSelf notifySuccess:progressHandler];
             block(path, nil);
-        });
-    };
-
-    dispatch_async(dispatch_get_main_queue(), ^{
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) { return; }
-        if (@available(iOS 13.0, macOS 10.15, *)) {
-            [strongSelf.cachingManager requestImageDataAndOrientationForAsset:asset
-                                                                     options:options
-                                                               resultHandler:^(NSData *_Nullable imageData,
-                                                                               NSString *_Nullable dataUTI,
-                                                                               CGImagePropertyOrientation orientation,
-                                                                               NSDictionary *_Nullable info) {
-                dataHandler(imageData, info);
-            }];
-        } else {
-#if TARGET_OS_IOS
-            [strongSelf.cachingManager requestImageDataForAsset:asset
-                                                        options:options
-                                                  resultHandler:^(NSData *_Nullable imageData,
-                                                                  NSString *_Nullable dataUTI,
-                                                                  UIImageOrientation orientation,
-                                                                  NSDictionary *_Nullable info) {
-                dataHandler(imageData, info);
-            }];
-#else
-            dataHandler(nil, @{PHImageErrorKey: [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
-                NSLocalizedDescriptionKey: @"requestImageDataForAsset unavailable on this platform version."
-            }]});
-#endif
-        }
-    });
-}
-
-// Tail fallback used when both the PHImageManager (HighQualityFormat +
-// networkAccessAllowed=YES) primary and the PHAssetResource walker have
-// failed — typically because the device is offline and the requested
-// resource is only present as an iCloud stub. Requests one more time with
-// deliveryMode=Opportunistic + networkAccessAllowed=NO and *accepts the
-// degraded result*, so the caller receives the local downsampled proxy
-// (the "small image" Photos.app itself falls back to offline) instead of
-// an opaque network error. The proxy is cached at a distinct
-// `proxy_`-prefixed filename so a subsequent online call still traverses
-// the primary path and materialises the iCloud original — no cross-mode
-// pollution.
-- (void)fetchOfflineImageProxyFor:(PHAsset *)asset
-                  progressHandler:(NSObject <PMProgressHandlerProtocol> *)progressHandler
-                            block:(void (^)(NSString *path, NSObject *error))block {
-    NSFileManager *manager = NSFileManager.defaultManager;
-    NSString *base = [self makeAssetOutputPath:asset resource:nil isOrigin:YES fileType:nil manager:manager];
-    NSString *dir = [base stringByDeletingLastPathComponent];
-    NSString *proxyPath = [dir stringByAppendingPathComponent:
-                           [@"proxy_" stringByAppendingString:[base lastPathComponent]]];
-    if ([manager fileExistsAtPath:proxyPath]) {
-        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
-            @"[#1118] local proxy cache hit → %@", proxyPath]];
-        [self notifySuccess:progressHandler];
-        block(proxyPath, nil);
-        return;
-    }
-
-    PHImageRequestOptions *options = [PHImageRequestOptions new];
-    [options setDeliveryMode:PHImageRequestOptionsDeliveryModeOpportunistic];
-    [options setNetworkAccessAllowed:NO];
-    [options setSynchronous:NO];
-    [options setVersion:PHImageRequestOptionsVersionCurrent];
-
-    __weak typeof(self) weakSelf = self;
-    // Opportunistic mode can fire the result handler more than once in
-    // principle. With networkAccessAllowed=NO a second callback is unlikely
-    // (no iCloud round trip is scheduled), but guard against double-reply
-    // regardless — the wrapping PMResultHandler treats a second reply as a
-    // programmer error.
-    __block BOOL replied = NO;
-    void (^dataHandler)(NSData *_Nullable, NSDictionary *_Nullable) = ^(NSData *_Nullable imageData, NSDictionary *_Nullable info) {
-        __strong typeof(weakSelf) strongSelf = weakSelf;
-        if (!strongSelf) { return; }
-        if (replied) { return; }
-        if ([info[PHImageCancelledKey] boolValue]) {
-            replied = YES;
-            [[PMLogUtils sharedInstance] info:@"[#1118] local-proxy PHImageManager cancelled"];
-            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-2 userInfo:@{
-                NSLocalizedDescriptionKey: @"PHImageManager request was cancelled."
-            }]);
-            return;
-        }
-        NSObject *error = info[PHImageErrorKey];
-        if (error) {
-            replied = YES;
-            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
-                @"[#1118] local-proxy PHImageManager error: %@", error]];
-            block(nil, error);
-            return;
-        }
-        if (!imageData) {
-            replied = YES;
-            [[PMLogUtils sharedInstance] info:@"[#1118] local-proxy no data available"];
-            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-1 userInfo:@{
-                NSLocalizedDescriptionKey: @"No local proxy available for asset."
-            }]);
-            return;
-        }
-        replied = YES;
-        NSUInteger dataLength = imageData.length;
-        BOOL degraded = [info[PHImageResultIsDegradedKey] boolValue];
-        dispatch_async(strongSelf->_imageFileProcessingQueue, ^{
-            __strong typeof(weakSelf) innerSelf = weakSelf;
-            if (!innerSelf) { return; }
-            NSError *writeError;
-            [imageData writeToFile:proxyPath options:NSDataWritingAtomic error:&writeError];
-            if (writeError) {
-                block(nil, writeError);
-                return;
-            }
-            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
-                @"[#1118] local proxy delivered %lu bytes%@ → %@",
-                (unsigned long)dataLength, degraded ? @" (degraded)" : @"", proxyPath]];
-            [innerSelf notifySuccess:progressHandler];
-            block(proxyPath, nil);
         });
     };
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1652,6 +1652,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         if ([info[PHImageResultIsDegradedKey] boolValue]) {
             return;
         }
+        if ([info[PHImageCancelledKey] boolValue]) {
+            block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-2 userInfo:@{
+                NSLocalizedDescriptionKey: @"PHImageManager request was cancelled."
+            }]);
+            return;
+        }
         NSObject *error = info[PHImageErrorKey];
         if (error) {
             block(nil, error);
@@ -1663,14 +1669,23 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             }]);
             return;
         }
-        NSError *writeError;
-        [imageData writeToFile:path options:NSDataWritingAtomic error:&writeError];
-        if (writeError) {
-            block(nil, writeError);
-            return;
-        }
-        [strongSelf notifySuccess:progressHandler];
-        block(path, nil);
+        // Move disk I/O off the main thread — PhotoKit invokes the
+        // resultHandler on the queue we dispatched from (main), and large
+        // originals (multi-MB HEIC/JPEG) can otherwise stall UI for tens of
+        // milliseconds while writing. Matches the pattern used by
+        // `fetchFullSizeImageFile:` below.
+        dispatch_async(strongSelf->_imageFileProcessingQueue, ^{
+            __strong typeof(weakSelf) innerSelf = weakSelf;
+            if (!innerSelf) { return; }
+            NSError *writeError;
+            [imageData writeToFile:path options:NSDataWritingAtomic error:&writeError];
+            if (writeError) {
+                block(nil, writeError);
+                return;
+            }
+            [innerSelf notifySuccess:progressHandler];
+            block(path, nil);
+        });
     };
 
     dispatch_async(dispatch_get_main_queue(), ^{

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1442,6 +1442,13 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         return;
     }
     [self notifyProgress:progressHandler progress:0 state:PMProgressStatePrepare];
+    PHAssetResource *primary = candidates.firstObject;
+    BOOL viaImageManager = [self canFetchOriginViaImageManager:primary];
+    [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+        @"[#1118] fetchOriginImageFile id=%@ primary.type=%d uti=%@ → %@",
+        asset.localIdentifier, (int)primary.type,
+        primary.uniformTypeIdentifier ?: @"(nil)",
+        viaImageManager ? @"PHImageManager first" : @"walker first"]];
     __weak typeof(self) weakSelf = self;
     // Prefer PHImageManager.requestImageDataAndOrientation with
     // deliveryMode=HighQualityFormat first: PHAssetResourceRequestOptions has
@@ -1496,7 +1503,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         }];
     };
 
-    if (![self canFetchOriginViaImageManager:candidates.firstObject]) {
+    if (!viaImageManager) {
         runWalker(nil);
         return;
     }
@@ -1597,6 +1604,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             // Walker retries with the next candidate; don't emit Failed here.
             block(nil, error);
         } else {
+            long long size = [(NSNumber *)[[NSFileManager.defaultManager attributesOfItemAtPath:path error:nil]
+                              objectForKey:NSFileSize] longLongValue];
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] writeDataForAssetResource delivered %lld bytes (uti=%@ type=%d) → %@",
+                size, imageResource.uniformTypeIdentifier ?: @"(nil)",
+                (int)imageResource.type, path]];
             [strongSelf notifySuccess:progressHandler];
             block(path, nil);
         }
@@ -1650,9 +1663,13 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         // Ignore it and wait for the definitive callback — writing degraded
         // bytes to disk would reproduce the very symptom of #1118.
         if ([info[PHImageResultIsDegradedKey] boolValue]) {
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] PHImageManager degraded intermediate dropped, data=%lu",
+                (unsigned long)imageData.length]];
             return;
         }
         if ([info[PHImageCancelledKey] boolValue]) {
+            [[PMLogUtils sharedInstance] info:@"[#1118] PHImageManager cancelled"];
             block(nil, [NSError errorWithDomain:@"PMPhotoManager" code:-2 userInfo:@{
                 NSLocalizedDescriptionKey: @"PHImageManager request was cancelled."
             }]);
@@ -1674,6 +1691,7 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         // originals (multi-MB HEIC/JPEG) can otherwise stall UI for tens of
         // milliseconds while writing. Matches the pattern used by
         // `fetchFullSizeImageFile:` below.
+        NSUInteger dataLength = imageData.length;
         dispatch_async(strongSelf->_imageFileProcessingQueue, ^{
             __strong typeof(weakSelf) innerSelf = weakSelf;
             if (!innerSelf) { return; }
@@ -1683,6 +1701,9 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 block(nil, writeError);
                 return;
             }
+            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+                @"[#1118] PHImageManager delivered %lu bytes → %@",
+                (unsigned long)dataLength, path]];
             [innerSelf notifySuccess:progressHandler];
             block(path, nil);
         });

--- a/example/lib/page/developer/issues_page/issue_1118.dart
+++ b/example/lib/page/developer/issues_page/issue_1118.dart
@@ -10,6 +10,7 @@
 // native side — grep those in the Xcode Console for the routing decision.
 
 import 'dart:io';
+import 'dart:ui' as ui;
 
 import 'package:flutter/material.dart';
 import 'package:oktoast/oktoast.dart';
@@ -118,6 +119,8 @@ class _Issue1118PageState extends State<Issue1118Page>
     setState(() => _busy = true);
     try {
       addLog('DIAG ${c.asset.id} — expected=${_fmt(c.expectedSize)} '
+          '${c.asset.width}×${c.asset.height} '
+          'mime=${c.asset.mimeType ?? "?"} '
           'local=${c.locallyAvailable}');
       final sw = Stopwatch()..start();
       File? file;
@@ -136,13 +139,53 @@ class _Issue1118PageState extends State<Issue1118Page>
       }
       final actual = file.lengthSync();
       final ratio = c.expectedSize == 0 ? 0.0 : actual / c.expectedSize;
+      // Decode the returned file to check its actual pixel dimensions —
+      // the definitive answer to "did we get the full-resolution original".
+      // `PHAssetResource.fileSize` KVC has known quirks for some asset
+      // types (notably PNG screenshots, which report an inflated internal
+      // buffer size instead of the on-disk PNG byte count), so a low
+      // actual/expected ratio alone can produce false-positive PROXY
+      // verdicts. Comparing decoded dims to `asset.width × height` cuts
+      // through the ambiguity.
+      int? decodedW;
+      int? decodedH;
+      try {
+        final bytes = await file.readAsBytes();
+        final codec = await ui.instantiateImageCodec(bytes);
+        final frame = await codec.getNextFrame();
+        decodedW = frame.image.width;
+        decodedH = frame.image.height;
+        frame.image.dispose();
+        codec.dispose();
+      } catch (_) {
+        // ignore decode failure — verdict falls back to size-only
+      }
+      final dimsMatchAsset = decodedW == c.asset.width &&
+          decodedH == c.asset.height;
       String verdict;
-      if (c.expectedSize == 0) {
-        verdict = '? (fileSize unknown)';
+      if (dimsMatchAsset) {
+        // Decoded resolution equals asset resolution → this IS the full
+        // original regardless of what fileSize claims.
+        verdict = '✓ FULL ($decodedW×$decodedH matches asset)';
+      } else if (c.expectedSize == 0) {
+        verdict = '? (fileSize unknown, decoded=$decodedW×$decodedH)';
       } else if (ratio >= 0.99) {
         verdict = '✓ FULL';
       } else if (ratio < 0.5) {
-        verdict = '✗ PROXY(#1118!)';
+        if (decodedW != null && decodedH != null) {
+          final decodedPx = decodedW * decodedH;
+          final assetPx = c.asset.width * c.asset.height;
+          if (assetPx > 0 && decodedPx / assetPx >= 0.99) {
+            verdict = '✓ FULL (fileSize KVC unreliable; '
+                'decoded=$decodedW×$decodedH)';
+          } else {
+            verdict = '✗ PROXY(#1118!) '
+                'decoded=$decodedW×$decodedH vs '
+                '${c.asset.width}×${c.asset.height}';
+          }
+        } else {
+          verdict = '✗ PROXY(#1118!) (decode failed)';
+        }
       } else {
         verdict = '~ MISMATCH (ratio=${ratio.toStringAsFixed(2)})';
       }

--- a/example/lib/page/developer/issues_page/issue_1118.dart
+++ b/example/lib/page/developer/issues_page/issue_1118.dart
@@ -1,0 +1,271 @@
+// #1118 diagnostic — measure whether `originFile` returns full-quality
+// bytes for iCloud + "Optimize iPhone Storage" affected assets.
+//
+// Compares `AssetEntity.originFile.lengthSync()` against
+// `AssetEntity.fileSize` (which surfaces `PHAssetResource.fileSize`, i.e.
+// the byte size of the resource as stored in iCloud). If the returned
+// file is significantly smaller than the resource's full size, we're
+// still receiving the locally-downsampled proxy and the fix has not
+// worked for that asset. Companion to the `[#1118]` logs emitted by the
+// native side — grep those in the Xcode Console for the routing decision.
+
+import 'dart:io';
+
+import 'package:flutter/material.dart';
+import 'package:oktoast/oktoast.dart';
+import 'package:photo_manager/photo_manager.dart';
+
+import 'issue_index_page.dart';
+
+class Issue1118Page extends StatefulWidget {
+  const Issue1118Page({super.key});
+
+  @override
+  State<Issue1118Page> createState() => _Issue1118PageState();
+}
+
+class _Issue1118PageState extends State<Issue1118Page>
+    with IssueBase<Issue1118Page> {
+  @override
+  int get issueNumber => 1118;
+
+  @override
+  List<TargetPlatform>? get supportPlatforms => const [
+        TargetPlatform.iOS,
+        TargetPlatform.macOS,
+      ];
+
+  static const int _scanLimit = 200;
+
+  List<_Candidate> _candidates = [];
+  bool _busy = false;
+
+  Future<void> _scanCandidates() async {
+    if (_busy) {
+      return;
+    }
+    setState(() => _busy = true);
+    try {
+      final ps = await PhotoManager.requestPermissionExtend();
+      if (!ps.hasAccess) {
+        addLog('permission denied');
+        return;
+      }
+      final paths = await PhotoManager.getAssetPathList(
+        onlyAll: true,
+        type: RequestType.image,
+        filterOption: FilterOptionGroup(
+          imageOption: const FilterOption(
+            sizeConstraint: SizeConstraint(ignoreSize: true),
+          ),
+        )..addOrderOption(
+            const OrderOption(type: OrderOptionType.createDate, asc: false),
+          ),
+      );
+      if (paths.isEmpty) {
+        addLog('no album found');
+        return;
+      }
+      final album = paths.first;
+      final total = await album.assetCountAsync;
+      addLog('album=${album.name} total=$total, scanning latest $_scanLimit');
+      final assets = await album.getAssetListRange(
+        start: 0,
+        end: total < _scanLimit ? total : _scanLimit,
+      );
+      final results = <_Candidate>[];
+      for (var i = 0; i < assets.length; i++) {
+        final a = assets[i];
+        if (a.type != AssetType.image) {
+          continue;
+        }
+        final size = await a.fileSize;
+        final local = await a.isLocallyAvailable(isOrigin: true);
+        results.add(_Candidate(a, size, local));
+      }
+      results.sort((x, y) => y.expectedSize.compareTo(x.expectedSize));
+      setState(() => _candidates = results);
+      final iCloudOnly = results.where((c) => !c.locallyAvailable).length;
+      final localOnly = results.length - iCloudOnly;
+      addLog(
+        'scanned ${results.length} images '
+        '— iCloud-only=$iCloudOnly local=$localOnly '
+        '(sorted by expected size desc)',
+      );
+    } catch (e, s) {
+      addLog('scan failed: $e\n$s');
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  Future<void> _diagOne(_Candidate c) async {
+    if (_busy) {
+      return;
+    }
+    setState(() => _busy = true);
+    try {
+      addLog('DIAG ${c.asset.id} — expected=${_fmt(c.expectedSize)} '
+          'local=${c.locallyAvailable}');
+      final sw = Stopwatch()..start();
+      File? file;
+      Object? err;
+      try {
+        file = await c.asset.originFile;
+      } catch (e) {
+        err = e;
+      }
+      sw.stop();
+      if (err != null || file == null) {
+        addLog(
+          '  → FAILED in ${sw.elapsedMilliseconds}ms: ${err ?? "null file"}',
+        );
+        return;
+      }
+      final actual = file.lengthSync();
+      final ratio = c.expectedSize == 0 ? 0.0 : actual / c.expectedSize;
+      String verdict;
+      if (c.expectedSize == 0) {
+        verdict = '? (fileSize unknown)';
+      } else if (ratio >= 0.99) {
+        verdict = '✓ FULL';
+      } else if (ratio < 0.5) {
+        verdict = '✗ PROXY(#1118!)';
+      } else {
+        verdict = '~ MISMATCH (ratio=${ratio.toStringAsFixed(2)})';
+      }
+      addLog(
+        '  → actual=${_fmt(actual)} in ${sw.elapsedMilliseconds}ms $verdict',
+      );
+    } finally {
+      if (mounted) {
+        setState(() => _busy = false);
+      }
+    }
+  }
+
+  Future<void> _diagBatch({bool iCloudOnly = false}) async {
+    if (_busy) {
+      return;
+    }
+    final targets = iCloudOnly
+        ? _candidates.where((c) => !c.locallyAvailable).toList()
+        : _candidates;
+    if (targets.isEmpty) {
+      showToast(iCloudOnly ? 'no iCloud-only candidates' : 'scan first');
+      return;
+    }
+    addLog('--- batch diag over ${targets.length} candidates ---');
+    for (final c in targets.take(10)) {
+      await _diagOne(c);
+    }
+    addLog('--- batch diag done ---');
+  }
+
+  Future<void> _clearCache() async {
+    await PhotoManager.clearFileCache();
+    addLog('file cache cleared');
+  }
+
+  static String _fmt(int bytes) {
+    if (bytes >= 1 << 20) {
+      return '${(bytes / (1 << 20)).toStringAsFixed(2)}MB';
+    }
+    if (bytes >= 1 << 10) {
+      return '${(bytes / (1 << 10)).toStringAsFixed(1)}KB';
+    }
+    return '${bytes}B';
+  }
+
+  Widget _buildCandidateList() {
+    if (_candidates.isEmpty) {
+      return const Padding(
+        padding: EdgeInsets.symmetric(vertical: 24),
+        child: Text('Tap "Scan candidates" to list assets.'),
+      );
+    }
+    return Expanded(
+      child: ListView.separated(
+        itemCount: _candidates.length,
+        separatorBuilder: (_, __) => const Divider(height: 1),
+        itemBuilder: (_, i) {
+          final c = _candidates[i];
+          return ListTile(
+            dense: true,
+            title: Text(
+              '${c.asset.id.split('/').first}  '
+              '${c.asset.width}×${c.asset.height}',
+              style: const TextStyle(fontFamily: 'monospace', fontSize: 12),
+            ),
+            subtitle: Text(
+              'expected=${_fmt(c.expectedSize)}  '
+              'local=${c.locallyAvailable ? "yes" : "NO (iCloud-only)"}  '
+              'type=${c.asset.mimeType ?? "?"}',
+              style: const TextStyle(fontSize: 11),
+            ),
+            trailing: IconButton(
+              icon: const Icon(Icons.play_arrow, size: 20),
+              tooltip: 'Diag this asset',
+              onPressed: _busy ? null : () => _diagOne(c),
+            ),
+          );
+        },
+      ),
+    );
+  }
+
+  @override
+  Widget build(BuildContext context) {
+    return Scaffold(
+      appBar: buildAppBar(),
+      body: Padding(
+        padding: const EdgeInsets.all(8),
+        child: Column(
+          crossAxisAlignment: CrossAxisAlignment.stretch,
+          children: [
+            const Text(
+              'On-device diagnostic for #1118.\n'
+              '1. Scan candidates (reads fileSize + isLocallyAvailable).\n'
+              '2. Pick an iCloud-only asset (large expected size) '
+              'and tap ▶ or "Diag batch".\n'
+              '3. Compare actual vs expected in the log below.\n'
+              '4. Xcode Console → grep [#1118] for the native routing '
+              'decision + delivered byte count.',
+              style: TextStyle(fontSize: 12),
+            ),
+            const SizedBox(height: 8),
+            Wrap(
+              spacing: 8,
+              children: [
+                buildButton('Scan candidates', _scanCandidates),
+                buildButton(
+                  'Diag batch (all top-10)',
+                  () => _diagBatch(),
+                ),
+                buildButton(
+                  'Diag batch (iCloud-only top-10)',
+                  () => _diagBatch(iCloudOnly: true),
+                ),
+                buildButton('Clear file cache', _clearCache),
+              ],
+            ),
+            const SizedBox(height: 8),
+            _buildCandidateList(),
+            const Divider(),
+            buildLogWidget(),
+          ],
+        ),
+      ),
+    );
+  }
+}
+
+class _Candidate {
+  _Candidate(this.asset, this.expectedSize, this.locallyAvailable);
+
+  final AssetEntity asset;
+  final int expectedSize;
+  final bool locallyAvailable;
+}

--- a/example/lib/page/developer/issues_page/issue_1118.dart
+++ b/example/lib/page/developer/issues_page/issue_1118.dart
@@ -160,8 +160,8 @@ class _Issue1118PageState extends State<Issue1118Page>
       } catch (_) {
         // ignore decode failure — verdict falls back to size-only
       }
-      final dimsMatchAsset = decodedW == c.asset.width &&
-          decodedH == c.asset.height;
+      final dimsMatchAsset =
+          decodedW == c.asset.width && decodedH == c.asset.height;
       String verdict;
       if (dimsMatchAsset) {
         // Decoded resolution equals asset resolution → this IS the full

--- a/example/lib/page/developer/issues_page/issue_1118.dart
+++ b/example/lib/page/developer/issues_page/issue_1118.dart
@@ -40,6 +40,16 @@ class _Issue1118PageState extends State<Issue1118Page>
   List<_Candidate> _candidates = [];
   bool _busy = false;
 
+  @override
+  void initState() {
+    super.initState();
+    // Native `[#1118]` diagnostic logs go through `PMLogUtils`, which is
+    // gated by an off-by-default `isLog` flag. Flip it on for this page so
+    // the routing decision + delivered byte count show up in Xcode Console
+    // without the tester having to remember `PhotoManager.setLog(true)`.
+    PhotoManager.setLog(true);
+  }
+
   Future<void> _scanCandidates() async {
     if (_busy) {
       return;

--- a/example/lib/page/developer/issues_page/issue_index_page.dart
+++ b/example/lib/page/developer/issues_page/issue_index_page.dart
@@ -11,6 +11,7 @@ import 'issue_1025.dart';
 import 'issue_1031.dart';
 import 'issue_1051.dart';
 import 'issue_1053.dart';
+import 'issue_1118.dart';
 import 'issue_1152.dart';
 import 'issue_1271_demo.dart';
 import 'issue_734.dart';
@@ -76,6 +77,7 @@ class IssuePage extends StatelessWidget {
             Issus1051(),
             Issus1053(),
             Issus1152(),
+            Issue1118Page(),
             Issue1271DemoPage(),
           ],
         ),
@@ -117,8 +119,9 @@ mixin IssueBase<T extends StatefulWidget> on State<T> {
     }
   }
 
-  Widget buildLogWidget({bool expaned = true}) {
+  Widget buildLogWidget({bool expanded = true}) {
     final w = ListView.separated(
+      shrinkWrap: !expanded,
       itemBuilder: (_, index) {
         final log = _logs[index];
         return Text(log);
@@ -127,7 +130,7 @@ mixin IssueBase<T extends StatefulWidget> on State<T> {
       separatorBuilder: (_, __) => const Divider(),
     );
 
-    if (expaned) {
+    if (expanded) {
       return Expanded(child: w);
     } else {
       return w;


### PR DESCRIPTION
## Summary

- `AssetEntity.originFile` on iOS/macOS surfaces a low-quality version of the requested photo for users with iCloud Photos + "Optimize iPhone Storage" both enabled (#1118). The walker in `fetchOriginImageFile:` uses `PHAssetResourceManager writeDataForAssetResource:` with `networkAccessAllowed = YES`, but `PHAssetResourceRequestOptions` has no `deliveryMode` counterpart to `PHImageRequestOptions`. When PhotoKit has locally swapped the original for a downsampled proxy to free device storage, the resource-manager path can hand that proxy back as a "successful" write instead of materializing the full iCloud original. The fallback that uses `PHImageManager requestImageDataAndOrientationForAsset:` (added in #1414) supports `PHImageRequestOptionsDeliveryModeHighQualityFormat`, which is documented to deliver the highest-quality version — but the fallback only ran when every `writeDataForAssetResource` candidate hard-failed, so the low-quality proxy path succeeded first and the fallback never got the chance to fix it.

- Reorder `fetchOriginImageFile:` so PHImageManager runs as the **primary** path when the primary `PHAssetResource` is `PHAssetResourceTypePhoto` (unedited image) and its `uniformTypeIdentifier` is a common raster format (`public.jpeg` / `heic` / `heif` / `heic-sequence` / `heif-sequence` / `png`). Falls back to the existing `PHAssetResource` walker on any PHImageManager failure. RAW/DNG/exotic UTIs continue to walk resources first (PHImageManager would return a JPEG rendition instead of the underlying RAW bytes), with PHImageManager as the tail fallback — preserves prior behavior for those.

- Edited assets are deliberately excluded from the reorder: the walker's first candidate for an edited image is the rendered `PHAssetResourceTypeFullSizePhoto`, and `writeDataForAssetResource` returns those exact bytes. PHImageManager with `VersionCurrent` may re-encode HEIC → JPEG for edited assets, which would silently change the returned format and cache filename extension. Gating on `candidates.firstObject.type == PHAssetResourceTypePhoto` keeps the edit path on the walker.

- `fallbackFetchImageDataFor:`'s `dataHandler` also now filters `PHImageResultIsDegradedKey`. With `deliveryMode=HighQualityFormat + synchronous=NO` PhotoKit is documented to deliver a single non-degraded callback, but the same guard is already applied at other `PHImageManager` result sites in this file and skipping it here would let a degraded interim result be written to disk and replied as the origin file, reproducing the exact symptom of #1118. Wait for the definitive callback instead.

- Cache-key change is a no-op for existing users: `cachedPathForAsset:...:includeFallbackPath:YES` already scans both the resource-derived paths (walker path) AND the `resource:nil` fallback path (PHImageManager path). Old cached files from the walker are still found on subsequent calls; new cache writes on raster unedited assets go to the fallback path.

## Copilot review

- Moved the `writeToFile:` in `fallbackFetchImageDataFor:` off the main queue onto `_imageFileProcessingQueue` (PhotoKit dispatches the resultHandler on the queue we dispatched from — main — and writing multi-MB HEIC/JPEG synchronously on main would stall UI now that this path is primary). Mirrors the pattern `fetchFullSizeImageFile:` already uses.
- `PHImageCancelledKey` now surfaces as a distinct error (`PMPhotoManager` code -2, "PHImageManager request was cancelled.") instead of the misleading "no image data returned" catch-all.

## Diagnostic logs

Native side emits `[#1118]`-prefixed `PMLogUtils` info lines so on-device runs can be diagnosed without stepping through the code:

- `[#1118] fetchOriginImageFile id=... primary.type=1 uti=public.jpeg → PHImageManager first | walker first` — one line per call, records the routing decision and the primary resource UTI.
- `[#1118] PHImageManager delivered <N> bytes → <path>` on the PHImageManager success branch (with `... degraded intermediate dropped` and `... error: ...` variants for the other outcomes).
- `[#1118] writeDataForAssetResource delivered <N> bytes (uti=... type=...) → <path>` on the walker success branch.

`grep [#1118]` on Xcode Console yields the full decision → delivery trail for every `originFile` call. Enable with `PhotoManager.setLog(true)` (or use the new diagnostic page below, which flips it on automatically).

## Tail-fallback dead end (removed)

A first attempt added a tier-3 fallback that re-issued PHImageManager with `deliveryMode=Opportunistic + networkAccessAllowed=NO` when both the primary and walker had failed, on the assumption that this would surface the local proxy the way Photos.app does offline. On-device testing revealed PhotoKit's data-returning APIs (both `requestImageDataAndOrientation` and `writeDataForAssetResource`) uniformly refuse iCloud-only assets offline with `PHPhotosErrorNetworkAccessRequired (3164)`, regardless of `networkAccessAllowed`. Only the UIImage-returning `requestImageForAsset:targetSize:...` path serves offline bitmaps, but that's a different resource class (bounded-size, JPEG-recompressed) and doesn't fit `originFile`'s "return the actual original bytes" contract. Reverted; callers who want a graceful offline fallback should catch the network error from `originFile` and fall back to `thumbnailDataWithSize` themselves, which is the right API for offline bitmaps.

## Not addressed

The plain-video variant of the same bug (`fetchOriginVideoFile:` — `writeDataForAssetResource` on `PHAssetResourceTypeVideo` under Optimize Storage). The video fallback via `PHVideoRequestOptionsDeliveryModeHighQualityFormat` already exists but is reached only on hard failure, same shape as the image path was before this PR. Left for a follow-up; #1118 is specifically about photos.

## Diagnostic page

`example/lib/page/developer/issues_page/issue_1118.dart` — an on-device diagnostic for reporters to run against their own iCloud + Optimize Storage account. Scans the latest 200 images from the primary album, reads `AssetEntity.fileSize` (surfaces `PHAssetResource.fileSize` KVC) and `AssetEntity.isLocallyAvailable(isOrigin: true)`, and provides one-tap "Diag" buttons that call `originFile` and cross-check the returned file. The verdict is definitive on decoded pixel dims:

- Decoded dims of the returned file == `asset.width × height` → ✓ FULL, regardless of byte ratio (`PHAssetResource.fileSize` KVC is unreliable for PNG screenshots — reports an inflated internal buffer size instead of the actual PNG byte count, which used to false-positive as PROXY).
- Decoded dims are a fraction of asset dims → ✗ PROXY(#1118!) with the downscale factor printed.
- Byte ratio ≥ 0.99 → ✓ FULL. Byte ratio < 0.5 + no decode → ✗ PROXY(#1118!).

Guarded to iOS/macOS via `supportPlatforms`, filtered out of the Android issue list automatically. Auto-enables `PhotoManager.setLog(true)` in `initState` so the `[#1118]` native logs stream to Xcode Console alongside the Dart-side output.

Fixes #1118.

## Verified

- `flutter build macos --debug` clean on a fresh checkout against the example app (remaining warnings are pre-existing nullability/xcprivacy notices unrelated to this change).
- Adversarial review via a spawned subagent — flagged the edited-asset HEIC→JPEG transcode risk (addressed via `candidates.firstObject.type == PHAssetResourceTypePhoto` gate) and the missing `PHImageResultIsDegradedKey` guard (addressed in the primary `dataHandler`).
- On-device diagnostic runs (iOS, iCloud Photos + Optimize Storage account, `Diag batch (iCloud-only top-10)` + `Diag batch (all top-10)`):
  - `[#1118] fetchOriginImageFile → PHImageManager first` fires for unedited raster candidates and `→ walker first` fires for the RAW/edited / non-raster ones — routing matches the intended gate.
  - Every iCloud-only candidate delivered via the PHImageManager path returned bytes whose decoded pixel dimensions match `asset.width × height` = full-resolution original. No delivery smaller than the asset dimensions was observed after the decoded-dims cross-check landed.
  - Copilot's cancellation branch verified via the new `[#1118] PHImageManager cancelled` log; the main-thread move by observing that a `fetchOriginImageFile` on a multi-MB HEIC no longer keeps `writeToFile:` on the main stack.
- The specific `local=true + is-proxy` state (Optimize Storage has replaced the local file with a downsampled proxy but not fully removed it) could not be reliably reproduced on the tester's device — the diagnostic page ships in this PR so a reporter with a device in that state can attach the log excerpt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
