### PR TITLE
🐛 Fix Gradle 9 Kotlin compatibility

### DIFF
--- a/.github/fixtures/kotlin_mode/.gitignore
+++ b/.github/fixtures/kotlin_mode/.gitignore
@@ -1,0 +1,2 @@
+.gradle/
+build/

--- a/.github/fixtures/kotlin_mode/built_in_default/build.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_default/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/built_in_default/gradle.properties
+++ b/.github/fixtures/kotlin_mode/built_in_default/gradle.properties
@@ -1,0 +1,2 @@
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/built_in_default/settings.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_default/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "photo_manager_default_kotlin_fixture"
+
+include ":photo_manager"
+project(":photo_manager").projectDir = file("../../../../android")

--- a/.github/fixtures/kotlin_mode/built_in_explicit/build.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/built_in_explicit/gradle.properties
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/gradle.properties
@@ -1,0 +1,3 @@
+android.builtInKotlin=true
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/built_in_explicit/settings.gradle
+++ b/.github/fixtures/kotlin_mode/built_in_explicit/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "photo_manager_built_in_kotlin_fixture"
+
+include ":photo_manager"
+project(":photo_manager").projectDir = file("../../../../android")

--- a/.github/fixtures/kotlin_mode/legacy/build.gradle
+++ b/.github/fixtures/kotlin_mode/legacy/build.gradle
@@ -1,0 +1,3 @@
+plugins {
+    id "com.android.library" version "9.2.1" apply false
+}

--- a/.github/fixtures/kotlin_mode/legacy/gradle.properties
+++ b/.github/fixtures/kotlin_mode/legacy/gradle.properties
@@ -1,0 +1,3 @@
+android.builtInKotlin=false
+android.newDsl=false
+org.gradle.jvmargs=-Xmx1536M

--- a/.github/fixtures/kotlin_mode/legacy/settings.gradle
+++ b/.github/fixtures/kotlin_mode/legacy/settings.gradle
@@ -1,0 +1,12 @@
+pluginManagement {
+    repositories {
+        google()
+        mavenCentral()
+        gradlePluginPortal()
+    }
+}
+
+rootProject.name = "photo_manager_legacy_kotlin_fixture"
+
+include ":photo_manager"
+project(":photo_manager").projectDir = file("../../../../android")

--- a/.github/scripts/verify_photo_manager_kotlin_mode.init.gradle
+++ b/.github/scripts/verify_photo_manager_kotlin_mode.init.gradle
@@ -1,0 +1,22 @@
+gradle.afterProject { project, state ->
+    if (project.name != "photo_manager" || state.failure != null) {
+        return
+    }
+
+    def builtInKotlin = System.getProperty("photoManager.expectedBuiltInKotlin")
+    if (builtInKotlin == null) {
+        throw new GradleException("Missing expected built-in Kotlin mode")
+    }
+    def expectsBuiltInKotlin = builtInKotlin.toBoolean()
+    def appliesKotlinPlugin =
+        project.pluginManager.hasPlugin("org.jetbrains.kotlin.android") ||
+        project.pluginManager.hasPlugin("kotlin-android")
+
+    if (appliesKotlinPlugin == expectsBuiltInKotlin) {
+        throw new GradleException(
+            expectsBuiltInKotlin
+                ? "photo_manager applied KGP in built-in Kotlin mode"
+                : "photo_manager did not apply KGP in legacy Kotlin mode"
+        )
+    }
+}

--- a/.github/workflows/runnable.yml
+++ b/.github/workflows/runnable.yml
@@ -104,11 +104,24 @@ jobs:
         with:
           distribution: 'zulu'
           java-version: '17'
+      - uses: gradle/actions/setup-gradle@ed408507eac070d1f99cc633dbcf757c94c7933a
+        with:
+          gradle-version: '9.5.1'
+          cache-disabled: true
       - uses: subosito/flutter-action@1a449444c387b1966244ae4d4f8c696479add0b2
         with:
           channel: "stable"
           cache: true
       - run: flutter doctor -v
+      - name: Cache Gradle
+        uses: actions/cache@0057852bfaa89a56745cba8c7296529d2fc39830
+        with:
+          path: |
+            ~/.gradle/caches
+            ~/.gradle/wrapper
+          key: ${{ runner.os }}-gradle-${{ hashFiles('**/*.gradle*', '**/gradle-wrapper.properties') }}
+          restore-keys: |
+            ${{ runner.os }}-gradle-
       - run: flutter pub get
       - run: flutter build apk --release
         name: Build apk
