### PR TITLE
Fix Android save/copy leaving visible incomplete MediaStore items (#1434)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ To know more about breaking changes, see the [Migration Guide][].
 **Fixes**
 
 - Fix failed cache writes leaving incomplete files that were later treated as valid cache entries (#1432).
+- Fix Android save/copy operations leaving visible incomplete MediaStore items when the write fails (#1434).
 
 ## 3.12.0
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/AndroidQDBUtils.kt
@@ -373,20 +373,30 @@ object AndroidQDBUtils : IDBUtils {
             }
             put(MediaStore.Files.FileColumns.MEDIA_TYPE, mediaType)
             put(RELATIVE_PATH, relativePath)
+            // Mark pending so the half-written copy isn't visible until done.
+            put(IS_PENDING, 1)
         }
 
         val insertedUri = cr.insert(insertUri, cv) ?: throwMsg("Cannot insert new asset.")
-        val outputStream = cr.openOutputStream(insertedUri)
-            ?: throwMsg("Cannot open output stream for $insertedUri.")
-        val inputUri = getUri(asset, true)
-        val inputStream = cr.openInputStream(inputUri)
-            ?: throwMsg("Cannot open input stream for $inputUri")
-        inputStream.use {
-            outputStream.use {
-                inputStream.copyTo(outputStream)
+        try {
+            val outputStream = cr.openOutputStream(insertedUri)
+                ?: throwMsg("Cannot open output stream for $insertedUri.")
+            val inputUri = getUri(asset, true)
+            val inputStream = cr.openInputStream(inputUri)
+                ?: throwMsg("Cannot open input stream for $inputUri")
+            inputStream.use {
+                outputStream.use {
+                    inputStream.copyTo(outputStream)
+                }
             }
+            val published = ContentValues().apply { put(IS_PENDING, 0) }
+            cr.update(insertedUri, published, null, null)
+        } catch (e: Exception) {
+            runCatching { cr.delete(insertedUri, null, null) }
+            throw e
+        } finally {
+            cursor.close()
         }
-        cursor.close()
 
         val insertedId = insertedUri.lastPathSegment
             ?: throwMsg("Cannot open output stream for $insertedUri.")

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/DBUtils.kt
@@ -317,16 +317,24 @@ object DBUtils : IDBUtils {
         }
 
         val insertedUri = cr.insert(insertUri, cv) ?: throwMsg("Cannot insert new asset.")
-        val outputStream = cr.openOutputStream(insertedUri)
-            ?: throwMsg("Cannot open output stream for $insertedUri.")
-        val inputStream = File(asset.path).inputStream()
-        inputStream.use {
-            outputStream.use {
-                inputStream.copyTo(outputStream)
+        try {
+            val outputStream = cr.openOutputStream(insertedUri)
+                ?: throwMsg("Cannot open output stream for $insertedUri.")
+            val inputStream = File(asset.path).inputStream()
+            inputStream.use {
+                outputStream.use {
+                    inputStream.copyTo(outputStream)
+                }
             }
+        } catch (e: Exception) {
+            // IS_PENDING is unavailable pre-Q, so delete the inserted row to
+            // avoid leaving a visible incomplete item. Best-effort: never let
+            // a cleanup failure mask the original error. See #1434.
+            runCatching { cr.delete(insertedUri, null, null) }
+            throw e
+        } finally {
+            cursor.close()
         }
-
-        cursor.close()
         val insertedId = insertedUri.lastPathSegment
             ?: throwMsg("Cannot open output stream for $insertedUri.")
         return getAssetEntity(context, insertedId) ?: throwIdNotFound(assetId)

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/utils/IDBUtils.kt
@@ -440,12 +440,31 @@ interface IDBUtils {
         shouldKeepPath: Boolean = false,
     ): AssetEntity {
         val cr = context.contentResolver
+        if (isAboveAndroidQ && !shouldKeepPath) {
+            // Mark the row pending so other apps/scanners don't see a
+            // half-written item; clear it only once the write succeeds.
+            values.put(MediaStore.MediaColumns.IS_PENDING, 1)
+        }
         val uri = cr.insert(contentUri, values) ?: throwMsg("Cannot insert new asset.")
         val id = ContentUris.parseId(uri)
-        if (!shouldKeepPath) {
-            val outputStream = cr.openOutputStream(uri)
-                ?: throwMsg("Cannot open the output stream for $uri.")
-            outputStream.use { os -> inputStream.use { it.copyTo(os) } }
+        try {
+            if (!shouldKeepPath) {
+                val outputStream = cr.openOutputStream(uri)
+                    ?: throwMsg("Cannot open the output stream for $uri.")
+                outputStream.use { os -> inputStream.use { it.copyTo(os) } }
+            }
+            if (isAboveAndroidQ && !shouldKeepPath) {
+                val published = ContentValues().apply {
+                    put(MediaStore.MediaColumns.IS_PENDING, 0)
+                }
+                cr.update(uri, published, null, null)
+            }
+        } catch (e: Exception) {
+            // Delete the inserted row so a failed/aborted save never leaves a
+            // visible incomplete item behind. Best-effort: never let a cleanup
+            // failure mask the original error. See #1434.
+            runCatching { cr.delete(uri, null, null) }
+            throw e
         }
         cr.notifyChange(uri, null)
         return getAssetEntity(context, id.toString()) ?: throwIdNotFound(id)


### PR DESCRIPTION
## Fixes #1434

Android save/copy operations inserted the MediaStore row **before** writing file contents. On failure (`openOutputStream`, `copyTo`, stream close), the exception escaped with the row left behind — a visible 0-byte or truncated gallery item.

### Root cause

`IDBUtils.insertUri` (shared by `saveImage`/`saveVideo`), `AndroidQDBUtils.copyToGallery`, and `DBUtils.copyToGallery` all follow the same insert-then-write pattern with no failure cleanup and no `IS_PENDING` on Q+.

### Fix

- **`IDBUtils.insertUri`** (shared save path): set `IS_PENDING=1` before insert on Android Q+; clear `IS_PENDING=0` only after the write succeeds; wrap the write in try/catch and `cr.delete(uri)` on failure before rethrowing.
- **`AndroidQDBUtils.copyToGallery`** (Q+): same `IS_PENDING` + cleanup; cursor now closed in a `finally` block (was leaked on the failure path).
- **`DBUtils.copyToGallery`** (pre-Q): `IS_PENDING` is unavailable (API 29+), but the inserted URI is deleted on failure; cursor closed in `finally`.

### Scope note

The issue cited only `IDBUtils.insertUri`. `copyToGallery` (both Q+ and pre-Q) had the identical defect and is fixed here too. `moveToGallery` only issues a `RELATIVE_PATH` `update` (no insert, no file write) and is unaffected.

### Verification

- `:photo_manager:compileDebugKotlin` — OK

Darwin is unaffected (this issue is Android-only).
