### PR TITLE
🐛 Fix App Store rejection from PHAsset.filename KVC access

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+**Fixes**
+
+- Avoid App Store rejections caused by referencing the private `PHAsset.filename` selector. The Darwin `title` lookup now uses the public `PHAssetResource.originalFilename` API directly instead of KVC'ing into the non-public `filename` selector.
 
 ## 3.11.0
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m
@@ -41,30 +41,26 @@
 }
 
 - (NSString *)title {
+    // Avoid KVC into the private `PHAsset.filename` selector; App Store's static
+    // scanner flags references to it. `PHAssetResource.originalFilename` is the
+    // only public API for obtaining an asset's filename.
     PMLogUtils *logger = [PMLogUtils sharedInstance];
-    [logger info:@"get title start"];
-    @try {
-        NSString *result = [self valueForKey:@"filename"];
-        [logger info:@"get title from kvo"];
-        return result;
-    } @catch (NSException *exception) {
-        [logger info: @"get title from PHAssetResource"];
-        NSArray *array = [PHAssetResource assetResourcesForAsset:self];
-        for (PHAssetResource *resource in array) {
-            if ([self isImage] && resource.type == PHAssetResourceTypePhoto) {
-                return resource.originalFilename;
-            } else if ([self isVideo] && resource.type == PHAssetResourceTypeVideo) {
-                return resource.originalFilename;
-            }
+    [logger info:@"get title from PHAssetResource"];
+    NSArray *array = [PHAssetResource assetResourcesForAsset:self];
+    for (PHAssetResource *resource in array) {
+        if ([self isImage] && resource.type == PHAssetResourceTypePhoto) {
+            return resource.originalFilename;
+        } else if ([self isVideo] && resource.type == PHAssetResourceTypeVideo) {
+            return resource.originalFilename;
         }
-        
-        PHAssetResource *firstRes = array.firstObject;
-        if (firstRes) {
-            return firstRes.originalFilename;
-        }
-        
-        return @"";
     }
+
+    PHAssetResource *firstRes = array.firstObject;
+    if (firstRes) {
+        return firstRes.originalFilename;
+    }
+
+    return @"";
 }
 
 - (NSString *)filenameWithOptions:(int)subtype isOrigin:(BOOL)isOrigin fileType:(AVFileType)fileType {


### PR DESCRIPTION
## Summary

- The Darwin `title` method reached the non-public `PHAsset.filename` selector via KVC (`[self valueForKey:@"filename"]`), which App Store's static private-API scanner flags, causing app rejections (#1429).
- Drop the `@try`/KVC attempt and go straight to the public `PHAssetResource.originalFilename` API — the same lookup the `@catch` branch already used as a fallback, and the same API the sibling `filenameWithOptions:isOrigin:fileType:` uses exclusively.
- Update `CHANGELOG.md` under `## Unreleased`.

Closes #1429

## Problem

`[self valueForKey:@"filename"]` is KVC: it invokes the `-filename` selector on a `PHAsset`. That selector is **not** part of the public Photos API (absent from `PHAsset.h` in both the iPhoneOS and MacOSX SDK headers), so it is private/undocumented. App Store's static scan detects the reference and rejects affected apps. The pre-existing `@catch` fallback already used the public `PHAssetResource.originalFilename`, so the KVC attempt was both risky and redundant.

## Change

`darwin/photo_manager/Sources/photo_manager/core/PHAsset+PM_COMMON.m` — `title`:
- Removed the `@try { [self valueForKey:@"filename"] } @catch { ... }` block.
- `title` now iterates `PHAssetResource.assetResourcesForAsset:` and returns `originalFilename` for the matching photo/video resource, falling back to the first resource, then `@""` — the exact logic that lived in the `@catch` branch.
- Added a comment documenting why KVC into `PHAsset.filename` is avoided.

No public Dart API, signature, or cross-platform semantics change. The returned value is the same `PHAssetResource.originalFilename` the fallback already produced.

## Verification

- `clang -fsyntax-only -fobjc-arc -isysroot "$(xcrun --sdk macosx --show-sdk-path)" -fmodules` on the changed file: compiles clean (only pre-existing, unrelated `UTTypeCopyPreferredTagWithClass`/`kUTTagClassMIMEType` deprecation warnings in `mimeType`).
- `dart format . -o none --set-exit-if-changed`: 0 changed.
- `flutter analyze lib`: No issues found.
- Confirmed no remaining `valueForKey:@"filename"` / `valueForKey:@"originalFilename"` references under `darwin/`.

## Risk

Low. Change is confined to the Darwin `title` accessor; behavior matches the previous `@catch` fallback path that already ran whenever the private selector threw. No new dependencies, abstractions, or files.

## Notes

- Could not reproduce an actual App Store rejection (requires submitting for review); the underlying claim — a reference to a private `PHAsset` selector via KVC — is verified and removed.
- Follows `AGENTS.md` (gitmoji commit, minimal diff, CHANGELOG under `## Unreleased`, no version-floor change).

> This comment was generated by AI agent omp (model: devin/glm-5-2).