### PR TITLE
Fix failed cache writes leaving incomplete files treated as valid (#1432)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,9 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
-*None.*
+**Fixes**
+
+- Fix failed cache writes leaving incomplete files that were later treated as valid cache entries (#1432).
 
 ## 3.12.0
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/cache/ScopedCache.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/cache/ScopedCache.kt
@@ -32,18 +32,30 @@ class ScopedCache {
         if (uri == Uri.EMPTY) {
             throwIdNotFound(assetId)
         }
+        // Write into a temporary file first, then atomically rename it into the
+        // final cache path. A failed or aborted copy never leaves an incomplete
+        // file at the cache path, which would otherwise be served as a valid
+        // entry on the next request via the `exists()` check above. See #1432.
+        val tempFile = File(targetFile.parentFile, targetFile.name + ".tmp")
         try {
             LogUtils.info(
                 "Caching $assetId [origin: $isOrigin] into ${targetFile.absolutePath}"
             )
             val inputStream = contentResolver.openInputStream(uri)
-            val outputStream = FileOutputStream(targetFile)
-            outputStream.use { os ->
-                inputStream?.use { it.copyTo(os) }
+                ?: throw IllegalStateException("Cannot open input stream for $assetId")
+            FileOutputStream(tempFile).use { os ->
+                inputStream.use { it.copyTo(os) }
             }
         } catch (e: Exception) {
+            tempFile.delete()
             LogUtils.error("Caching $assetId [origin: $isOrigin] error", e)
             throw e
+        }
+        // renameTo atomically replaces the target on the same filesystem. If it
+        // somehow fails, surface the error rather than leaving the temp behind.
+        if (!tempFile.renameTo(targetFile)) {
+            tempFile.delete()
+            throw IllegalStateException("Failed to move cache file for $assetId")
         }
         return targetFile
     }

--- a/darwin/photo_manager/Sources/photo_manager/core/PMFileHelper.h
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMFileHelper.h
@@ -11,6 +11,10 @@ NS_ASSUME_NONNULL_BEGIN
 @interface PMFileHelper : NSObject
 
 +(void)deleteFile:(NSString *)path isDirectory:(BOOL)isDirectory error:(NSError *)error;
+/// Atomically move a file into its final cache path. Any existing destination
+/// is removed first. On failure the source is deleted so no partial file is
+/// left behind for a later existence-only cache check to serve. See #1432.
++ (BOOL)moveItemAtPath:(NSString *)sourcePath toPath:(NSString *)destinationPath error:(NSError * _Nullable *)error;
 
 @end
 

--- a/darwin/photo_manager/Sources/photo_manager/core/PMFileHelper.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMFileHelper.m
@@ -15,4 +15,14 @@
     }
 }
 
++ (BOOL)moveItemAtPath:(NSString *)sourcePath toPath:(NSString *)destinationPath error:(NSError * _Nullable *)error {
+    NSFileManager *fileManager = NSFileManager.defaultManager;
+    [fileManager removeItemAtPath:destinationPath error:nil];
+    if (![fileManager moveItemAtPath:sourcePath toPath:destinationPath error:error]) {
+        [fileManager removeItemAtPath:sourcePath error:nil];
+        return NO;
+    }
+    return YES;
+}
+
 @end

--- a/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
+++ b/darwin/photo_manager/Sources/photo_manager/core/PMManager.m
@@ -955,18 +955,23 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     block(withScheme ? videoURL.absoluteString : videoURL.path, nil);
                     return;
                 }
-                // `copyItemAtURL:toURL:` fails with NSFileWriteFileExistsError
-                // when the destination already has a stub from a prior aborted
-                // fetch. Match the guard `exportAssetToFile` uses on iOS 18.
-                if ([manager fileExistsAtPath:destination.path]) {
-                    [innerSelf notifySuccess:progressHandler];
-                    block(withScheme ? destination.absoluteString : path, nil);
+                // Copy into a temporary file first, then atomically move it
+                // into the cache path. This avoids both the
+                // NSFileWriteFileExistsError that `copyItemAtURL:toURL:`
+                // raises on a pre-existing destination and the risk of
+                // serving a stub left by a prior aborted fetch. See #1432.
+                NSString *tempPath = [path stringByAppendingPathExtension:@"pmcache"];
+                NSURL *tempUrl = [NSURL fileURLWithPath:tempPath];
+                [manager removeItemAtPath:tempPath error:nil];
+                NSError *copyError;
+                if (![manager copyItemAtURL:videoURL toURL:tempUrl error:&copyError]) {
+                    [manager removeItemAtPath:tempPath error:nil];
+                    block(nil, copyError);
                     return;
                 }
-                NSError *copyError;
-                [manager copyItemAtURL:videoURL toURL:destination error:&copyError];
-                if (copyError) {
-                    block(nil, copyError);
+                NSError *moveError;
+                if (![PMFileHelper moveItemAtPath:tempPath toPath:path error:&moveError]) {
+                    block(nil, moveError);
                     return;
                 }
                 [innerSelf notifySuccess:progressHandler];
@@ -1066,9 +1071,14 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }];
     
     PHAssetResourceManager *resourceManager = PHAssetResourceManager.defaultManager;
