### PR TITLE
🐛 Fix Android IllegalArgumentException: Volume external_primary not found

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -28,6 +28,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 **Fixes**
 
+- Fix Android `PlatformException`s from `IllegalArgumentException: Volume external_primary not found` by returning an empty cursor when MediaProvider reports the primary volume as unavailable, and guard the media-store `ContentObserver` against the same exception.
 - Fix Darwin `AssetEntity.originFile` returning the locally-downsampled proxy for iCloud + "Optimize iPhone Storage"-affected photos by preferring `PHImageManager` with `HighQualityFormat` over `writeDataForAssetResource` on unedited raster primaries.
 - Fix Darwin `PhotoManager.editor.darwin.saveLivePhoto` returning `PHPhotosErrorDomain (-1)` when the caller-supplied image and video lacked the shared Live Photo pairing identifier `PHAssetCreationRequest` requires.
 - Fix iOS 18+ raising `Unsupported fetch for asset collections with type 2 and subtype 2` when navigating into the primary album, caused by an invalid `SmartAlbum` + `AlbumRegular` combination in the recent-collection check.

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerNotifyChannel.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerNotifyChannel.kt
@@ -3,6 +3,7 @@ package com.fluttercandies.photo_manager.core
 import android.content.ContentResolver
 import android.content.Context
 import android.database.ContentObserver
+import android.database.Cursor
 import android.net.Uri
 import android.os.Build
 import android.os.Handler
