### PR TITLE
✨ Add Android MANAGE_MEDIA permission APIs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Add `updateCreationDate` to `PhotoManager.editor.darwin` and `PhotoManager.editor.android` for modifying an asset's creation date after it has been saved.
   - On iOS/macOS: updates the `PHAsset.creationDate` property.
   - On Android Q (API 29)+: updates the MediaStore `DATE_TAKEN` field; unsupported on API 28 and below.
+- Add `PhotoManager.canManageMedia()` and `PhotoManager.requestManageMedia()` to check and request the Android 12 (API 31+) `MANAGE_MEDIA` special permission. When granted, MediaStore delete/trash/favorite/write requests no longer prompt the user for confirmation on each call. Both methods return `false` on iOS/macOS/OpenHarmony and on Android below 12. Host apps must add `<uses-permission android:name="android.permission.MANAGE_MEDIA"/>` to opt in.
 
 **Improvements**
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,7 +19,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Add `updateCreationDate` to `PhotoManager.editor.darwin` and `PhotoManager.editor.android` for modifying an asset's creation date after it has been saved.
   - On iOS/macOS: updates the `PHAsset.creationDate` property.
   - On Android Q (API 29)+: updates the MediaStore `DATE_TAKEN` field; unsupported on API 28 and below.
-- Add `PhotoManager.canManageMedia()` and `PhotoManager.requestManageMedia()` to check and request the Android 12 (API 31+) `MANAGE_MEDIA` special permission. When granted, MediaStore delete/trash/favorite/write requests no longer prompt the user for confirmation on each call. Both methods return `false` on iOS/macOS/OpenHarmony and on Android below 12. Host apps must add `<uses-permission android:name="android.permission.MANAGE_MEDIA"/>` to opt in.
+- Add `PhotoManager.canManageMedia()` and `PhotoManager.requestManageMedia()` for the Android 12 (API 31+) `MANAGE_MEDIA` special permission.
 
 **Improvements**
 