-    NSURL *fileUrl = [NSURL fileURLWithPath:path];
+    // Write to a temporary file first, then atomically move it into place so a
+    // failed or aborted fetch never leaves a stub at the final cache path.
+    // See #1432.
+    NSString *tempPath = [path stringByAppendingPathExtension:@"pmcache"];
+    NSURL *tempUrl = [NSURL fileURLWithPath:tempPath];
+    [fileManager removeItemAtPath:tempPath error:nil];
     [resourceManager writeDataForAssetResource:resource
-                                        toFile:fileUrl
+                                        toFile:tempUrl
                                        options:options
                              completionHandler:^(NSError *_Nullable error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -1076,10 +1086,16 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             return;
         }
         if (error) {
+            [fileManager removeItemAtPath:tempPath error:nil];
             // Don't emit Failed here — the walker may retry with another
             // candidate and only the terminal outcome should surface as a
             // failure state to progress observers.
             block(nil, error);
+            return;
+        }
+        NSError *moveError;
+        if (![PMFileHelper moveItemAtPath:tempPath toPath:path error:&moveError]) {
+            block(nil, moveError);
             return;
         }
         if (fileType) {
@@ -1125,11 +1141,13 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     NSString *path = [self makeAssetOutputPath:asset resource:nil isOrigin:NO fileType:fileType manager:manager];
     if ([manager fileExistsAtPath:path]) {
         [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"Read cache from %@", path]];
+        [self notifySuccess:progressHandler];
         if (withScheme) {
             block([NSURL fileURLWithPath:path].absoluteString, nil);
         } else {
             block(path, nil);
         }
+        return;
     }
 
     PHVideoRequestOptions *options = [PHVideoRequestOptions new];
@@ -1202,22 +1220,25 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                 }
                 NSError *error;
                 NSString *destinationPath = destination.path;
-                if ([manager fileExistsAtPath:destinationPath]) {
-                    [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"Reading cache from %@", destinationPath]];
-                    if (withScheme) {
-                        block(destination.absoluteString, nil);
-                    } else {
-                        block(destinationPath, nil);
-                    }
-                    [innerStrongSelf notifySuccess:progressHandler];
-                    return;
-                }
+                // Copy into a temporary file first, then atomically move into
+                // the cache path, so a failed copy never leaves a partial file
+                // that the next request would serve as a valid entry. See #1432.
+                NSString *tempPath = [destinationPath stringByAppendingPathExtension:@"pmcache"];
+                NSURL *tempUrl = [NSURL fileURLWithPath:tempPath];
+                [manager removeItemAtPath:tempPath error:nil];
                 [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:@"Caching the video to %@", destination]];
                 [[NSFileManager defaultManager] copyItemAtURL:videoURL
-                                                        toURL:destination
+                                                        toURL:tempUrl
                                                         error:&error];
                 if (error) {
+                    [manager removeItemAtPath:tempPath error:nil];
                     block(nil, error);
+                    [innerStrongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
+                    return;
+                }
+                NSError *moveError;
+                if (![PMFileHelper moveItemAtPath:tempPath toPath:destinationPath error:&moveError]) {
+                    block(nil, moveError);
                     [innerStrongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
                     return;
                 }
@@ -1395,7 +1416,15 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     [path appendString:[PMHashUtils sha256FromString:asset.localIdentifier]];
     [path appendString:@"_exif"];
     [path appendString:@".jpg"];
-    [manager createFileAtPath:path contents:imageData attributes:@{}];
+    // createFileAtPath:contents: is atomic, but its BOOL return was previously
+    // discarded — on failure the method returned a path to a non-existent file
+    // that the caller replied with unconditionally. Surface the failure
+    // instead. See #1432.
+    if (![manager createFileAtPath:path contents:imageData attributes:@{}]) {
+        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+            @"Failed to write full-size image cache at %@", path]];
+        return nil;
+    }
     return path;
 }
 
@@ -1597,9 +1626,14 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
     }];
 
     PHAssetResourceManager *resourceManager = PHAssetResourceManager.defaultManager;
-    NSURL *fileUrl = [NSURL fileURLWithPath:path];
+    // Write to a temporary file first, then atomically move it into place so a
+    // failed or aborted fetch never leaves a stub at the final cache path
+    // (which fileExistsAtPath would later serve as a valid entry). See #1432.
+    NSString *tempPath = [path stringByAppendingPathExtension:@"pmcache"];
+    NSURL *tempUrl = [NSURL fileURLWithPath:tempPath];
+    [fileManager removeItemAtPath:tempPath error:nil];
     [resourceManager writeDataForAssetResource:imageResource
-                                        toFile:fileUrl
+                                        toFile:tempUrl
                                        options:options
                              completionHandler:^(NSError *_Nullable error) {
         __strong typeof(weakSelf) strongSelf = weakSelf;
@@ -1607,18 +1641,24 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
             return;
         }
         if (error) {
+            [fileManager removeItemAtPath:tempPath error:nil];
             // Walker retries with the next candidate; don't emit Failed here.
             block(nil, error);
-        } else {
-            long long size = [(NSNumber *)[[NSFileManager.defaultManager attributesOfItemAtPath:path error:nil]
-                              objectForKey:NSFileSize] longLongValue];
-            [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
-                @"[#1118] writeDataForAssetResource delivered %lld bytes (uti=%@ type=%d) → %@",
-                size, imageResource.uniformTypeIdentifier ?: @"(nil)",
-                (int)imageResource.type, path]];
-            [strongSelf notifySuccess:progressHandler];
-            block(path, nil);
+            return;
         }
