### PR TITLE
Fix Android thumbnail requests not releasing Glide FutureTargets (#1436)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ To know more about breaking changes, see the [Migration Guide][].
 
 - Fix failed cache writes leaving incomplete files that were later treated as valid cache entries (#1432).
 - Fix Android save/copy operations leaving visible incomplete MediaStore items when the write fails (#1434).
+- Fix Android thumbnail requests not deterministically releasing Glide resources (#1436).
 
 ## 3.12.0
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManager.kt
@@ -19,6 +19,7 @@ import com.fluttercandies.photo_manager.thumb.ThumbnailUtil
 import com.fluttercandies.photo_manager.util.LogUtils
 import com.fluttercandies.photo_manager.util.ResultHandler
 import java.util.concurrent.Executors
+import java.util.concurrent.ConcurrentHashMap
 
 class PhotoManager(private val context: Context) {
     companion object {
@@ -315,26 +316,34 @@ class PhotoManager(private val context: Context) {
         return asset.getUri()
     }
 
-    private val cacheFutures = ArrayList<FutureTarget<Bitmap>>()
+    private val cacheFutures: MutableSet<FutureTarget<Bitmap>> = ConcurrentHashMap.newKeySet()
 
     fun requestCache(ids: List<String>, option: ThumbLoadOption, resultHandler: ResultHandler) {
         val pathList = dbUtils.getAssetsPath(context, ids)
+        // Schedule only the newly requested targets, not the accumulated history.
+        val newFutures = ArrayList<FutureTarget<Bitmap>>(pathList.size)
         for (s in pathList) {
             val future = ThumbnailUtil.requestCacheThumb(context, s, option)
-            cacheFutures.add(future)
+            if (cacheFutures.add(future)) {
+                newFutures.add(future)
+            }
         }
         resultHandler.reply(1)
-        val needExecuteFutures = cacheFutures.toList()
-        for (cacheFuture in needExecuteFutures) {
+        for (cacheFuture in newFutures) {
             threadPool.execute {
-                if (cacheFuture.isCancelled) {
-                    return@execute
-                }
-
                 try {
                     cacheFuture.get()
                 } catch (e: Exception) {
                     LogUtils.error(e)
+                } finally {
+                    // Clear and drop the target once it completes so its bitmap
+                    // is released deterministically and the set never retains
+                    // finished targets. Safe against a concurrent cancel: the
+                    // clear is idempotent. See #1436.
+                    if (cacheFutures.remove(cacheFuture)) {
+                        runCatching { Glide.with(context).clear(cacheFuture) }
+                            .onFailure { LogUtils.error(it) }
+                    }
                 }
             }
         }
@@ -344,7 +353,8 @@ class PhotoManager(private val context: Context) {
         val needCancelFutures = cacheFutures.toList()
         cacheFutures.clear()
         for (futureTarget in needCancelFutures) {
-            Glide.with(context).clear(futureTarget)
+            runCatching { Glide.with(context).clear(futureTarget) }
+                .onFailure { LogUtils.error(it) }
         }
     }
 

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/thumb/ThumbnailUtil.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/thumb/ThumbnailUtil.kt
@@ -24,18 +24,25 @@ object ThumbnailUtil {
         frame: Long,
         resultHandler: ResultHandler
     ) {
+        var target: FutureTarget<Bitmap>? = null
         try {
-            val resource = Glide.with(context)
+            target = Glide.with(context)
                 .asBitmap()
                 .apply(RequestOptions().frame(frame).priority(Priority.IMMEDIATE))
                 .load(entity.getUri())
                 .signature(ObjectKey(entity.modifiedDate))
-                .submit(width, height).get()
+                .submit(width, height)
+            val resource = target.get()
             val bos = ByteArrayOutputStream()
             resource.compress(format, quality, bos)
             resultHandler.reply(bos.toByteArray())
         } catch (e: Exception) {
             resultHandler.replyError("Thumbnail request error", e.toString())
+        } finally {
+            // Release the decoded bitmap deterministically; leaving it to GC /
+            // Glide lifecycle handling delays reuse and raises GC pressure
+            // during fast scrolling. See #1436.
+            target?.let { Glide.with(context).clear(it) }
         }
     }
 


### PR DESCRIPTION
## Fixes #1436

Android thumbnail paths did not deterministically release Glide `FutureTarget` resources.

### Defect 1 — `ThumbnailUtil.getThumbnail`

`submit(width, height).get()` was chained, discarding the `FutureTarget` reference immediately. The decoded bitmap was never explicitly cleared — release was left to GC / Glide lifecycle handling, adding GC pressure during fast scrolling.

**Fix:** retain the `FutureTarget`, call `Glide.with(context).clear(target)` in a `finally` after compression + reply.

### Defect 2 — `PhotoManager.requestCache`

`cacheFutures` was an append-only `ArrayList`:
- Completed targets stayed strongly referenced until the global `cancelCacheRequests()` cleared the entire list.
- Every `requestCache` call copied the full accumulated history and re-scheduled `get()` over all of it, including completed targets.

**Fix:**
- `cacheFutures` is now a `ConcurrentHashMap.newKeySet()` — thread-safe, bounded to active targets.
- Each target is cleared and removed in the worker's `finally` after `get()` completes (success or failure).
- `requestCache` schedules only the newly added targets, not the accumulated history.
- `cancelCacheRequests` stays safe racing completion: the set clear and the per-target `clear()` are idempotent, and the worker's `finally` uses `cacheFutures.remove(target)` (returns false if cancel already removed it) before clearing.

### Verification

- `:photo_manager:compileDebugKotlin` — OK
