### PR TITLE
feat: Add AndroidEditor.renameAsset to rename assets on Android (#1314)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ To know more about breaking changes, see the [Migration Guide][].
 
 ## Unreleased
 
+**Features**
+
+- Add `AndroidEditor.renameAsset` to rename an asset by updating its MediaStore `DISPLAY_NAME` on Android (#1314).
+
 **Fixes**
 
 - Fix failed cache writes leaving incomplete files that were later treated as valid cache entries (#1432).

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/constant/Methods.kt
@@ -95,6 +95,7 @@ class Methods {
         const val removeNoExistsAssets = "removeNoExistsAssets"
         const val getColumnNames = "getColumnNames"
         const val updateCreationDate = "updateCreationDate"
+        const val renameAsset = "renameAsset"
 
         private val needMediaLocationMethods = arrayOf(
             getLatLng,

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerPlugin.kt
@@ -649,6 +649,18 @@ class PhotoManagerPlugin(
                 }
             }
 
+            Methods.renameAsset -> {
+                val assetId = call.argument<String>("id")!!
+                val newName = call.argument<String>("newName")!!
+                try {
+                    val uri = photoManager.getUri(assetId)
+                    writeManager.renameAsset(uri, newName, resultHandler)
+                } catch (e: Exception) {
+                    LogUtils.error("renameAsset failed", e)
+                    resultHandler.replyError("renameAsset failed", message = e.message)
+                }
+            }
+
             Methods.deleteWithIds -> {
                 try {
                     val ids = call.argument<List<String>>("ids")!!

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerWriteManager.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerWriteManager.kt
@@ -42,7 +42,8 @@ class PhotoManagerWriteManager(val context: Context, private var activity: Activ
 
     enum class OperationType {
         MOVE,       // Move files to another folder
-        UPDATE      // Generic update operation
+        UPDATE,     // Generic update operation
+        RENAME      // Rename files (update DISPLAY_NAME)
     }
 
     override fun onActivityResult(requestCode: Int, resultCode: Int, intent: Intent?): Boolean {
@@ -61,6 +62,7 @@ class PhotoManagerWriteManager(val context: Context, private var activity: Activ
                 val success = when (operation.operationType) {
                     OperationType.MOVE -> performMove(operation.uris, operation.targetPath)
                     OperationType.UPDATE -> performUpdate(operation.uris, operation.targetPath)
+                    OperationType.RENAME -> performRename(operation.uris, operation.targetPath)
                 }
                 writeHandler?.reply(success)
             } else {
@@ -189,5 +191,99 @@ class PhotoManagerWriteManager(val context: Context, private var activity: Activ
             resultHandler.reply(false)
             writeHandler = null
         }
+    }
+
+    /**
+     * Rename a single asset by updating its MediaStore DISPLAY_NAME.
+     *
+     * Files owned by the app (or under legacy storage, or when the app holds
+     * MANAGE_MEDIA access) are renamed directly without any user prompt.
+     * Files owned by other apps under scoped storage require write consent:
+     * on Android 11+ (API 30+) the system [MediaStore.createWriteRequest]
+     * dialog is shown; below that the operation is unsupported and surfaces an
+     * error. See issue #1314.
+     *
+     * @param uri Content URI of the asset to rename.
+     * @param newName New display name including the file extension
+     *                (e.g. "IMG_001.jpg").
+     * @param resultHandler Replies `true`/`false`, or an error.
+     */
+    fun renameAsset(uri: Uri, newName: String, resultHandler: ResultHandler) {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, newName)
+        }
+        try {
+            val updated = cr.update(uri, values, null, null)
+            resultHandler.reply(updated > 0)
+        } catch (e: SecurityException) {
+            // The asset belongs to another app under scoped storage; request
+            // write consent before retrying the update.
+            if (Build.VERSION.SDK_INT >= Build.VERSION_CODES.R) {
+                requestRenamePermission(uri, newName, resultHandler)
+            } else {
+                LogUtils.error("Renaming other apps' media requires Android 11+", e)
+                resultHandler.replyError(
+                    "renameAsset requires Android 11+ for files not owned by the app",
+                    message = e.message
+                )
+            }
+        } catch (e: Exception) {
+            LogUtils.error("Failed to rename asset", e)
+            resultHandler.replyError("renameAsset failed", message = e.message)
+        }
+    }
+
+    @RequiresApi(Build.VERSION_CODES.R)
+    private fun requestRenamePermission(
+        uri: Uri,
+        newName: String,
+        resultHandler: ResultHandler
+    ) {
+        if (activity == null) {
+            LogUtils.error("Activity is null, cannot request write permission")
+            resultHandler.reply(false)
+            return
+        }
+
+        this.writeHandler = resultHandler
+        this.pendingOperation = WriteOperation(listOf(uri), newName, OperationType.RENAME)
+
+        try {
+            val pendingIntent = MediaStore.createWriteRequest(cr, listOf(uri))
+            activity?.startIntentSenderForResult(
+                pendingIntent.intentSender,
+                androidRWriteRequestCode,
+                null,
+                0,
+                0,
+                0
+            )
+        } catch (e: Exception) {
+            LogUtils.error("Failed to create write request for rename", e)
+            resultHandler.reply(false)
+            pendingOperation = null
+            writeHandler = null
+        }
+    }
+
+    /**
+     * Apply the DISPLAY_NAME update after write consent has been granted.
+     */
+    private fun performRename(uris: List<Uri>, newName: String): Boolean {
+        val values = ContentValues().apply {
+            put(MediaStore.MediaColumns.DISPLAY_NAME, newName)
+        }
+        var successCount = 0
+        for (uri in uris) {
+            try {
+                if (cr.update(uri, values, null, null) > 0) {
+                    successCount++
+                }
+            } catch (e: Exception) {
+                LogUtils.error("Failed to rename URI: $uri", e)
+            }
+        }
+        LogUtils.info("Renamed $successCount/${uris.size} files to $newName")
+        return successCount > 0
     }
 }

--- a/lib/src/internal/constants.dart
+++ b/lib/src/internal/constants.dart
@@ -65,6 +65,7 @@ class PMConstants {
   static const String mMoveAssetsToPath = 'moveAssetsToPath';
   static const String mColumnNames = 'getColumnNames';
   static const String mUpdateCreationDate = 'updateCreationDate';
+  static const String mRenameAsset = 'renameAsset';
   static const String mCanManageMedia = 'canManageMedia';
   static const String mRequestManageMedia = 'requestManageMedia';
 

--- a/lib/src/internal/editor.dart
+++ b/lib/src/internal/editor.dart
@@ -467,6 +467,35 @@ class AndroidEditor {
     return plugin.androidMoveAssetsToPath(assetIds, targetPath);
   }
 
+  /// Renames the given [entity] on Android.
+  ///
+  /// The [newTitle] is the new display name of the asset, **including the file
+  /// extension** (e.g. `IMG_001.jpg`). Only the `DISPLAY_NAME` column of the
+  /// MediaStore record is updated; the underlying file is renamed by the
+  /// MediaProvider accordingly.
+  ///
+  /// Behavior by ownership and platform version:
+  /// - Files owned by the app (or under legacy storage, or when the app holds
+  ///   media management access) are renamed silently without any prompt.
+  /// - Files owned by other apps under scoped storage show the system
+  ///   `createWriteRequest` consent dialog on Android 11+ (API 30+).
+  /// - Renaming other apps' files below Android 11 is unsupported and throws.
+  ///
+  /// Returns `true` if the asset was renamed; otherwise `false`.
+  ///
+  /// ```dart
+  /// final ok = await PhotoManager.editor.android.renameAsset(
+  ///   entity: asset,
+  ///   newTitle: 'IMG_001.jpg',
+  /// );
+  /// ```
+  Future<bool> renameAsset({
+    required AssetEntity entity,
+    required String newTitle,
+  }) {
+    return plugin.androidRenameAsset(entity.id, newTitle);
+  }
+
   /// Removes all assets from the gallery that are no longer available on disk.
   ///
   /// This method is intended to be used after manually deleting files from the

--- a/lib/src/internal/plugin.dart
+++ b/lib/src/internal/plugin.dart
@@ -1134,6 +1134,21 @@ mixin AndroidPlugin on BasePlugin {
     return result == true;
   }
 
+  /// Rename the given [assetId] on Android.
+  ///
+  /// [newTitle] is the new display name, including the file extension
+  /// (e.g. "IMG_001.jpg"). Files owned by the app are renamed silently; files
+  /// owned by other apps prompt the user for write consent on Android 11+.
+  ///
+  /// Returns true if the operation was successful, false otherwise.
+  Future<bool> androidRenameAsset(String assetId, String newTitle) async {
+    final result = await _channel.invokeMethod(
+      PMConstants.mRenameAsset,
+      <String, dynamic>{'id': assetId, 'newName': newTitle},
+    );
+    return result == true;
+  }
+
   Future<bool> androidRemoveNoExistsAssets() async {
     final bool? result = await _channel.invokeMethod(
       PMConstants.mRemoveNoExistsAssets,


### PR DESCRIPTION
## Resolves #1314

Add the ability to rename an asset on Android, and document why iOS/macOS cannot support it.

## Platform feasibility (verified against SDK docs)

### iOS / macOS — not possible

PhotoKit exposes **no public API** to rename an existing asset:
- `PHAsset` is immutable and exposes no `filename`/`title` property.
- `PHAssetChangeRequest` only allows `creationDate`, `location`, `isFavorite`, `isHidden`, `caption`, keywords, `rating`, and content editing — no filename/title.
- `PHAssetResource` is entirely read-only, and there is no `PHAssetResourceModificationRequest` class; `originalFilename` can only be set at creation time via `PHAssetCreationRequest`.

The full analysis is posted in https://github.com/fluttercandies/flutter_photo_manager/issues/1314#issuecomment-5241614253.

### Android — possible

`ContentResolver.update()` on the item's content URI with `MediaStore.MediaColumns.DISPLAY_NAME` renames both the MediaStore record and the underlying file (the MediaProvider performs the file rename under scoped storage). The permission model reuses the paths the plugin already gates on:

| Scenario | Behavior |
|---|---|
| Files owned by the app / legacy storage / app holds `MANAGE_MEDIA` | Silent direct `cr.update(DISPLAY_NAME)`, no prompt |
| Files owned by other apps, Android 11+ (API 30+) | System `MediaStore.createWriteRequest()` consent dialog, retry after grant |
| Files owned by other apps, Android 10 and below | Unsupported, surfaces an error |

The `MANAGE_MEDIA` gating uses the existing `PermissionsUtils.canManageMedia()`.

## Changes

- `AndroidEditor.renameAsset({required AssetEntity entity, required String newTitle})` — new public Dart API.
- `PhotoManagerWriteManager.renameAsset` — attempts a direct `DISPLAY_NAME` update first; on `SecurityException` escalates to `createWriteRequest()` on Android 11+.
- `OperationType.RENAME` + `performRename` wired into the existing activity-result machinery.
- Method channel handler in `PhotoManagerPlugin`.
- CHANGELOG entry under Unreleased → Features.

### Design note: try-direct-first

`moveAssetsToPath` always shows the consent dialog because moving RELATIVE_PATH is inherently cross-album. Rename is different — the overwhelmingly common case is the app renaming a file it owns (e.g. camera apps), where prompting "Allow modifying this photo?" is confusing UX. So `renameAsset` attempts the silent `cr.update` first and only escalates to `createWriteRequest` when the provider actually throws `SecurityException`. Under `MANAGE_MEDIA`, updates never throw, so the whole operation is silent.

## Verification

- `flutter analyze lib` — No issues found.
- `dart format` — 0 changed.
- `:photo_manager:compileDebugKotlin` — BUILD SUCCESSFUL.