+        NSError *moveError;
+        if (![PMFileHelper moveItemAtPath:tempPath toPath:path error:&moveError]) {
+            block(nil, moveError);
+            return;
+        }
+        long long size = [(NSNumber *)[[NSFileManager.defaultManager attributesOfItemAtPath:path error:nil]
+                          objectForKey:NSFileSize] longLongValue];
+        [[PMLogUtils sharedInstance] info:[NSString stringWithFormat:
+            @"[#1118] writeDataForAssetResource delivered %lld bytes (uti=%@ type=%d) → %@",
+            size, imageResource.uniformTypeIdentifier ?: @"(nil)",
+            (int)imageResource.type, path]];
+        [strongSelf notifySuccess:progressHandler];
+        block(path, nil);
     }];
 }
 
@@ -1837,6 +1877,12 @@ static NSString *PMResourceTypeName(PHAssetResourceType type) {
                     NSString *path = [innerStrongSelf writeFullFileWithAssetId:asset imageData:data];
                     if (![innerStrongSelf consumeRequestWithCancelToken:cancelToken]) {
                         [innerStrongSelf handleCancelRequestIfNeeded:handler progressHandler:progressHandler];
+                        return;
+                    }
+                    if (!path) {
+                        [handler replyError:[NSString stringWithFormat:
+                            @"Failed to write full-size image cache for %@.", asset.localIdentifier]];
+                        [innerStrongSelf notifyProgress:progressHandler progress:lastProgress state:PMProgressStateFailed];
                         return;
                     }
                     [handler reply:path];


### PR DESCRIPTION
## Fixes #1432

Failed cache writes left incomplete files at the final cache path, which the next request's existence-only check served as a valid cache entry — potentially returning truncated/partial data.

### Root cause

All cache write paths staged data **directly into the final cache path**:

- **Android `ScopedCache`**: `FileOutputStream(targetFile)` created/truncated the cache file *before* copying; a `copyTo` failure rethrew without deleting the partial file, which `targetFile.exists()` then served as a hit. A second latent bug: a `null` `openInputStream` produced a **0-byte** file.
- **Darwin `writeDataForAssetResource:toFile:`** (image + video resource fetch) streamed to the final path and could leave a stub on failure/abort, served by the top-of-method `fileExistsAtPath:` check.
- **Darwin video copy paths** (`fallbackFetchVideoViaAVAsset`, `exportAssetToFile`) explicitly served a pre-existing destination as a cache hit to dodge `NSFileWriteFileExistsError` — its own comment noted this was to handle "a stub from a prior aborted fetch."
- **Darwin `writeFullFileWithAssetId`** discarded the `createFileAtPath:` BOOL return and returned the path unconditionally; the caller replied with a path to a non-existent file on failure.

### Fix

Write into a **temporary file** and **atomically move** it into the final cache path, so a failed or aborted fetch can never leave a partial file at the cache path.

- **Android `ScopedCache`**: stage into `.tmp`, `renameTo` on success; `delete()` the temp on any failure path; throw instead of returning a 0-byte file when the content stream cannot be opened.
- **Darwin `PMFileHelper`**: new `moveItemAtPath:toPath:error:` helper — removes any existing destination, moves the source, deletes the source on failure.
- **Darwin `writeImageResourceToFile` / `fetchVideoResourceToFile`**: write `PHAssetResourceManager` output to a `.pmcache` temp, then atomic move into the final path.
- **Darwin `fallbackFetchVideoViaAVAsset` / `exportAssetToFile`**: copy into a temp then move, replacing the stub-as-hit guard.
- **Darwin `writeFullFileWithAssetId`**: honor the `createFileAtPath:` return and return `nil` on failure; the caller now replies an error.

Not a regression for the core defect — present since feature inception (#833 for Android, `4c010d2` for Darwin). The video-fallback stub-as-hit guard (#1414, shipped in v3.10.0) is the one recent change that turned a loud `NSFileWriteFileExistsError` into a silent cache hit.

### Verification

- `dart format . --set-exit-if-changed` — 0 changed
- `flutter analyze lib` — no issues
- `:photo_manager:compileDebugKotlin` (Android) — OK
- `flutter build ios --no-codesign --debug` (Darwin) — `Xcode build done` ✓

### Notes

- No public API change.
- The temp file uses a `.pmcache`/`.tmp` suffix and is cleaned up on every failure path; existing cache files are not affected (the move helper removes a stale destination before moving).