@@ -102,6 +103,29 @@ class PhotoManagerNotifyChannel(
         val cr: ContentResolver
             get() = context.contentResolver
 
+        // ContentObserver callbacks run on the handler thread. When
+        // MediaProvider rejects the query with "Volume <name> not found" on
+        // devices where the primary volume is transiently unavailable, letting
+        // it propagate would crash that thread. Downgrade only that specific
+        // IllegalArgumentException to a null cursor so the change notification
+        // is dropped for this event; other IllegalArgumentException causes
+        // (bad projection, unauthorized column, etc.) still surface.
+        private fun safeQuery(
+            uri: Uri,
+            projection: Array<String>,
+            selection: String,
+            selectionArgs: Array<String>
+        ): Cursor? = try {
+            cr.query(uri, projection, selection, selectionArgs, null)
+        } catch (e: IllegalArgumentException) {
+            if (IDBUtils.isVolumeNotFound(e)) {
+                LogUtils.error("MediaStore observer query hit missing volume, dropping event", e)
+                null
+            } else {
+                throw e
+            }
+        }
+
         override fun onChange(selfChange: Boolean, uri: Uri?) {
             if (uri == null) {
                 return
@@ -110,12 +134,11 @@ class PhotoManagerNotifyChannel(
             val id = last?.toLongOrNull()
 
             if (id != null) { // insert or update
-                val cursor = cr.query(
+                val cursor = safeQuery(
                     allUri,
                     arrayOf(DATE_ADDED, DATE_MODIFIED, MEDIA_TYPE),
                     "$_ID = ?",
-                    arrayOf(id.toString()),
-                    null
+                    arrayOf(id.toString())
                 )
                 cursor?.use {
                     if (!cursor.moveToNext()) {
@@ -158,15 +181,14 @@ class PhotoManagerNotifyChannel(
         private fun getGalleryIdAndName(id: Long, type: Int): Pair<Long?, String?> {
             when {
                 Build.VERSION.SDK_INT >= Build.VERSION_CODES.Q -> {
-                    val cursor = cr.query(
+                    val cursor = safeQuery(
                         allUri,
                         arrayOf(
                             BUCKET_ID,
                             BUCKET_DISPLAY_NAME
                         ),
                         "$_ID = ?",
-                        arrayOf(id.toString()),
-                        null
+                        arrayOf(id.toString())
                     )
                     cursor?.use {
                         if (cursor.moveToNext()) {
@@ -182,15 +204,14 @@ class PhotoManagerNotifyChannel(
                 }
 
                 type == MEDIA_TYPE_AUDIO -> {
-                    val cursor = cr.query(
+                    val cursor = safeQuery(
                         allUri,
                         arrayOf(
                             MediaStore.Audio.AudioColumns.ALBUM_ID,
                             ALBUM
                         ),
                         "$_ID = ?",
-                        arrayOf(id.toString()),
-                        null
+                        arrayOf(id.toString())
                     )
                     cursor?.use {
                         if (cursor.moveToNext()) {
@@ -206,12 +227,11 @@ class PhotoManagerNotifyChannel(
                 }
 
                 else -> {
-                    val cursor = cr.query(
+                    val cursor = safeQuery(
                         allUri,
                         arrayOf("bucket_id", "bucket_display_name"),
                         "$_ID = ?",
-                        arrayOf(id.toString()),
-                        null
+                        arrayOf(id.toString())
                     )
                     cursor?.use {
                         if (cursor.moveToNext()) {

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -5,6 +5,7 @@ import android.content.ContentUris
 import android.content.ContentValues
 import android.content.Context
 import android.database.Cursor
+import android.database.MatrixCursor
 import android.media.MediaMetadataRetriever
 import android.net.Uri
 import android.os.Build
@@ -96,6 +97,20 @@ interface IDBUtils {
         val allUri: Uri
             get() = MediaStore.Files.getContentUri(VOLUME_EXTERNAL)
 
+        // MediaProvider throws IllegalArgumentException with the hard-coded
+        // English message `"Volume " + volumeName + " not found"` on devices
+        // where the primary shared-storage volume is transiently unavailable
+        // (Direct Boot, secondary user / work profile without primary storage
+        // mounted, some OEM storage quirks, OTA mount race). The volume name is
+        // any valid identifier, so match on the fixed prefix + suffix so future
+        // MediaProvider volume aliases still route through the graceful path.
+        // Callers should only downgrade this specific case; other
+        // IllegalArgumentException causes (bad projection, unauthorized column,
+        // malformed CustomFilter selection) must still surface.
+        fun isVolumeNotFound(e: IllegalArgumentException): Boolean {
+            val msg = e.message ?: return false
+            return msg.startsWith("Volume ") && msg.endsWith(" not found")
+        }
     }
 
     fun keys(): Array<String>
@@ -774,6 +789,21 @@ interface IDBUtils {
             val cursor = query(uri, projection, selection, selectionArgs, sortOrder)
             log(LogUtils::info, cursor)
             return cursor ?: throwMsg("Failed to obtain the cursor.")
+        } catch (e: IllegalArgumentException) {
+            // See IDBUtils.isVolumeNotFound: the specific case where
+            // MediaProvider can't resolve the primary volume is downgraded to
+            // an empty cursor so the gallery renders empty for that moment
+            // instead of surfacing a PlatformException. Every other
+            // IllegalArgumentException (bad projection, malformed CustomFilter
+            // selection, unauthorized column) still propagates.
+            if (IDBUtils.isVolumeNotFound(e)) {
+                log(LogUtils::error, null)
+                LogUtils.error("MediaStore volume unavailable, returning empty cursor", e)
+                return MatrixCursor(projection ?: emptyArray())
+            }
+            log(LogUtils::error, null)
+            LogUtils.error("happen query error", e)
+            throw e
         } catch (e: Exception) {
             log(LogUtils::error, null)
             LogUtils.error("happen query error", e)

--- a/android/src/test/kotlin/com/fluttercandies/photo_manager/core/utils/IsVolumeNotFoundTest.kt
+++ b/android/src/test/kotlin/com/fluttercandies/photo_manager/core/utils/IsVolumeNotFoundTest.kt
@@ -1,0 +1,65 @@
+package com.fluttercandies.photo_manager.core.utils
+
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
+import org.junit.Test
+
+/**
+ * Unit tests for [IDBUtils.isVolumeNotFound].
+ *
+ * The predicate exists to route only MediaProvider's transient
+ * "Volume <name> not found" IllegalArgumentException through the empty-cursor
+ * graceful path. Any other IllegalArgumentException (bad projection, malformed
+ * CustomFilter selection, unauthorized column) must still surface.
+ */
+class IsVolumeNotFoundTest {
+
+    @Test
+    fun `matches the primary volume message`() {
+        val e = IllegalArgumentException("Volume external_primary not found")
+        assertTrue(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `matches the external umbrella volume message`() {
+        val e = IllegalArgumentException("Volume external not found")
+        assertTrue(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `matches a hypothetical named removable volume`() {
+        val e = IllegalArgumentException("Volume 0000-1234 not found")
+        assertTrue(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `does not match a bad-projection error`() {
+        val e = IllegalArgumentException("Invalid column bogus_column")
+        assertFalse(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `does not match a bad-selection error`() {
+        val e = IllegalArgumentException("bad SQL syntax near AND")
+        assertFalse(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `does not match a message that only starts with Volume`() {
+        // e.g. an unrelated exception that happens to mention Volume
+        val e = IllegalArgumentException("Volume must be positive")
+        assertFalse(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `does not match a message that only ends with not found`() {
+        val e = IllegalArgumentException("Row not found")
+        assertFalse(IDBUtils.isVolumeNotFound(e))
+    }
+
+    @Test
+    fun `does not match when the exception has no message`() {
+        val e = IllegalArgumentException()
+        assertFalse(IDBUtils.isVolumeNotFound(e))
+    }
+}


### PR DESCRIPTION
## Summary

- Closes #906. On some devices — Moto Edge 20 / g 5G, Samsung A13x are the ones reported, but the underlying trigger is more general (Direct Boot before user unlock, secondary user / work profile without primary shared storage mounted, some OEM adopted-storage quirks, OTA mount race) — `MediaProvider` throws `IllegalArgumentException("Volume external_primary not found")` from every read this plugin issues, because it resolves the `external` umbrella volume through the primary volume even though the plugin never names `external_primary` itself. Same root cause reported against `image_picker` in [flutter/flutter#127494](https://github.com/flutter/flutter/issues/127494) and [#158331](https://github.com/flutter/flutter/issues/158331), and against `capacitor` in [ionic-team/capacitor#3889](https://github.com/ionic-team/capacitor/issues/3889).

- On the current codebase this no longer hard-crashes (`PhotoManagerPlugin.handleOtherMethods` wraps invocations in `try { ... } catch (e: Exception)` since the Kotlin rewrite), but every `getAssetPathList` / `getAssetListPaged` / `getAssetListRange` / `getFilePath` / … call surfaces to Flutter as a `PlatformException` for the duration of the bad state — the gallery is effectively unusable. `PhotoManagerNotifyChannel.MediaObserver.onChange` also runs on the main-looper handler and calls `cr.query(...)` directly with no guard, so the same exception thrown from a subsequent `MediaStore` change notification could still crash the process on the observer thread.

- `IDBUtils.logQuery` now downgrades **only** the `"Volume <name> not found"` case to an empty `MatrixCursor` (matching the caller's projection so `cursor.getColumnIndex` / iteration keep working), routed through a new pure predicate `IDBUtils.isVolumeNotFound(IllegalArgumentException)`. The gallery renders as empty for the moment instead of raising a `PlatformException`, and callers that legitimately return null / empty on no-hit rows (`getAssetEntity`, `getPathRelativePath`, `getSomeInfo`, …) fall through their existing branches. Every other `IllegalArgumentException` — bad projection, unauthorized column on Android 11+, malformed `CustomFilter` selection (which would produce an SQL-syntax IAE in some Android versions) — is still re-thrown so real developer errors remain visible.

- Adversarial reviewer's catch that shaped this: an unconditional `catch (IllegalArgumentException)` would have masked a broken `CustomFilter` as \"empty gallery\" with no signal in Flutter. Narrowing to `startsWith(\"Volume \") && endsWith(\" not found\")` matches AOSP `MediaProvider`'s hard-coded `\"Volume \" + volumeName + \" not found\"` format across all volume names (`external`, `external_primary`, removable UUID-style like `0000-1234`, hypothetical future aliases) without swallowing anything else. Verified by unit tests covering the accept + reject cases.

- `PhotoManagerNotifyChannel.MediaObserver` gains a `safeQuery` helper that applies the same `isVolumeNotFound` guard, so the four direct `cr.query(...)` sites (change-decision cursor + three `getGalleryIdAndName` branches for Q+/audio/pre-Q) drop the event instead of crashing the observer thread. Non-volume `IllegalArgumentException`s still propagate.

## Not touched

- Write paths (`cr.insert` / `cr.update` / `cr.delete`) can throw the same exception on the same devices, but silently succeeding a save into a missing volume would be worse than the loud failure. Writes are triggered by explicit user action, so surfacing the error is the correct behavior; left as-is.
- `removeAllExistsAssets` will still fail on the `cr.delete` after the query returns empty, matching the pre-existing behavior when the user simply has no media at all. Not new to this PR.

Sources for the platform-side root cause:
- [AOSP `MediaProvider` volume lookup](https://android.googlesource.com/platform/packages/providers/MediaProvider/+/65c8bd6f10fa52c110caa4e95eef9193e7b604c8/src/com/android/providers/media/MediaProvider.java)
- [Google IssueTracker 147619577 — MediaStore volume SecurityException](https://issuetracker.google.com/issues/147619577)

🤖 Generated with [Claude Code](https://claude.com/claude-code)