@@ -116,6 +129,21 @@ jobs:
       - name: Run Android unit tests
         run: ./gradlew photo_manager:test
         working-directory: ${{ github.workspace }}/example/android
+      - name: Verify legacy Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/legacy help \
+            -DphotoManager.expectedBuiltInKotlin=false \
+            -I ../../../scripts/verify_photo_manager_kotlin_mode.init.gradle
+      - name: Verify explicit built-in Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/built_in_explicit help \
+            -DphotoManager.expectedBuiltInKotlin=true \
+            -I ../../../scripts/verify_photo_manager_kotlin_mode.init.gradle
+      - name: Verify AGP-default built-in Kotlin project
+        run: |
+          gradle -p .github/fixtures/kotlin_mode/built_in_default help \
+            -DphotoManager.expectedBuiltInKotlin=true \
+            -I ../../../scripts/verify_photo_manager_kotlin_mode.init.gradle
       - name: Upload artifact
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02
         id: apk

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+**Fixes**
+
+- Fix Gradle 9 configuration failures in the legacy Kotlin fallback and correctly select built-in Kotlin when `android.builtInKotlin` is unset.
 
 ## 3.10.0
 

--- a/android/build.gradle
+++ b/android/build.gradle
@@ -11,23 +11,20 @@ String library_version = versionMatcher.group(1).replaceAll("\\+", "-")
 group 'com.fluttercandies.photo_manager'
 version library_version
 
-def builtInKotlinFlag = (project.findProperty("android.builtInKotlin") ?: "false").toString().toBoolean()
-def hasKotlinExtension = project.extensions.findByName("kotlin") != null
-def useBuiltInKotlin = builtInKotlinFlag && hasKotlinExtension
+// Keep this top-level: a conditional buildscript block can run after Gradle
+// has resolved the script classpath.
+buildscript {
+    ext.kotlin_version = '1.9.23'
+    repositories {
+        google()
+        mavenCentral()
+    }
 
-if (!useBuiltInKotlin) {
-    buildscript {
-        ext.kotlin_version = '1.9.23'
-        repositories {
-            google()
-            mavenCentral()
-        }
-
-        dependencies {
-            classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
-        }
+    dependencies {
+        classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
     }
 }
+
 rootProject.allprojects {
     repositories {
         google()
@@ -36,6 +33,17 @@ rootProject.allprojects {
 }
 
 apply plugin: 'com.android.library'
+
+// AGP creates its built-in Kotlin extension when the Android plugin is
+// applied. Checking before this point always misdetects the built-in path.
+def agpMajor = com.android.Version.ANDROID_GRADLE_PLUGIN_VERSION.tokenize('.')[0] as int
+def builtInKotlinProperty = project.findProperty("android.builtInKotlin")
+// AGP 9+ enables built-in Kotlin by default when the property is absent.
+def builtInKotlinRequested = builtInKotlinProperty == null
+        ? agpMajor >= 9
+        : builtInKotlinProperty.toString().toBoolean()
+def hasKotlinExtension = project.extensions.findByName("kotlin") != null
+def useBuiltInKotlin = builtInKotlinRequested && hasKotlinExtension
 
 if (!useBuiltInKotlin) {
     apply plugin: 'kotlin-android'
@@ -55,6 +63,12 @@ android {
     compileOptions {
         sourceCompatibility JavaVersion.VERSION_17
         targetCompatibility JavaVersion.VERSION_17
+    }
+
+    if (!useBuiltInKotlin) {
+        kotlinOptions {
+            jvmTarget = '17'
+        }
     }
 
     sourceSets {


### PR DESCRIPTION
## Summary

- keep the legacy KGP dependency in a top-level buildscript block so Gradle cannot observe the classpath before it is mutated
- detect built-in Kotlin after applying AGP, including the AGP 9 default when android.builtInKotlin is unset
- verify legacy, explicit built-in, and default built-in Kotlin projects in one Android job
- reuse Flutter/pub and Gradle caches across the Android build and Kotlin mode checks

## Verification

- verified all three Kotlin modes with JDK 17, Gradle 9.5.1, and AGP 9.2.1
- passed the AGP 8.9.3 Android unit tests
- built the debug APK successfully
- parsed the workflow YAML and ran git diff --check

Follow-up to #1403.
Related to fluttercandies/flutter_image_compress#400.