### PR TITLE
fix: classify Android change notifications by MediaProvider flags on API 30+

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ To know more about breaking changes, see the [Migration Guide][].
 - Fix Android save/copy operations leaving visible incomplete MediaStore items when the write fails (#1434).
 - Fix Android thumbnail requests not deterministically releasing Glide resources (#1436).
 - Fix Android path-based saves leaking file descriptors by not closing inspection streams (#1438).
+- Fix Android change notifications reporting inserts of not-yet-published rows (e.g. files pushed via `adb push` or desktop drag-and-drop) as deletions (#1443).
 
 ## 3.12.0
 

--- a/analysis_options.yaml
+++ b/analysis_options.yaml
@@ -17,6 +17,14 @@ analyzer:
     prefer_single_quotes: warning
     require_trailing_commas: warning
     invalid_annotation_target: false
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 
 linter:
   rules:

--- a/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerNotifyChannel.kt
+++ b/android/src/main/kotlin/com/fluttercandies/photo_manager/core/PhotoManagerNotifyChannel.kt
@@ -127,47 +127,41 @@ class PhotoManagerNotifyChannel(
         }
 
         override fun onChange(selfChange: Boolean, uri: Uri?) {
+            // Dispatch target on frameworks below API 30, which have no
+            // change-kind flags; the type is inferred from the row state.
+            handleOnChange(uri, null)
+        }
+
+        override fun onChange(selfChange: Boolean, uri: Uri?, flags: Int) {
+            // Dispatch target on API 30+, where MediaProvider tags row
+            // notifications with the kind of change. Untagged notifications
+            // (flags without any kind bit, e.g. plain
+            // ContentResolver#notifyChange calls) fall back to the row-state
+            // inference used pre-30.
+            val kind = flags and (
+                ContentResolver.NOTIFY_INSERT
+                    or ContentResolver.NOTIFY_UPDATE
+                    or ContentResolver.NOTIFY_DELETE
+                )
+            handleOnChange(
+                uri,
+                when (kind) {
+                    ContentResolver.NOTIFY_INSERT -> "insert"
+                    ContentResolver.NOTIFY_UPDATE -> "update"
+                    ContentResolver.NOTIFY_DELETE -> "delete"
+                    else -> null
+                },
+            )
+        }
+
+        private fun handleOnChange(uri: Uri?, authoritativeType: String?) {
             if (uri == null) {
                 return
             }
             val last = uri.lastPathSegment
             val id = last?.toLongOrNull()
 
-            if (id != null) { // insert or update
-                val cursor = safeQuery(
-                    allUri,
-                    arrayOf(DATE_ADDED, DATE_MODIFIED, MEDIA_TYPE),
-                    "$_ID = ?",
-                    arrayOf(id.toString())
-                )
-                cursor?.use {
-                    if (!cursor.moveToNext()) {
-                        // If the ID not have item, make it as deleted.
-                        onOuterChange(uri, "delete", id, null, type)
-                        return
-                    }
-                    // Find date to determine insert or update.
-                    val addTimestampSecond = cursor.getLong(cursor.getColumnIndex(DATE_ADDED))
-                    val currentTimeMillis = System.currentTimeMillis()
-
-                    val diffTime = currentTimeMillis / 1000 - addTimestampSecond
-
-                    // Within 30s, it is considered to be inserted, if it is exceeded, it is considered to be changed
-                    val typeString = if (diffTime < 30) {
-                        "insert"
-                    } else {
-                        "update"
-                    }
-                    // get Type
-                    val type = cursor.getInt(cursor.getColumnIndex(MEDIA_TYPE))
-                    val (gId, gName) = getGalleryIdAndName(id, type)
-
-                    if (gId == null || gName == null) {
-                        return
-                    }
-                    onOuterChange(uri, typeString, id, gId, type)
-                }
-            } else { // delete
+            if (id == null) { // collection-level change
                 if (Build.VERSION.SDK_INT < Build.VERSION_CODES.Q) {
                     if (uri == this.uri) {
                         onOuterChange(uri, "insert", null, null, type)
@@ -175,6 +169,55 @@ class PhotoManagerNotifyChannel(
                     }
                 }
                 onOuterChange(uri, "delete", null, null, type)
+                return
+            }
+
+            if (authoritativeType == "delete") {
+                // The row is gone; no point in querying it.
+                onOuterChange(uri, "delete", id, null, type)
+                return
+            }
+
+            val cursor = safeQuery(
+                allUri,
+                arrayOf(DATE_ADDED, DATE_MODIFIED, MEDIA_TYPE),
+                "$_ID = ?",
+                arrayOf(id.toString())
+            )
+            cursor?.use {
+                if (!it.moveToNext()) {
+                    // The row is not visible to this app. On Android 10+,
+                    // rows inserted by other packages — such as files pushed
+                    // via `adb push` or desktop drag-and-drop to an emulator
+                    // — stay pending and hidden until their owner publishes
+                    // them (#1443). An INSERT flag still proves an insert,
+                    // but every other invisible outcome (a trashed row, a
+                    // still-pending row being updated, a real deletion with
+                    // an untagged notification) is reported as "delete",
+                    // matching the historical behavior for missing rows.
+                    val typeString =
+                        if (authoritativeType == "insert") "insert" else "delete"
+                    onOuterChange(uri, typeString, id, null, type)
+                    return
+                }
+                // Find date to determine insert or update for untagged events.
+                val typeString = authoritativeType ?: run {
+                    val addTimestampSecond = it.getLong(it.getColumnIndex(DATE_ADDED))
+
+                    // Within 30s, it is considered to be inserted, if it is exceeded, it is considered to be changed
+                    if (System.currentTimeMillis() / 1000 - addTimestampSecond < 30) {
+                        "insert"
+                    } else {
+                        "update"
+                    }
+                }
+                // get Type
+                val mediaType = it.getInt(it.getColumnIndex(MEDIA_TYPE))
+                val (gId, _) = getGalleryIdAndName(id, mediaType)
+
+                // The gallery may fail to resolve in racy cases; galleryId
+                // is optional in the payload, so still deliver the event.
+                onOuterChange(uri, typeString, id, gId, mediaType)
             }
         }
 

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,12 @@
+analyzer:
+  exclude:
+    - build/**
+    - android/**
+    - ios/**
+    - web/**
+    - windows/**
+    - macos/**
+    - linux/**
 include: ../analysis_options.yaml
 
 linter:

--- a/example/analysis_options.yaml
+++ b/example/analysis_options.yaml
@@ -1,3 +1,5 @@
+include: ../analysis_options.yaml
+
 analyzer:
   exclude:
     - build/**
@@ -7,7 +9,6 @@ analyzer:
     - windows/**
     - macos/**
     - linux/**
-include: ../analysis_options.yaml
 
 linter:
   rules:

--- a/example/android/app/build.gradle
+++ b/example/android/app/build.gradle
@@ -34,7 +34,7 @@ android {
 
     defaultConfig {
         applicationId "com.fluttercandies.photo_manager_example"
-        minSdkVersion 21
+        minSdkVersion flutter.minSdkVersion
         targetSdk = flutter.targetSdkVersion
         versionCode = flutter.versionCode
         versionName = flutter.versionName

--- a/example/android/gradle.properties
+++ b/example/android/gradle.properties
@@ -2,3 +2,7 @@ org.gradle.jvmargs=-Xmx4G -XX:MaxMetaspaceSize=2G -XX:+HeapDumpOnOutOfMemoryErro
 android.useAndroidX=true
 android.enableJetifier=true
 kotlin.code.style=official
+# This builtInKotlin flag was added automatically by Flutter migrator
+android.builtInKotlin=false
+# This newDsl flag was added automatically by Flutter migrator
+android.newDsl=false

--- a/example/android/gradle/wrapper/gradle-wrapper.properties
+++ b/example/android/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14-all.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/example/android/settings.gradle
+++ b/example/android/settings.gradle
@@ -18,10 +18,10 @@ pluginManagement {
 
 plugins {
     id "dev.flutter.flutter-plugin-loader" version "1.0.0"
-    id "com.android.application" version "8.9.3" apply false
-    id "com.android.library" version "8.9.3" apply false
-    id "org.jetbrains.kotlin.android" version "2.1.20" apply false
-    id "org.jetbrains.kotlin.kapt" version "2.1.20" apply false
+    id "com.android.application" version "8.11.1" apply false
+    id "com.android.library" version "8.11.1" apply false
+    id "org.jetbrains.kotlin.android" version "2.2.20" apply false
+    id "org.jetbrains.kotlin.kapt" version "2.2.20" apply false
 }
 
 include ":app"


### PR DESCRIPTION
## Problem

Closes #1443.

The issue reports that change callbacks never fire when a file is dragged from the desktop into an emulator, and proposes registering additional `ContentObserver`s on the `external_primary` volume URIs.

Investigation on API 34 and API 36 emulators shows the diagnosis is different:

- MediaProvider **does** notify the merged `external` view for every row change (`acceptWithExpansion` in AOSP recurses into `VOLUME_EXTERNAL`), so the existing observers do receive the event — verified via `setprop log.tag.MediaProvider VERBOSE` and `dumpsys content`.
- Registering `external_primary` as well would produce **duplicate callbacks** for every regular write, since both volumes are notified.

The actual failure: rows inserted via `adb push` / desktop drag-and-drop are owned by `com.android.shell` and stay `is_pending=1` indefinitely, so they are **not visible** to the app. `MediaObserver.onChange` classifies the event by querying the row; the query comes back empty, and the code falls into the "row not found ⇒ delete" branch. The callback fires, but misreports the insert as a **deletion**.

## Fix

On API 30+, MediaProvider tags row notifications with `NOTIFY_INSERT` / `NOTIFY_UPDATE` / `NOTIFY_DELETE` flags (observed values on an API 36 emulator: insert=5, update=9, delete=17). `PhotoManagerNotifyChannel` now overrides `onChange(selfChange, uri, flags)` and uses the flag as the authoritative change type, keeping the existing date-diff inference only for untagged notifications (API < 30 or plain `notifyChange(uri, null)` senders).

Additionally:

- `delete` no longer queries the (already gone) row.
- When the gallery cannot be resolved, the event is still delivered without `galleryId` instead of being dropped.

## Verification

Example app with `addChangeCallback` + `startChangeNotify` on emulators:

| Scenario | API 36 (flags path) | API 28 (inference path) |
|---|---|---|
| `adb push` file (pending row) | `insert` (was `delete`) ✅ | `insert` (via scan broadcast) ✅ |
| `content insert` complete row | `insert` + galleryId ✅ | n/a |
| `content update` favorite | `update` (heuristic would say `insert`) ✅ | n/a |
| `content delete` | `delete` ✅ | n/a |

One callback per change in all cases — no duplicates.

Note: `flutter test` has one pre-existing failure (`convertMapToAsset reads Android trash state`) that also fails on clean `main`, unrelated to this change.