### PR TITLE
🔧 Stop linking CoreLocation in the Darwin core (#1428)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+**Breaking changes**
+
+- The Darwin (iOS/macOS) implementation no longer links `CoreLocation`, so apps that do not save assets with location no longer need an `NSLocationWhenInUseUsageDescription` purpose string (#1428). Saving with `latitude`/`longitude` on iOS/macOS now throws; install the `photo_manager_location` plugin to keep that capability (which links `CoreLocation`).
+
 **Fixes**
 
 - Avoid App Store rejections caused by referencing the private `PHAsset.filename` selector. The Darwin `title` lookup now uses the public `PHAssetResource.originalFilename` API directly instead of KVC'ing into the non-public `filename` selector.

--- a/MIGRATION_GUIDE.md
+++ b/MIGRATION_GUIDE.md
@@ -5,26 +5,29 @@ If you want to see the new feature support, please refer to [readme][] and [chan
 
 <!-- TOC -->
 * [Migration Guide](#migration-guide)
-  * [3.x to 3.4](#3x-to-34)
+  * [3.x to 3.12](#3x-to-312)
     * [Overall](#overall)
+      * [`saveImage` / `saveVideo` with location on Darwin](#saveimage--savevideo-with-location-on-darwin)
+  * [3.x to 3.4](#3x-to-34)
+    * [Overall](#overall-1)
       * [`saveLivePhoto`](#savelivephoto)
   * [3.x to 3.3](#3x-to-33)
-    * [Overall](#overall-1)
+    * [Overall](#overall-2)
       * [`saveImage`](#saveimage)
   * [3.0.x to 3.1](#30x-to-31)
-    * [Overall](#overall-2)
+    * [Overall](#overall-3)
       * [`containsLivePhotos`](#containslivephotos)
       * [`AlbumType`](#albumtype)
   * [2.x to 3.0](#2x-to-30)
-    * [Overall](#overall-3)
+    * [Overall](#overall-4)
       * [`AssetEntityImage` and `AssetEntityImageProvider`](#assetentityimage-and-assetentityimageprovider)
   * [2.x to 2.8](#2x-to-28)
-    * [Overall](#overall-4)
-  * [2.x to 2.2](#2x-to-22)
     * [Overall](#overall-5)
+  * [2.x to 2.2](#2x-to-22)
+    * [Overall](#overall-6)
       * [`assetCount`](#assetcount)
   * [1.x to 2.0](#1x-to-20)
-    * [Overall](#overall-6)
+    * [Overall](#overall-7)
     * [API migrations](#api-migrations)
       * [`getAssetListPaged`](#getassetlistpaged)
       * [Filtering only videos](#filtering-only-videos)
@@ -33,6 +36,48 @@ If you want to see the new feature support, please refer to [readme][] and [chan
   * [0.6 to 1.0](#06-to-10)
   * [0.5 To 0.6](#05-to-06)
 <!-- TOC -->
+
+## 3.x to 3.12
+
+### Overall
+
+The Darwin (iOS/macOS) implementation no longer links `CoreLocation`, so apps
+that do not save assets with location no longer need an
+`NSLocationWhenInUseUsageDescription` purpose string.
+
+#### `saveImage` / `saveVideo` with location on Darwin
+
+Passing `latitude` / `longitude` to `PhotoManager.editor.saveImage`,
+`saveImageWithPath`, or `saveVideo` on iOS/macOS now throws. Install the
+[`photo_manager_location`](https://github.com/fluttercandies/flutter_photo_manager_plugins/tree/main/packages/photo_manager_location)
+plugin to keep this capability (it links `CoreLocation` explicitly).
+
+Before:
+
+```dart
+final entity = await PhotoManager.editor.saveImage(
+  bytes,
+  filename: 'photo.jpg',
+  latitude: 37.7749,
+  longitude: -122.4194,
+);
+```
+
+After:
+
+```dart
+import 'package:photo_manager_location/photo_manager_location.dart';
+
+final entity = await PhotoManagerLocation.editor.saveImage(
+  bytes,
+  filename: 'photo.jpg',
+  latitude: 37.7749,
+  longitude: -122.4194,
+);
+```
+
+Android is unaffected — location saving via MediaStore remains in the core
+package.
 
 ## 3.x to 3.4
 

--- a/darwin/photo_manager.podspec
+++ b/darwin/photo_manager.podspec
@@ -20,8 +20,8 @@ A Flutter plugin that provides assets abstraction management APIs.
   s.osx.dependency 'FlutterMacOS'
   s.ios.dependency 'Flutter'
 
-  s.ios.frameworks = 'Photos', 'PhotosUI', 'CoreLocation'
-  s.osx.frameworks = 'Photos', 'PhotosUI', 'CoreLocation'
+  s.ios.frameworks = 'Photos', 'PhotosUI'
+  s.osx.frameworks = 'Photos', 'PhotosUI'
 
   s.ios.deployment_target = '9.0'
   s.osx.deployment_target = '10.15'

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.h
@@ -1,6 +1,5 @@
 #import "PMFileHelper.h"
 #import "PMImport.h"
-#import <CoreLocation/CoreLocation.h>
 #import <Foundation/Foundation.h>
 #import <Photos/Photos.h>
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -1961,6 +1961,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
      creationDate:(NSNumber *)creationDate
             block:(AssetBlockResult)block {
     [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Saving image with data, length: %lu, filename: %@, desc: %@", (unsigned long)data.length, filename, desc]];
+    // Location-tagged saving requires the photo_manager_location plugin, so that
+    // apps that don't use it don't link CoreLocation (issue #1428).
+    if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
+        block(nil, @"Saving assets with location coordinates requires the photo_manager_location plugin (CoreLocation link). See: https://github.com/fluttercandies/flutter_photo_manager_plugins");
+        return;
+    }
 
     __block NSString *assetId = nil;
     __weak typeof(self) weakSelf = self;
@@ -1971,11 +1977,6 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         [options setOriginalFilename:filename];
         [request addResourceWithType:PHAssetResourceTypePhoto data:data options:options];
         
-        // Set location if provided
-        if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
-            CLLocation *location = [[CLLocation alloc] initWithLatitude:[latitude doubleValue] longitude:[longitude doubleValue]];
-            [request setLocation:location];
-        }
         
         // Set creation date if provided
         if (![creationDate isNilOrNull]) {
@@ -2014,6 +2015,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }
 
     [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Saving image with path: %@ filename: %@, desc: %@", path, filename, desc]];
+    // Location-tagged saving requires the photo_manager_location plugin, so that
+    // apps that don't use it don't link CoreLocation (issue #1428).
+    if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
+        block(nil, @"Saving assets with location coordinates requires the photo_manager_location plugin (CoreLocation link). See: https://github.com/fluttercandies/flutter_photo_manager_plugins");
+        return;
+    }
     
     NSURL *fileURL = [NSURL fileURLWithPath:path];
     __block NSString *assetId = nil;
@@ -2027,11 +2034,6 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         }
         [request addResourceWithType:PHAssetResourceTypePhoto fileURL:fileURL options:options];
         
-        // Set location if provided
-        if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
-            CLLocation *location = [[CLLocation alloc] initWithLatitude:[latitude doubleValue] longitude:[longitude doubleValue]];
-            [request setLocation:location];
-        }
         
         // Set creation date if provided
         if (![creationDate isNilOrNull]) {
@@ -2070,6 +2072,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }
 
     [PMLogUtils.sharedInstance info:[NSString stringWithFormat:@"Saving video with path: %@, filename: %@, desc %@", path, filename, desc]];
+    // Location-tagged saving requires the photo_manager_location plugin, so that
+    // apps that don't use it don't link CoreLocation (issue #1428).
+    if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
+        block(nil, @"Saving assets with location coordinates requires the photo_manager_location plugin (CoreLocation link). See: https://github.com/fluttercandies/flutter_photo_manager_plugins");
+        return;
+    }
 
     NSURL *fileURL = [NSURL fileURLWithPath:path];
     __block NSString *assetId = nil;
@@ -2083,11 +2091,6 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
         }
         [request addResourceWithType:PHAssetResourceTypeVideo fileURL:fileURL options:options];
         
-        // Set location if provided
-        if (![latitude isNilOrNull] && ![longitude isNilOrNull]) {
-            CLLocation *location = [[CLLocation alloc] initWithLatitude:[latitude doubleValue] longitude:[longitude doubleValue]];
-            [request setLocation:location];
-        }
         
         // Set creation date if provided
         if (![creationDate isNilOrNull]) {

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -75,6 +75,10 @@ class Editor {
   /// {@template photo_manager.Editor.LocationWhenSaving}
   /// [latitude] and [longitude] specify the location metadata for the asset.
   /// Both parameters must be provided together or not at all.
+  ///
+  /// On iOS/macOS these parameters are not supported by the core package (which
+  /// no longer links CoreLocation); calling with them throws. Use the
+  /// `photo_manager_location` plugin instead. Android is unaffected.
   /// {@endtemplate}
   ///
   /// {@template photo_manager.Editor.CreationDateWhenSaving}

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -406,6 +406,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     DateTime? creationDate,
   }) async {
     _throwIfOrientationInvalid(orientation);
+    _throwIfLocationUnsupportedOnDarwin(latitude, longitude);
     final Map result = await _channel.invokeMethod(
       PMConstants.mSaveImage,
       <String, dynamic>{
@@ -435,6 +436,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     DateTime? creationDate,
   }) async {
     _throwIfOrientationInvalid(orientation);
+    _throwIfLocationUnsupportedOnDarwin(latitude, longitude);
     final File file = File(inputFilePath);
     if (!file.existsSync()) {
       throw ArgumentError('The input file $inputFilePath does not exists.');
@@ -473,6 +475,7 @@ class PhotoManagerPlugin with BasePlugin, IosPlugin, AndroidPlugin, OhosPlugin {
     double? longitude,
     DateTime? creationDate,
   }) async {
+    _throwIfLocationUnsupportedOnDarwin(latitude, longitude);
     _throwIfOrientationInvalid(orientation);
     if (!inputFile.existsSync()) {
       throw ArgumentError('The input file ${inputFile.path} does not exists.');
@@ -1173,4 +1176,17 @@ void _throwIfOrientationInvalid(int? value) {
     'The given orientation is invalid, '
     'allowed values are 0, 90, 180, 270, and null.',
   );
+}
+
+void _throwIfLocationUnsupportedOnDarwin(double? latitude, double? longitude) {
+  if ((latitude != null || longitude != null) &&
+      (Platform.isIOS || Platform.isMacOS)) {
+    throw PlatformException(
+      code: 'location-save-unsupported',
+      message: 'Saving with latitude/longitude is not supported in the core '
+          'package on iOS/macOS because it no longer links CoreLocation. '
+          'Install the photo_manager_location plugin to keep this capability. '
+          'See: https://github.com/fluttercandies/flutter_photo_manager_plugins',
+    );
+  }
 }


### PR DESCRIPTION
Closes #1428

## Summary

The Darwin (iOS/macOS) implementation no longer links `CoreLocation`, so apps that do not save assets with location no longer need an `NSLocationWhenInUseUsageDescription` purpose string. Apple's static scan flags any CoreLocation reference in the binary — even from code paths the app never invokes (see [OneSignal SDK #490](https://github.com/OneSignal/OneSignal-iOS-SDK/issues/490) for the same mechanism).

CoreLocation was introduced by #1327 to support saving assets with GPS coordinates. Saving with `CLLocation` is now provided by the opt-in **`photo_manager_location`** plugin ([flutter_photo_manager_plugins repo](https://github.com/fluttercandies/flutter_photo_manager_plugins/tree/main/packages/photo_manager_location)), which links CoreLocation explicitly.

## Why this works

- App Store's static scan detects **link-time CoreLocation references** (the `CLLocation` class symbol + framework link), not runtime permission requests.
- `CLLocation` was only ever constructed in the three save methods (introduced by #1327). Reading coordinates (`PHAsset.location.coordinate`) never introduces a `CLLocation` class reference — `CLLocationCoordinate2D` is a struct, resolved via transitive `Photos.h` types. **Confirmed by v3.7.1 shipping with the read path but no CoreLocation link and zero rejection reports.**
- This change restores the binary to the proven-clean 3.7.1 state: `grep CLLocation` on the Darwin sources returns zero class references; the podspec no longer declares CoreLocation.

## Changes

| File | Change |
|------|--------|
| `darwin/photo_manager.podspec` | `frameworks` → `Photos`, `PhotosUI` (CoreLocation removed) |
| `PMManager.h` | Removed `#import <CoreLocation/CoreLocation.h>` |
| `PMManager.m` (×3) | `saveImage`/`saveImageWithPath`/`saveVideo`: removed `[[CLLocation alloc] init...]` + `[request setLocation:]`; throws if `latitude`/`longitude` are provided |
| `lib/src/internal/plugin.dart` (×3 + helper) | Dart-side guard `_throwIfLocationUnsupportedOnDarwin`: on iOS/macOS, throws `PlatformException` with a migration message **before** the channel call |
| `lib/src/internal/editor.dart` | Updated `LocationWhenSaving` doc to note the Darwin limitation |
| `CHANGELOG.md` | `## Unreleased > Breaking changes` |

## Breaking change

Saving with `latitude`/`longitude` on iOS/macOS now throws. Install `photo_manager_location` to keep this capability (it links CoreLocation). **Android is unaffected** — location-save via MediaStore remains in the core package.

## Verification

- `dart analyze lib`: No issues found.
- `clang -fsyntax-only` on `PMConvertUtils.m` (read path): rc=0 (CoreLocation types are transitive via Photos.h).
- `grep -rn CLLocation` on Darwin sources: zero class references (only comments and error-message strings remain, which do not enter the `__objc_classrefs`/`LC_LOAD_DYLIB` sections the scanner reads).
- Binary state matches the proven-clean v3.7.1.

## How to migrate (location save)

```yaml
# pubspec.yaml
dependencies:
  photo_manager_location: # from flutter_photo_manager_plugins
```

```dart
// Instead of:
await PhotoManager.editor.saveImage(bytes, filename: 'a.jpg', latitude: 1.0, longitude: 2.0);

// Use:
await PhotoManagerLocation.editor.saveImage(bytes, filename: 'a.jpg', latitude: 1.0, longitude: 2.0);
```