--- a/README-ZH.md
+++ b/README-ZH.md
@@ -899,6 +899,36 @@ rootProject.allprojects {
 </manifest>
 ```
 
+#### Android 12 (API 31) `MANAGE_MEDIA` （可选）
+
+Android 12 引入了 [`MANAGE_MEDIA`][manage_media_docs] 这个特殊权限。授予该权限后，
+`PhotoManager.editor.deleteWithIds`、`moveToTrash`、收藏等操作不再触发系统的
+逐次确认弹窗，适合有批量操作诉求的相册 / 媒体管理类应用。
+
+如果需要启用，请在 `AndroidManifest.xml` 中声明：
+
+```xml
+<manifest>
+    <uses-permission android:name="android.permission.MANAGE_MEDIA" />
+</manifest>
+```
+
+用户还需要在 `设置 > 应用 > 特殊应用权限 > 媒体管理` 里手动为你的应用打开开关，
+系统不会弹出运行时弹窗。可以使用下列 API 检查状态并跳转到设置页：
+
+```dart
+if (!await PhotoManager.canManageMedia()) {
+  await PhotoManager.requestManageMedia();
+  // 用户从设置页返回后再次调用 canManageMedia() 检查是否已授予。
+}
+```
+
+两个方法在 iOS / macOS / OpenHarmony 及 Android 12 以下均返回 `false`。
+`READ_MEDIA_*` 和 `ACCESS_MEDIA_LOCATION` 仍然是前置依赖，
+`MANAGE_MEDIA` 只是移除了系统的确认弹窗。
+
+[manage_media_docs]: https://developer.android.com/reference/android/provider/MediaStore#canManageMedia(android.content.Context)
+
 ### iOS 额外配置
 
 #### 配置系统相册名称的国际化

--- a/README.md
+++ b/README.md
@@ -959,6 +959,40 @@ even if your `targetSdkVersion` and `compileSdkVersion` is not `33`:
 </manifest>
 ```
 
+#### Android 12 (API 31) `MANAGE_MEDIA` (optional)
+
+Android 12 introduced the [`MANAGE_MEDIA`][manage_media_docs] special
+permission. When granted, `PhotoManager.editor.deleteWithIds`,
+`moveToTrash`, and favorite operations no longer show the system
+confirmation dialog on each call, which is useful for gallery / media
+management apps that perform bulk operations.
+
+To opt in, declare the permission in your `AndroidManifest.xml`:
+
+```xml
+<manifest>
+    <uses-permission android:name="android.permission.MANAGE_MEDIA" />
+</manifest>
+```
+
+The user must additionally toggle the switch for your app in
+`Settings > Apps > Special app access > Media management`. There is no
+runtime dialog; use the APIs below to check the state and route the user
+to the settings page:
+
+```dart
+if (!await PhotoManager.canManageMedia()) {
+  await PhotoManager.requestManageMedia();
+  // Re-check canManageMedia() after the user returns from Settings.
+}
+```
+
+Both methods return `false` on iOS/macOS/OpenHarmony and on Android
+versions below 12. `READ_MEDIA_*` and `ACCESS_MEDIA_LOCATION` remain
+prerequisites — `MANAGE_MEDIA` only suppresses the confirmation dialog.
+
+[manage_media_docs]: https://developer.android.com/reference/android/provider/MediaStore#canManageMedia(android.content.Context)
+
 ### iOS extra configs
 
 #### Localized system albums name

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -12,6 +12,8 @@ class Methods {
         const val releaseMemoryCache = "releaseMemoryCache"
         const val ignorePermissionCheck = "ignorePermissionCheck"
         const val getPermissionState = "getPermissionState"
+        const val canManageMedia = "canManageMedia"
+        const val requestManageMedia = "requestManageMedia"
 
         fun isNotNeedPermissionMethod(method: String): Boolean {
             return method in arrayOf(
@@ -23,6 +25,8 @@ class Methods {
                 releaseMemoryCache,
                 ignorePermissionCheck,
                 getPermissionState,
+                canManageMedia,
+                requestManageMedia,
             )
         }
         // Not need permission methods end

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -348,6 +348,14 @@ class PhotoManagerPlugin(
                     resultHandler.reply(it.value)
                 }
             }
+
+            Methods.canManageMedia -> {
+                resultHandler.reply(permissionsUtils.canManageMedia(applicationContext))
+            }
+
+            Methods.requestManageMedia -> {
+                resultHandler.reply(permissionsUtils.requestManageMedia(applicationContext))
+            }
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/permission/PermissionsUtils.kt
@@ -6,6 +6,9 @@ import android.content.Context
 import android.content.Intent
 import android.content.pm.PackageManager
 import android.net.Uri
+import android.os.Build
+import android.provider.MediaStore
+import android.provider.Settings
 import androidx.core.content.PermissionChecker
 import androidx.core.content.PermissionChecker.PERMISSION_GRANTED
 import com.fluttercandies.photo_manager.core.entity.PermissionResult
@@ -196,6 +199,45 @@ class PermissionsUtils {
 
     fun presentLimited(type: Int, resultHandler: ResultHandler) {
         delegate.presentLimited(this, context!!, type, resultHandler)
+    }
+
+    /**
+     * Whether the app currently holds the special MANAGE_MEDIA permission.
+     *
+     * Available on Android 12 (API 31) and above; returns false on older
+     * versions. When granted, MediaStore create*Request intents (delete,
+     * trash, favorite, write) skip the system confirmation dialog.
+     */
+    fun canManageMedia(applicationContext: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return false
+        }
+        return MediaStore.canManageMedia(applicationContext)
+    }
+
+    /**
+     * Opens the system Settings page where the user can toggle the
+     * MANAGE_MEDIA permission for this app. No-op on Android below 12.
+     *
+     * Returns true if the intent was launched. Callers should re-check
+     * [canManageMedia] after the user returns from Settings.
+     */
+    fun requestManageMedia(applicationContext: Context): Boolean {
+        if (Build.VERSION.SDK_INT < Build.VERSION_CODES.S) {
+            return false
+        }
+        val intent = Intent(Settings.ACTION_REQUEST_MANAGE_MEDIA).apply {
+            data = Uri.fromParts("package", applicationContext.packageName, null)
+            addFlags(Intent.FLAG_ACTIVITY_NEW_TASK)
+        }
+        val target = mActivity ?: applicationContext
+        return try {
+            target.startActivity(intent)
+            true
+        } catch (e: Exception) {
+            LogUtils.error("Failed to launch ACTION_REQUEST_MANAGE_MEDIA", e)
+            false
+        }
     }
 
     fun getAuthValue(requestType: Int, mediaLocation: Boolean): PermissionResult {

--- a/example/android/app/src/main/AndroidManifest.xml
+++ b/example/android/app/src/main/AndroidManifest.xml
@@ -11,6 +11,7 @@
         android:name="android.permission.WRITE_EXTERNAL_STORAGE"
         android:maxSdkVersion="28"/>
     <uses-permission android:name="android.permission.ACCESS_MEDIA_LOCATION" />
+    <uses-permission android:name="android.permission.MANAGE_MEDIA" />
 
     <application
         android:label="photo_manager example"

--- a/example/lib/page/developer/permission_state_page.dart
+++ b/example/lib/page/developer/permission_state_page.dart
@@ -31,6 +31,8 @@ class _PermissionStatePageState extends State<PermissionStatePage> {
 
   IosAccessLevel _iosAccessLevel = IosAccessLevel.readWrite; // 添加这一行
 
+  bool? _canManageMedia;
+
   @override
   Widget build(BuildContext context) {
     return Scaffold(
@@ -87,6 +89,29 @@ class _PermissionStatePageState extends State<PermissionStatePage> {
           ),
           if (_permissionState != null)
             Text('Current Permission State: $_permissionState'),
+          if (Platform.isAndroid) ...[
+            const Divider(),
+            const Text(
+              'Android MANAGE_MEDIA (API 31+)',
+              style: TextStyle(fontWeight: FontWeight.bold),
+            ),
+            const Text(
+              'When granted, delete/trash/favorite/write requests skip the '
+              'system confirmation dialog. Requires the '
+              'android.permission.MANAGE_MEDIA manifest entry and a user '
+              'toggle in Settings > Special app access > Media management.',
+            ),
+            ElevatedButton(
+              onPressed: _checkCanManageMedia,
+              child: const Text('Check canManageMedia()'),
+            ),
+            ElevatedButton(
+              onPressed: _requestManageMedia,
+              child: const Text('Open MANAGE_MEDIA Settings'),
+            ),
+            if (_canManageMedia != null)
+              Text('canManageMedia: $_canManageMedia'),
+          ],
         ].paddingAll(16),
       ),
     );
@@ -117,5 +142,16 @@ class _PermissionStatePageState extends State<PermissionStatePage> {
     setState(() {
       _permissionState = state;
     });
+  }
+
+  Future<void> _checkCanManageMedia() async {
+    final bool result = await PhotoManager.canManageMedia();
+    setState(() {
+      _canManageMedia = result;
+    });
+  }
+
+  Future<void> _requestManageMedia() async {
+    await PhotoManager.requestManageMedia();
   }
 }

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -64,6 +64,8 @@ class PMConstants {
   static const String mMoveAssetsToPath = 'moveAssetsToPath';
   static const String mColumnNames = 'getColumnNames';
   static const String mUpdateCreationDate = 'updateCreationDate';
+  static const String mCanManageMedia = 'canManageMedia';
+  static const String mRequestManageMedia = 'requestManageMedia';
 
   /// Darwin (iOS/macOS) only methods.
   static const String mGetCloudIdentifiers = 'getCloudIdentifiers';

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -700,6 +700,26 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     }
   }
 
+  Future<bool> canManageMedia() async {
+    if (!Platform.isAndroid) {
+      return false;
+    }
+    final bool? result = await _channel.invokeMethod<bool>(
+      PMConstants.mCanManageMedia,
+    );
+    return result ?? false;
+  }
+
+  Future<bool> requestManageMedia() async {
+    if (!Platform.isAndroid) {
+      return false;
+    }
+    final bool? result = await _channel.invokeMethod<bool>(
+      PMConstants.mRequestManageMedia,
+    );
+    return result ?? false;
+  }
+
   Future<String?> getMimeTypeAsync(AssetEntity entity) async {
     if (Platform.isAndroid || PlatformUtils.isOhos) {
       return entity.mimeType;

--- a/lib/src/managers/photo_manager.dart
+++ b/lib/src/managers/photo_manager.dart
@@ -172,6 +172,38 @@ class PhotoManager {
   /// Open the system settings page of the current app.
   static Future<void> openSetting() => plugin.openSetting();
 
+  /// Whether the app currently holds the Android `MANAGE_MEDIA` special
+  /// permission (Android 12+ / API 31+).
+  ///
+  /// When granted, `deleteWithIds`, `moveToTrash`, `favoriteAsset`, and other
+  /// MediaStore mutation intents no longer show the system confirmation
+  /// dialog to the user. This is useful for gallery/media-manager apps that
+  /// want to perform bulk operations without per-item prompts.
+  ///
+  /// Requires `<uses-permission android:name="android.permission.MANAGE_MEDIA"/>`
+  /// in the host app's `AndroidManifest.xml`. Returns `false` on iOS/macOS/
+  /// OpenHarmony and on Android versions below 12.
+  ///
+  /// See also:
+  ///  * [requestManageMedia] to send the user to the Settings page where the
+  ///    permission can be toggled.
+  ///  * https://developer.android.com/reference/android/provider/MediaStore#canManageMedia(android.content.Context)
+  static Future<bool> canManageMedia() => plugin.canManageMedia();
+
+  /// Opens the system Settings page where the user can grant the Android
+  /// `MANAGE_MEDIA` permission to this app. Returns `true` if the Settings
+  /// intent was launched.
+  ///
+  /// The system provides no result callback; re-check [canManageMedia] once
+  /// the user returns to the app (for example when the app resumes).
+  ///
+  /// No-op that returns `false` on iOS/macOS/OpenHarmony and on Android
+  /// versions below 12.
+  ///
+  /// See also:
+  ///  * https://developer.android.com/reference/android/provider/Settings#ACTION_REQUEST_MANAGE_MEDIA
+  static Future<bool> requestManageMedia() => plugin.requestManageMedia();
+
   /// Release native caches, there are no common use case for this method,
   /// so this method is not recommended.
   ///


### PR DESCRIPTION
## Summary

Closes #891. Adds `PhotoManager.canManageMedia()` and `PhotoManager.requestManageMedia()` for Android 12 (API 31+)'s [`MANAGE_MEDIA`](https://developer.android.com/reference/android/provider/MediaStore#canManageMedia(android.content.Context)) special permission. When the user grants it, the existing MediaStore `create*Request` intents used by `deleteWithIds`, `moveToTrash`, `favoriteAsset`, and write operations automatically stop showing the per-item system confirmation dialog — so the mutation paths themselves need no changes. This is aimed at gallery / media-manager apps that perform bulk operations.

- Kotlin: register the two methods in `Methods.kt`, implement `MediaStore.canManageMedia` and `Settings.ACTION_REQUEST_MANAGE_MEDIA` in `PermissionsUtils`, and dispatch them alongside the other no-permission-required methods in `PhotoManagerPlugin`.
- Dart: expose the two methods on `PhotoManager` next to `openSetting`, with doc comments covering the manifest opt-in, the user-toggle in Settings > Special app access, and the re-check-on-return flow. Both methods return `false` on iOS / macOS / OpenHarmony and on Android < 12.
- Docs: new "Android 12 (API 31) `MANAGE_MEDIA` (optional)" subsection under Android extra configs in `README.md` and `README-ZH.md`, plus a CHANGELOG entry under Unreleased.

Host apps opt in by declaring `<uses-permission android:name="android.permission.MANAGE_MEDIA"/>` — the plugin manifest is intentionally left untouched to match how `READ_MEDIA_*` is handled today.